### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,6 @@
 name: Bump Version and Release
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/revisium/schema-toolkit/security/code-scanning/1](https://github.com/revisium/schema-toolkit/security/code-scanning/1)

To fix the issue, the recommended approach is to add a `permissions` block at the top level of the workflow file (recommended so it applies to all jobs by default). This block should declare the minimum set of permissions required for the workflow. Since the workflow only checks out code and pushes using a PAT (not GITHUB_TOKEN), it does not require write access for most scopes. The minimal starting point is generally `contents: read`, which is safe and will work for code checkout, reading files, and similar non-destructive operations. If the workflow were to use the default token for releases, pull requests, or other actions requiring write access, more granular permissions would be needed; but in this scenario, `contents: read` suffices.

Add the following at the top, after the `name` declaration and before `on`:  
```yaml
permissions:
  contents: read
```

No imports or further code changes are needed, and there is no impact to core functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted continuous integration workflow permissions to refine access scope.
  * No changes to app functionality or user experience.
  * Build and release processes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->