### PR TITLE
feat: readonly x-formula

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.coverage.exclusions=**/__tests__**,**/__mocks__**,**/*.spec.ts
 # ====================
 # Issue Ignore Rules
 # ====================
-sonar.issue.ignore.multicriteria=tech1,tech2
+sonar.issue.ignore.multicriteria=tech1,tech2,fp1
 
 # ====================
 # Technical Debt Exclusions
@@ -30,6 +30,13 @@ sonar.issue.ignore.multicriteria.tech1.resourceKey=**src/lib/*
 # TODO: Refactor complex functions in lib (S3776: Cognitive Complexity)
 sonar.issue.ignore.multicriteria.tech2.ruleKey=typescript:S3776
 sonar.issue.ignore.multicriteria.tech2.resourceKey=**src/lib/*
+
+# ====================
+# False Positives
+# ====================
+# FP: JSON Schema if/then is valid schema syntax, not Promise-related
+sonar.issue.ignore.multicriteria.fp1.ruleKey=typescript:S6544
+sonar.issue.ignore.multicriteria.fp1.resourceKey=**/meta-schema.ts
 
 # ====================
 # Duplicate Code Exclusions

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -35,7 +35,7 @@ sonar.issue.ignore.multicriteria.tech2.resourceKey=**src/lib/*
 # False Positives
 # ====================
 # FP: JSON Schema if/then is valid schema syntax, not Promise-related
-sonar.issue.ignore.multicriteria.fp1.ruleKey=typescript:S6544
+sonar.issue.ignore.multicriteria.fp1.ruleKey=typescript:S7739
 sonar.issue.ignore.multicriteria.fp1.resourceKey=**/meta-schema.ts
 
 # ====================

