### PR TITLE
fix: x-formula and foreign key

### DIFF
--- a/src/validation-schemas/__tests__/meta-schema.spec.ts
+++ b/src/validation-schemas/__tests__/meta-schema.spec.ts
@@ -656,6 +656,28 @@ describe('meta-schema', () => {
         }),
       ).toBe(true);
     });
+
+    it('should reject x-formula when foreignKey is present', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'string',
+          default: '',
+          foreignKey: 'tableId',
+          readOnly: true,
+          'x-formula': { version: 1, expression: 'price' },
+        }),
+      ).toBe(false);
+    });
+
+    it('should allow foreignKey without x-formula', () => {
+      expect(
+        ajv.validate(metaSchema, {
+          type: 'string',
+          default: '',
+          foreignKey: 'tableId',
+        }),
+      ).toBe(true);
+    });
   });
 
   function checkBaseFields(

--- a/src/validation-schemas/meta-schema.ts
+++ b/src/validation-schemas/meta-schema.ts
@@ -25,6 +25,17 @@ export const xFormulaRequiresReadOnly: Schema = {
   },
 };
 
+// foreignKey and x-formula are mutually exclusive
+export const foreignKeyExcludesFormula: Schema = {
+  if: {
+    properties: { foreignKey: { type: 'string' } },
+    required: ['foreignKey'],
+  },
+  then: {
+    not: { required: ['x-formula'] },
+  },
+};
+
 export const refMetaSchema: Schema = {
   type: 'object',
   properties: {
@@ -86,7 +97,7 @@ export const stringMetaSchema: Schema = {
   },
   additionalProperties: false,
   required: ['type', 'default'],
-  ...xFormulaRequiresReadOnly,
+  allOf: [xFormulaRequiresReadOnly, foreignKeyExcludesFormula],
 };
 
 export const noForeignKeyStringMetaSchema: Schema = {


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent using x-formula on fields that have a foreignKey. This enforces mutually exclusive config and avoids conflicting behavior.

- **Bug Fixes**
  - Added foreignKeyExcludesFormula rule to the meta schema.
  - Combined with xFormulaRequiresReadOnly via allOf in stringMetaSchema.
  - Added tests to reject foreignKey + x-formula and allow foreignKey without x-formula.

<sup>Written for commit 67f18963f54597726a6df0310e6d93b70386fb40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
