### PR TITLE
feat: schema path to json path

### DIFF
--- a/src/lib/json-path-utils.ts
+++ b/src/lib/json-path-utils.ts
@@ -346,7 +346,8 @@ export function convertSchemaPathToJsonPath(schemaPath: string): string {
   const segments = cleanPath.split('/');
   let result = '';
 
-  for (let i = 0; i < segments.length; i++) {
+  let i = 0;
+  while (i < segments.length) {
     const segment = segments[i];
 
     if (segment === 'properties') {
@@ -363,6 +364,8 @@ export function convertSchemaPathToJsonPath(schemaPath: string): string {
     } else if (segment === 'items') {
       result += '[*]';
     }
+
+    i++;
   }
 
   return result;

--- a/src/lib/json-path-utils.ts
+++ b/src/lib/json-path-utils.ts
@@ -331,3 +331,39 @@ export function convertJsonPathToSchemaPath(jsonPath: string): string {
 
   return schemaPath;
 }
+
+export function convertSchemaPathToJsonPath(schemaPath: string): string {
+  if (schemaPath === '') {
+    return '';
+  }
+
+  const cleanPath = schemaPath.startsWith('/') ? schemaPath.slice(1) : schemaPath;
+
+  if (cleanPath === '') {
+    return '';
+  }
+
+  const segments = cleanPath.split('/');
+  let result = '';
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+
+    if (segment === 'properties') {
+      i++;
+      if (i < segments.length) {
+        const propertyName = segments[i];
+        if (propertyName) {
+          if (result) {
+            result += '.';
+          }
+          result += propertyName;
+        }
+      }
+    } else if (segment === 'items') {
+      result += '[*]';
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a converter to transform schema-style paths into JSON-style paths, including support for nested objects and array wildcards.

* **Tests**
  * Added comprehensive tests covering simple and deep nesting, arrays, various path shapes, and round-trip validation between the two path formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->