--- a/src/validation-schemas/__tests__/meta-schema.spec.ts
+++ b/src/validation-schemas/__tests__/meta-schema.spec.ts
@@ -511,31 +511,34 @@ describe('meta-schema', () => {
   });
 
   describe('x-formula', () => {
-    it('should validate x-formula on number field', () => {
+    it('should validate x-formula on number field with readOnly: true', () => {
       expect(
         ajv.validate(metaSchema, {
           type: 'number',
           default: 0,
+          readOnly: true,
           'x-formula': { version: 1, expression: 'price * quantity' },
         }),
       ).toBe(true);
     });
 
-    it('should validate x-formula on boolean field', () => {
+    it('should validate x-formula on boolean field with readOnly: true', () => {
       expect(
         ajv.validate(metaSchema, {
           type: 'boolean',
           default: false,
+          readOnly: true,
           'x-formula': { version: 1, expression: 'count > 0' },
         }),
       ).toBe(true);
     });
 
-    it('should validate x-formula on string field', () => {
+    it('should validate x-formula on string field with readOnly: true', () => {
       expect(
         ajv.validate(metaSchema, {
           type: 'string',
           default: '',
+          readOnly: true,
           'x-formula': {
             version: 1,
             expression: 'firstName + " " + lastName',
@@ -544,11 +547,33 @@ describe('meta-schema', () => {
       ).toBe(true);
     });
 
+    it('should reject x-formula without readOnly', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          'x-formula': { version: 1, expression: 'a + b' },
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject x-formula with readOnly: false', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'number',
+          default: 0,
+          readOnly: false,
+          'x-formula': { version: 1, expression: 'a + b' },
+        }),
+      ).toBe(false);
+    });
+
     it('should reject invalid x-formula missing version', () => {
       expect(
         ajv.validate(metaSchema, {
           type: 'number',
           default: 0,
+          readOnly: true,
           'x-formula': { expression: 'a + b' },
         }),
       ).toBe(false);
@@ -559,6 +584,7 @@ describe('meta-schema', () => {
         ajv.validate(metaSchema, {
           type: 'number',
           default: 0,
+          readOnly: true,
           'x-formula': { version: 1 },
         }),
       ).toBe(false);
@@ -569,6 +595,7 @@ describe('meta-schema', () => {
         ajv.validate(metaSchema, {
           type: 'number',
           default: 0,
+          readOnly: true,
           'x-formula': { version: 2, expression: 'a + b' },
         }),
       ).toBe(false);
@@ -579,6 +606,7 @@ describe('meta-schema', () => {
         ajv.validate(metaSchema, {
           type: 'number',
           default: 0,
+          readOnly: true,
           'x-formula': { version: 1, expression: '' },
         }),
       ).toBe(false);
@@ -589,12 +617,13 @@ describe('meta-schema', () => {
         ajv.validate(metaSchema, {
           type: 'number',
           default: 0,
+          readOnly: true,
           'x-formula': { version: 1, expression: 'a + b', extra: 'field' },
         }),
       ).toBe(false);
     });
 
-    it('should allow x-formula in nested object properties', () => {
+    it('should allow x-formula in nested object properties with readOnly', () => {
       expect(
         ajv.validate(metaSchema, {
           type: 'object',
@@ -605,6 +634,7 @@ describe('meta-schema', () => {
             total: {
               type: 'number',
               default: 0,
+              readOnly: true,
               'x-formula': { version: 1, expression: 'price * quantity' },
             },
           },
@@ -613,13 +643,14 @@ describe('meta-schema', () => {
       ).toBe(true);
     });
 
-    it('should allow x-formula in array items', () => {
+    it('should allow x-formula in array items with readOnly', () => {
       expect(
         ajv.validate(metaSchema, {
           type: 'array',
           items: {
             type: 'number',
             default: 0,
+            readOnly: true,
             'x-formula': { version: 1, expression: 'index * 2' },
           },
         }),

--- a/src/validation-schemas/meta-schema.ts
+++ b/src/validation-schemas/meta-schema.ts
@@ -13,6 +13,18 @@ export const xFormulaSchema: Schema = {
   additionalProperties: false,
 };
 
+// When x-formula is present, readOnly must be true
+export const xFormulaRequiresReadOnly: Schema = {
+  if: {
+    properties: { 'x-formula': { type: 'object' } },
+    required: ['x-formula'],
+  },
+  then: {
+    properties: { readOnly: { const: true } },
+    required: ['readOnly'],
+  },
+};
+
 export const refMetaSchema: Schema = {
   type: 'object',
   properties: {
@@ -74,6 +86,7 @@ export const stringMetaSchema: Schema = {
   },
   additionalProperties: false,
   required: ['type', 'default'],
+  ...xFormulaRequiresReadOnly,
 };
 
 export const noForeignKeyStringMetaSchema: Schema = {
@@ -83,6 +96,7 @@ export const noForeignKeyStringMetaSchema: Schema = {
   },
   additionalProperties: false,
   required: ['type', 'default'],
+  ...xFormulaRequiresReadOnly,
 };
 
 export const numberMetaSchema: Schema = {
@@ -102,6 +116,7 @@ export const numberMetaSchema: Schema = {
   },
   additionalProperties: false,
   required: ['type', 'default'],
+  ...xFormulaRequiresReadOnly,
 };
 
 export const booleanMetaSchema: Schema = {
@@ -121,6 +136,7 @@ export const booleanMetaSchema: Schema = {
   },
   additionalProperties: false,
   required: ['type', 'default'],
+  ...xFormulaRequiresReadOnly,
 };
 
 export const objectMetaSchema: Schema = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces readOnly: true whenever x-formula is present to ensure formula-driven fields are not editable. Adds validation and tests to cover objects and arrays.

- **New Features**
  - Added xFormulaRequiresReadOnly conditional schema and applied it to string, number, boolean, and noForeignKeyString schemas.
  - Updated tests to require readOnly with x-formula and to allow usage in nested object properties and array items.

- **Migration**
  - Add readOnly: true to any field using x-formula, or validation will fail.

<sup>Written for commit 4fbb3704abcf111ae16a536bb260496099938dc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now enforces that fields with formulas must be readOnly: true across supported field types and nesting.
* **Tests**
  * Expanded unit tests and added negative cases to ensure readOnly gating for formula fields, including nested properties and array item scenarios.
* **Chores**
  * Updated static analysis configuration to adjust false-positive and duplication exclusions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->