### PR TITLE
feat: x-formula

### DIFF
--- a/src/lib/createJsonSchemaStore.ts
+++ b/src/lib/createJsonSchemaStore.ts
@@ -82,11 +82,16 @@ export const createPrimitiveStoreBySchema = (
     stringStore.enum = schema.enum;
     stringStore.contentMediaType = schema.contentMediaType;
     stringStore.pattern = schema.pattern;
+    stringStore['x-formula'] = schema['x-formula'];
     return stringStore;
   } else if (schema.type === JsonSchemaTypeName.Number) {
-    return new JsonNumberStore();
+    const numberStore = new JsonNumberStore();
+    numberStore['x-formula'] = schema['x-formula'];
+    return numberStore;
   } else if (schema.type === JsonSchemaTypeName.Boolean) {
-    return new JsonBooleanStore();
+    const booleanStore = new JsonBooleanStore();
+    booleanStore['x-formula'] = schema['x-formula'];
+    return booleanStore;
   } else {
     throw new Error('this type is not allowed');
   }

--- a/src/model/schema/__tests__/json-boolean.store.spec.ts
+++ b/src/model/schema/__tests__/json-boolean.store.spec.ts
@@ -106,4 +106,28 @@ describe('JsonBooleanStore', () => {
       readOnly: true,
     });
   });
+
+  it('x-formula', () => {
+    const store = new JsonBooleanStore();
+
+    expect(store.getPlainSchema()).toStrictEqual({
+      type: 'boolean',
+      default: false,
+    });
+
+    store['x-formula'] = { version: 1, expression: 'count > 0' };
+
+    expect(store.getPlainSchema()).toStrictEqual({
+      type: 'boolean',
+      default: false,
+      'x-formula': { version: 1, expression: 'count > 0' },
+    });
+  });
+
+  it('x-formula is optional', () => {
+    const store = new JsonBooleanStore();
+
+    const schema = store.getPlainSchema();
+    expect(schema).not.toHaveProperty('x-formula');
+  });
 });

--- a/src/model/schema/__tests__/json-number.store.spec.ts
+++ b/src/model/schema/__tests__/json-number.store.spec.ts
@@ -106,4 +106,28 @@ describe('JsonNumberStore', () => {
       readOnly: true,
     });
   });
+
+  it('x-formula', () => {
+    const store = new JsonNumberStore();
+
+    expect(store.getPlainSchema()).toStrictEqual({
+      type: 'number',
+      default: 0,
+    });
+
+    store['x-formula'] = { version: 1, expression: 'a + b' };
+
+    expect(store.getPlainSchema()).toStrictEqual({
+      type: 'number',
+      default: 0,
+      'x-formula': { version: 1, expression: 'a + b' },
+    });
+  });
+
+  it('x-formula is optional', () => {
+    const store = new JsonNumberStore();
+
+    const schema = store.getPlainSchema();
+    expect(schema).not.toHaveProperty('x-formula');
+  });
 });

--- a/src/model/schema/__tests__/json-string.store.spec.ts
+++ b/src/model/schema/__tests__/json-string.store.spec.ts
@@ -191,4 +191,31 @@ describe('JsonStringStore', () => {
       title: 'title',
     });
   });
+
+  it('x-formula', () => {
+    const store = new JsonStringStore();
+
+    expect(store.getPlainSchema()).toStrictEqual({
+      type: 'string',
+      default: '',
+    });
+
+    store['x-formula'] = {
+      version: 1,
+      expression: 'firstName + " " + lastName',
+    };
+
+    expect(store.getPlainSchema()).toStrictEqual({
+      type: 'string',
+      default: '',
+      'x-formula': { version: 1, expression: 'firstName + " " + lastName' },
+    });
+  });
+
+  it('x-formula is optional', () => {
+    const store = new JsonStringStore();
+
+    const schema = store.getPlainSchema();
+    expect(schema).not.toHaveProperty('x-formula');
+  });
 });

