### PR TITLE
fix: bugs

### DIFF
--- a/src/lib/__tests__/formula.spec.ts
+++ b/src/lib/__tests__/formula.spec.ts
@@ -398,7 +398,7 @@ describe('evaluateFormulas', () => {
     expect(errors).toEqual([]);
   });
 
-  it('should compute nested object formula', () => {
+  it('should compute nested object formula referencing root field', () => {
     const formulas: PreparedFormula[] = [
       {
         fieldName: 'nested.computed',
@@ -417,6 +417,51 @@ describe('evaluateFormulas', () => {
 
     expect(errors).toEqual([]);
     expect((values.nested as Record<string, unknown>)?.computed).toBe(100);
+  });
+
+  it('should compute nested object formula referencing sibling field', () => {
+    const formulas: PreparedFormula[] = [
+      {
+        fieldName: 'nested.computed',
+        expression: 'sourceValue * 2',
+        fieldType: 'number',
+        dependencies: ['sourceValue'],
+        isArrayItem: false,
+        arrayPath: null,
+        localFieldPath: 'nested.computed',
+      },
+    ];
+
+    const data = { nested: { sourceValue: 25, computed: 0 } };
+
+    const { values, errors } = evaluateFormulas(formulas, data);
+
+    expect(errors).toEqual([]);
+    expect((values.nested as Record<string, unknown>)?.computed).toBe(50);
+    expect((data.nested as Record<string, unknown>).computed).toBe(50);
+  });
+
+  it('should compute deeply nested object formula referencing sibling field', () => {
+    const formulas: PreparedFormula[] = [
+      {
+        fieldName: 'level1.level2.result',
+        expression: 'value * 3',
+        fieldType: 'number',
+        dependencies: ['value'],
+        isArrayItem: false,
+        arrayPath: null,
+        localFieldPath: 'level1.level2.result',
+      },
+    ];
+
+    const data = { level1: { level2: { value: 10, result: 0 } } };
+
+    const { values, errors } = evaluateFormulas(formulas, data);
+
+    expect(errors).toEqual([]);
+    expect(
+      ((values.level1 as Record<string, unknown>)?.level2 as Record<string, unknown>)?.result,
+    ).toBe(30);
   });
 });
 

--- a/src/lib/formula.ts
+++ b/src/lib/formula.ts
@@ -176,7 +176,15 @@ function evaluateSingleFormula(
   values: Record<string, unknown>,
   options: EvaluateFormulasOptions,
 ): FormulaError[] {
-  const context: EvaluateContextOptions = { rootData: data };
+  const parentPath = getParentPath(formula.fieldName);
+  const itemData = parentPath
+    ? (getValueByPath(data, parentPath) as Record<string, unknown> | undefined)
+    : undefined;
+
+  const context: EvaluateContextOptions = {
+    rootData: data,
+    ...(itemData && { itemData, currentPath: parentPath }),
+  };
 
   try {
     const result = evaluateWithContext(formula.expression, context);
@@ -280,6 +288,14 @@ function evaluateArrayFormula(
   }
 
   return errors;
+}
+
+function getParentPath(fieldPath: string): string {
+  const lastDotIndex = fieldPath.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    return '';
+  }
+  return fieldPath.substring(0, lastDotIndex);
 }
 
 function getValueByPath(

--- a/src/lib/validate-schema-formulas.ts
+++ b/src/lib/validate-schema-formulas.ts
@@ -65,6 +65,10 @@ export function validateSchemaFormulas(
       if (dep.startsWith('/')) {
         return extractFieldRoot(dep.slice(1));
       }
+      if (dep.startsWith('../')) {
+        const fieldWithoutPrefix = dep.replace(/^(\.\.\/)+/, '');
+        return extractFieldRoot(fieldWithoutPrefix);
+      }
       const rootField = extractFieldRoot(dep);
       return `${prefix}${rootField}`;
     });
@@ -128,6 +132,15 @@ function validateFormulaInContext(
   for (const dep of parseResult.dependencies) {
     if (dep.startsWith('/')) {
       const rootField = extractFieldRoot(dep.slice(1));
+      if (!rootSchemaFields.has(rootField)) {
+        return {
+          field: fieldPath,
+          error: `Unknown root field '${rootField}' in formula`,
+        };
+      }
+    } else if (dep.startsWith('../')) {
+      const fieldWithoutPrefix = dep.replace(/^(\.\.\/)+/, '');
+      const rootField = extractFieldRoot(fieldWithoutPrefix);
       if (!rootSchemaFields.has(rootField)) {
         return {
           field: fieldPath,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix formula evaluation for nested fields so formulas can read sibling and root values. Added support for ../ relative paths in schema validation to resolve references across array/item boundaries.

- **Bug Fixes**
  - Provide item-level context (currentPath and itemData) based on the formula’s parent path.
  - Correct computation for nested and deeply nested formulas referencing sibling fields.
  - Handle root field references in nested formulas without errors.

- **New Features**
  - Validate ../ relative dependencies in formulas (../field, ../object.field, ../../field).
  - Add tests for sibling references and relative path validation.

<sup>Written for commit 0963ecd1b350a18d236e0952cc0502ff6ad5121b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Significantly enhanced test coverage for nested object formulas with sibling and root field references
  * Added comprehensive validation tests for relative path references in formulas, including multi-level relative paths

* **New Features**
  * Formulas now support relative parent-path references using `../` syntax for accessing sibling and parent-level fields

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->