### PR TITLE
feat: convertJsonPathToSchemaPath

### DIFF
--- a/src/lib/__tests__/json-path-utils.spec.ts
+++ b/src/lib/__tests__/json-path-utils.spec.ts
@@ -6,6 +6,7 @@ import {
   setValueByPath,
   hasPath,
   deepEqual,
+  convertJsonPathToSchemaPath,
 } from '../json-path-utils.js';
 
 describe('parsePath', () => {
@@ -585,5 +586,71 @@ describe('deepEqual', () => {
       const arr = [1, 2, 3];
       expect(deepEqual(arr, arr)).toBe(true);
     });
+  });
+});
+
+describe('convertJsonPathToSchemaPath', () => {
+  it('converts simple property', () => {
+    expect(convertJsonPathToSchemaPath('title')).toBe('/properties/title');
+  });
+
+  it('converts nested property', () => {
+    expect(convertJsonPathToSchemaPath('address.city')).toBe('/properties/address/properties/city');
+  });
+
+  it('converts deep nested property', () => {
+    expect(convertJsonPathToSchemaPath('a.b.c.d')).toBe('/properties/a/properties/b/properties/c/properties/d');
+  });
+
+  it('converts array path', () => {
+    expect(convertJsonPathToSchemaPath('tags[0]')).toBe('/properties/tags/items');
+  });
+
+  it('converts array with property', () => {
+    expect(convertJsonPathToSchemaPath('users[0].name')).toBe('/properties/users/items/properties/name');
+  });
+
+  it('converts nested arrays', () => {
+    expect(convertJsonPathToSchemaPath('matrix[0][1]')).toBe('/properties/matrix/items/items');
+  });
+
+  it('converts complex nested path with arrays and objects', () => {
+    expect(convertJsonPathToSchemaPath('data[0].items[1].value')).toBe('/properties/data/items/properties/items/items/properties/value');
+  });
+
+  it('converts deeply nested array of objects', () => {
+    expect(convertJsonPathToSchemaPath('categories[0].products[1].variants[2].price')).toBe('/properties/categories/items/properties/products/items/properties/variants/items/properties/price');
+  });
+
+  it('converts nested object in array of arrays', () => {
+    expect(convertJsonPathToSchemaPath('grid[0][1].cell.value')).toBe('/properties/grid/items/items/properties/cell/properties/value');
+  });
+
+  it('converts triple nested arrays', () => {
+    expect(convertJsonPathToSchemaPath('cube[0][1][2]')).toBe('/properties/cube/items/items/items');
+  });
+
+  it('converts complex mixed structure', () => {
+    expect(convertJsonPathToSchemaPath('api.endpoints[0].responses[1].schema.properties.data[0].fields')).toBe('/properties/api/properties/endpoints/items/properties/responses/items/properties/schema/properties/properties/properties/data/items/properties/fields');
+  });
+
+  it('converts array of objects with nested arrays', () => {
+    expect(convertJsonPathToSchemaPath('users[0].permissions[1].roles[2].name')).toBe('/properties/users/items/properties/permissions/items/properties/roles/items/properties/name');
+  });
+
+  it('handles empty path', () => {
+    expect(convertJsonPathToSchemaPath('')).toBe('');
+  });
+
+  it('converts single array index', () => {
+    expect(convertJsonPathToSchemaPath('[0]')).toBe('/items');
+  });
+
+  it('converts multiple array indices', () => {
+    expect(convertJsonPathToSchemaPath('[0][1][2]')).toBe('/items/items/items');
+  });
+
+  it('converts object property after array indices', () => {
+    expect(convertJsonPathToSchemaPath('[0][1].property')).toBe('/items/items/properties/property');
   });
 });

--- a/src/lib/getJsonValueByPath.ts
+++ b/src/lib/getJsonValueByPath.ts
@@ -1,6 +1,7 @@
 import { JsonArrayValueStore } from '../model/value/json-array-value.store.js';
 import { JsonObjectValueStore } from '../model/value/json-object-value.store.js';
 import { JsonValueStore } from '../model/value/json-value.store.js';
+import { parsePath } from './json-path-utils.js';
 
 export const getJsonValueStoreByPath = (
   root: JsonValueStore,
@@ -10,7 +11,7 @@ export const getJsonValueStoreByPath = (
     return root;
   }
 
-  const segments = getSegments(path);
+  const segments = parsePath(path);
 
   let current: JsonValueStore = root;
 
@@ -38,20 +39,3 @@ export const getJsonValueStoreByPath = (
   return current;
 };
 
-const regex = /([^.[\]]+)|\[(\d+)]/g;
-
-const getSegments = (path: string) => {
-  const segments: (string | number)[] = [];
-
-  let match: RegExpExecArray | null;
-
-  while ((match = regex.exec(path))) {
-    if (match[1] !== undefined) {
-      segments.push(match[1]);
-    } else if (match[2] !== undefined) {
-      segments.push(Number(match[2]));
-    }
-  }
-
-  return segments;
-};

--- a/src/lib/json-path-utils.ts
+++ b/src/lib/json-path-utils.ts
@@ -1,12 +1,5 @@
 import { JsonArray, JsonObject, JsonValue } from '../types';
 
-/**
- * Parse path string into segments using regex
- * Internal helper used by parsePath and getSegments
- *
- * @param path - Path string to parse
- * @returns Array of segments (strings and numbers)
- */
 function parsePathSegments(path: string): (string | number)[] {
   const segments: (string | number)[] = [];
   const regex = /([^.[\]]+)|\[(\d+)]/g;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to convert simplified JSON paths (e.g., title, address.city, tags[0], users[0].name) into corresponding JSON Schema paths; handles empty input and is now available publicly.

* **Refactor**
  * Unified path parsing by delegating to a shared parser, improving consistency and maintainability while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->