--- a/src/model/schema/json-boolean.store.ts
+++ b/src/model/schema/json-boolean.store.ts
@@ -4,6 +4,7 @@ import {
   JsonBooleanSchema,
   JsonRefSchema,
   JsonSchemaTypeName,
+  XFormula,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
 import { JsonBooleanValueStore } from '../value/json-boolean-value.store.js';
@@ -24,6 +25,7 @@ export class JsonBooleanStore
   public title?: string;
   public description?: string;
   public deprecated?: boolean;
+  public 'x-formula'?: XFormula;
 
   private readonly valuesMap: Map<string, JsonBooleanValueStore[]> = new Map<
     string,
@@ -58,6 +60,7 @@ export class JsonBooleanStore
         type: this.type,
         default: this.default,
         ...(this.readOnly ? { readOnly: this.readOnly } : {}),
+        ...(this['x-formula'] ? { 'x-formula': this['x-formula'] } : {}),
       },
       this,
     );

--- a/src/model/schema/json-number.store.ts
+++ b/src/model/schema/json-number.store.ts
@@ -4,6 +4,7 @@ import {
   JsonNumberSchema,
   JsonRefSchema,
   JsonSchemaTypeName,
+  XFormula,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
 import { JsonNumberValueStore } from '../value/json-number-value.store.js';
@@ -21,6 +22,7 @@ export class JsonNumberStore extends EventEmitter implements JsonNumberSchema {
   public title?: string;
   public description?: string;
   public deprecated?: boolean;
+  public 'x-formula'?: XFormula;
 
   private readonly valuesMap: Map<string, JsonNumberValueStore[]> = new Map<
     string,
@@ -55,6 +57,7 @@ export class JsonNumberStore extends EventEmitter implements JsonNumberSchema {
         type: this.type,
         default: this.default,
         ...(this.readOnly ? { readOnly: this.readOnly } : {}),
+        ...(this['x-formula'] ? { 'x-formula': this['x-formula'] } : {}),
       },
       this,
     );

--- a/src/model/schema/json-string.store.ts
+++ b/src/model/schema/json-string.store.ts
@@ -4,6 +4,7 @@ import {
   JsonRefSchema,
   JsonSchemaTypeName,
   JsonStringSchema,
+  XFormula,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
 import { JsonStringValueStore } from '../value/json-string-value.store.js';
@@ -26,6 +27,7 @@ export class JsonStringStore extends EventEmitter implements JsonStringSchema {
   public enum?: string[];
   public format?: JsonStringSchema['format'];
   public contentMediaType?: JsonStringSchema['contentMediaType'];
+  public 'x-formula'?: XFormula;
 
   private readonly valuesMap: Map<string, JsonStringValueStore[]> = new Map<
     string,
@@ -67,6 +69,7 @@ export class JsonStringStore extends EventEmitter implements JsonStringSchema {
         ...(this.contentMediaType
           ? { contentMediaType: this.contentMediaType }
           : {}),
+        ...(this['x-formula'] ? { 'x-formula': this['x-formula'] } : {}),
       },
       this,
     );

--- a/src/types/schema.types.ts
+++ b/src/types/schema.types.ts
@@ -6,6 +6,11 @@ export enum JsonSchemaTypeName {
   Array = 'array',
 }
 
+export type XFormula = {
+  version: 1;
+  expression: string;
+};
+
 export type JsonSchemaSharedFields = {
   deprecated?: boolean;
   description?: string;
@@ -30,6 +35,7 @@ export type JsonStringSchema = {
     | 'application/schema+json'
     | 'application/yaml';
   enum?: string[];
+  'x-formula'?: XFormula;
 } & JsonSchemaSharedFields;
 
 export type JsonNumberSchema = {
@@ -39,6 +45,7 @@ export type JsonNumberSchema = {
   title?: string;
   description?: string;
   deprecated?: boolean;
+  'x-formula'?: XFormula;
 } & JsonSchemaSharedFields;
 
 export type JsonBooleanSchema = {
@@ -48,6 +55,7 @@ export type JsonBooleanSchema = {
   title?: string;
   description?: string;
   deprecated?: boolean;
+  'x-formula'?: XFormula;
 } & JsonSchemaSharedFields;
 
 export type JsonSchemaPrimitives =

--- a/src/validation-schemas/__tests__/meta-schema.spec.ts
+++ b/src/validation-schemas/__tests__/meta-schema.spec.ts
@@ -510,6 +510,123 @@ describe('meta-schema', () => {
     ).toBe(true);
   });
 
+  describe('x-formula', () => {
+    it('should validate x-formula on number field', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { version: 1, expression: 'price * quantity' },
+        }),
+      ).toBe(true);
+    });
+
+    it('should validate x-formula on boolean field', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'boolean',
+          default: false,
+          'x-formula': { version: 1, expression: 'count > 0' },
+        }),
+      ).toBe(true);
+    });
+
+    it('should validate x-formula on string field', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'string',
+          default: '',
+          'x-formula': {
+            version: 1,
+            expression: 'firstName + " " + lastName',
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('should reject invalid x-formula missing version', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { expression: 'a + b' },
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject invalid x-formula missing expression', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { version: 1 },
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject invalid x-formula with wrong version', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { version: 2, expression: 'a + b' },
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject x-formula with empty expression', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { version: 1, expression: '' },
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject x-formula with additional properties', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { version: 1, expression: 'a + b', extra: 'field' },
+        }),
+      ).toBe(false);
+    });
+
+    it('should allow x-formula in nested object properties', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            price: { type: 'number', default: 0 },
+            quantity: { type: 'number', default: 0 },
+            total: {
+              type: 'number',
+              default: 0,
+              'x-formula': { version: 1, expression: 'price * quantity' },
+            },
+          },
+          required: ['price', 'quantity', 'total'],
+        }),
+      ).toBe(true);
+    });
+
+    it('should allow x-formula in array items', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'array',
+          items: {
+            type: 'number',
+            default: 0,
+            'x-formula': { version: 1, expression: 'index * 2' },
+          },
+        }),
+      ).toBe(true);
+    });
+  });
+
   function checkBaseFields(
     data: Record<string, unknown>,
     options?: { skipReadOnly?: boolean },

--- a/src/validation-schemas/meta-schema.ts
+++ b/src/validation-schemas/meta-schema.ts
@@ -3,6 +3,16 @@ import { sharedFields } from './shared-fields.js';
 
 // https://json-schema.org/specification#single-vocabulary-meta-schemas
 
+export const xFormulaSchema: Schema = {
+  type: 'object',
+  properties: {
+    version: { const: 1 },
+    expression: { type: 'string', minLength: 1, maxLength: 10000 },
+  },
+  required: ['version', 'expression'],
+  additionalProperties: false,
+};
+
 export const refMetaSchema: Schema = {
   type: 'object',
   properties: {
@@ -50,6 +60,7 @@ export const baseStringFields: Schema = {
       'application/yaml',
     ],
   },
+  'x-formula': xFormulaSchema,
   ...sharedFields,
 };
 
@@ -86,6 +97,7 @@ export const numberMetaSchema: Schema = {
     readOnly: {
       type: 'boolean',
     },
+    'x-formula': xFormulaSchema,
     ...sharedFields,
   },
   additionalProperties: false,
@@ -104,6 +116,7 @@ export const booleanMetaSchema: Schema = {
     readOnly: {
       type: 'boolean',
     },
+    'x-formula': xFormulaSchema,
     ...sharedFields,
   },
   additionalProperties: false,


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add x-formula support to string, number, and boolean schema fields, and preserve it across patch operations and store serialization. Updates the meta-schema to validate x-formula and adds tests for valid and invalid cases.

- **New Features**
  - Add 'x-formula' to primitive schemas and stores, including hydration in createJsonSchemaStore and serialization via getPlainSchema.
  - Validate 'x-formula' in the meta-schema (version=1, non-empty expression, no extra props); allowed in nested object properties and array items.
  - Preserve 'x-formula' in applyPatches when adding or moving fields; includes tests for stores, validation, and patch behavior.

<sup>Written for commit eeb40a72f5dd57f197b3394cb7a85ba05d934419. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
