### PR TITLE
feat: formulas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "@revisium/formula": "^0.6.1",
+        "@revisium/formula": "^0.6.2",
         "nanoid": "^3.3.7"
       },
       "devDependencies": {
@@ -1812,9 +1812,9 @@
       }
     },
     "node_modules/@revisium/formula": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@revisium/formula/-/formula-0.6.1.tgz",
-      "integrity": "sha512-nLV+3XvCafh6uzAujKBySiW6/eowOonTO67YvyxkrKuhXRpirqG08buqOcv9vjB+FMPyjFQJxkUc8JOi8KEUZw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@revisium/formula/-/formula-0.6.2.tgz",
+      "integrity": "sha512-kek4kCRc+8OEbnHb+4J2nHvBh2HpfWowKjFhRrVWZDRgLytw3J7MILZA5W46/2kA4cGgpgp8lqHBX/nTTeiM4g==",
       "license": "MIT",
       "dependencies": {
         "ohm-js": "^17.3.0"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,16 @@
         "types": "./dist/validation-schemas/index.d.cts",
         "default": "./dist/validation-schemas/index.cjs"
       }
+    },
+    "./formula": {
+      "import": {
+        "types": "./dist/formula/index.d.ts",
+        "default": "./dist/formula/index.js"
+      },
+      "require": {
+        "types": "./dist/formula/index.d.cts",
+        "default": "./dist/formula/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",
@@ -122,6 +132,9 @@
       ],
       "validation-schemas": [
         "./dist/validation-schemas/index.d.ts"
+      ],
+      "formula": [
+        "./dist/formula/index.d.ts"
       ]
     }
   },
@@ -158,7 +171,7 @@
     "typescript-eslint": "^8.15.0"
   },
   "dependencies": {
-    "@revisium/formula": "^0.6.1",
+    "@revisium/formula": "^0.6.2",
     "nanoid": "^3.3.7"
   },
   "engines": {

--- a/src/formula/index.ts
+++ b/src/formula/index.ts
@@ -1,0 +1,15 @@
+export {
+  collectFormulaNodes,
+  evaluateFormulas,
+  formulaSpec,
+  extractSchemaFormulas,
+  validateSchemaFormulas,
+  validateFormulaAgainstSchema,
+  type FormulaNode,
+  type FormulaError,
+  type EvaluateFormulasResult,
+  type EvaluateFormulasOptions,
+  type ExtractedFormula,
+  type SchemaValidationResult,
+  type FormulaValidationError,
+} from '../lib/formula.js';

--- a/src/lib/__tests__/formula.spec.ts
+++ b/src/lib/__tests__/formula.spec.ts
@@ -1,8 +1,7 @@
 import { JsonSchema } from '../../types/index.js';
 import {
-  prepareFormulas,
+  collectFormulaNodes,
   evaluateFormulas,
-  type PreparedFormula,
 } from '../formula.js';
 
 const createSchema = (
@@ -27,67 +26,37 @@ const createSchema = (
     required: Object.keys(fields),
   }) as JsonSchema;
 
-describe('prepareFormulas', () => {
+describe('collectFormulaNodes', () => {
   it('should return empty array when no formulas', () => {
     const schema = createSchema({
       name: { type: 'string' },
       price: { type: 'number' },
     });
 
-    const result = prepareFormulas(schema);
+    const result = collectFormulaNodes(schema, { name: 'test', price: 10 });
 
     expect(result).toEqual([]);
   });
 
-  it('should extract single formula', () => {
+  it('should collect single formula', () => {
     const schema = createSchema({
       price: { type: 'number' },
       doubled: { type: 'number', formula: 'price * 2' },
     });
 
-    const result = prepareFormulas(schema);
+    const result = collectFormulaNodes(schema, { price: 10, doubled: 0 });
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      fieldName: 'doubled',
+      path: 'doubled',
       expression: 'price * 2',
       fieldType: 'number',
+      currentPath: '',
       dependencies: ['price'],
-      isArrayItem: false,
-      arrayPath: null,
-      localFieldPath: 'doubled',
     });
   });
 
-  it('should order formulas by dependencies', () => {
-    const schema = createSchema({
-      price: { type: 'number' },
-      tax: { type: 'number', formula: 'subtotal * 0.1' },
-      subtotal: { type: 'number', formula: 'price' },
-      total: { type: 'number', formula: 'subtotal + tax' },
-    });
-
-    const result = prepareFormulas(schema);
-
-    expect(result).toHaveLength(3);
-    const names = result.map((f) => f.fieldName);
-    expect(names.indexOf('subtotal')).toBeLessThan(names.indexOf('tax'));
-    expect(names.indexOf('subtotal')).toBeLessThan(names.indexOf('total'));
-    expect(names.indexOf('tax')).toBeLessThan(names.indexOf('total'));
-  });
-
-  it('should throw on cyclic dependencies', () => {
-    const schema = createSchema({
-      a: { type: 'number', formula: 'b + 1' },
-      b: { type: 'number', formula: 'a + 1' },
-    });
-
-    expect(() => prepareFormulas(schema)).toThrow(
-      'Cyclic dependency detected in formulas',
-    );
-  });
-
-  it('should parse array item path', () => {
+  it('should collect formulas from array items with concrete indices', () => {
     const schema: JsonSchema = {
       type: 'object',
       properties: {
@@ -112,89 +81,140 @@ describe('prepareFormulas', () => {
       required: ['items'],
     } as JsonSchema;
 
-    const result = prepareFormulas(schema);
+    const data = {
+      items: [
+        { price: 10, doubled: 0 },
+        { price: 20, doubled: 0 },
+      ],
+    };
+
+    const result = collectFormulaNodes(schema, data);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      path: 'items[0].doubled',
+      currentPath: 'items[0]',
+    });
+    expect(result[1]).toMatchObject({
+      path: 'items[1].doubled',
+      currentPath: 'items[1]',
+    });
+  });
+
+  it('should collect formulas from nested arrays', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        orders: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              items: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    qty: { type: 'number' },
+                    price: { type: 'number' },
+                    total: {
+                      type: 'number',
+                      readOnly: true,
+                      'x-formula': { version: 1, expression: 'qty * price' },
+                    },
+                  },
+                  additionalProperties: false,
+                  required: ['qty', 'price', 'total'],
+                },
+              },
+            },
+            additionalProperties: false,
+            required: ['items'],
+          },
+        },
+      },
+      additionalProperties: false,
+      required: ['orders'],
+    } as JsonSchema;
+
+    const data = {
+      orders: [
+        { items: [{ qty: 2, price: 10, total: 0 }, { qty: 3, price: 5, total: 0 }] },
+        { items: [{ qty: 1, price: 20, total: 0 }] },
+      ],
+    };
+
+    const result = collectFormulaNodes(schema, data);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.path).toBe('orders[0].items[0].total');
+    expect(result[0]?.currentPath).toBe('orders[0].items[0]');
+    expect(result[1]?.path).toBe('orders[0].items[1].total');
+    expect(result[2]?.path).toBe('orders[1].items[0].total');
+  });
+
+  it('should ignore formulas on non-primitive types', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          'x-formula': { version: 1, expression: 'something' },
+          properties: {},
+        },
+        valid: {
+          type: 'number',
+          'x-formula': { version: 1, expression: '1 + 1' },
+        },
+      },
+      additionalProperties: false,
+      required: ['data', 'valid'],
+    } as JsonSchema;
+
+    const result = collectFormulaNodes(schema, { data: {}, valid: 0 });
 
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      fieldName: 'items[].doubled',
-      isArrayItem: true,
-      arrayPath: 'items',
-      localFieldPath: 'doubled',
-    });
+    expect(result[0]?.path).toBe('valid');
   });
 });
 
 describe('evaluateFormulas', () => {
   it('should compute simple formula', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'doubled',
-        expression: 'price * 2',
-        fieldType: 'number',
-        dependencies: ['price'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'doubled',
-      },
-    ];
+    const schema = createSchema({
+      price: { type: 'number' },
+      doubled: { type: 'number', formula: 'price * 2' },
+    });
 
-    const { values, errors } = evaluateFormulas(formulas, { price: 10 });
+    const data = { price: 10, doubled: 0 };
+    const { values, errors } = evaluateFormulas(schema, data);
 
-    expect(values).toEqual({ doubled: 20 });
     expect(errors).toEqual([]);
+    expect(values).toEqual({ doubled: 20 });
+    expect(data.doubled).toBe(20);
   });
 
   it('should compute chained formulas', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'subtotal',
-        expression: 'price',
-        fieldType: 'number',
-        dependencies: ['price'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'subtotal',
-      },
-      {
-        fieldName: 'tax',
-        expression: 'subtotal * 0.1',
-        fieldType: 'number',
-        dependencies: ['subtotal'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'tax',
-      },
-      {
-        fieldName: 'total',
-        expression: 'subtotal + tax',
-        fieldType: 'number',
-        dependencies: ['subtotal', 'tax'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'total',
-      },
-    ];
+    const schema = createSchema({
+      price: { type: 'number' },
+      subtotal: { type: 'number', formula: 'price' },
+      tax: { type: 'number', formula: 'subtotal * 0.1' },
+      total: { type: 'number', formula: 'subtotal + tax' },
+    });
 
-    const { values, errors } = evaluateFormulas(formulas, { price: 100 });
+    const data = { price: 100, subtotal: 0, tax: 0, total: 0 };
+    const { values, errors } = evaluateFormulas(schema, data);
 
-    expect(values).toEqual({ subtotal: 100, tax: 10, total: 110 });
     expect(errors).toEqual([]);
+    expect(values).toEqual({ subtotal: 100, tax: 10, total: 110 });
   });
 
   it('should return errors for failed formulas', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'result',
-        expression: '(((',
-        fieldType: 'number',
-        dependencies: [],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'result',
-      },
-    ];
+    const schema = createSchema({
+      result: { type: 'number', formula: '(((' },
+    });
 
-    const { values, errors } = evaluateFormulas(formulas, {});
+    const data = { result: 0 };
+    const { values, errors } = evaluateFormulas(schema, data);
 
     expect(values).toEqual({});
     expect(errors).toHaveLength(1);
@@ -205,70 +225,41 @@ describe('evaluateFormulas', () => {
   });
 
   it('should use defaults when formula fails and useDefaults is true', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'result',
-        expression: '(((',
-        fieldType: 'number',
-        dependencies: [],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'result',
-      },
-    ];
+    const schema = createSchema({
+      result: { type: 'number', formula: '(((' },
+    });
 
-    const { values, errors } = evaluateFormulas(formulas, {}, { useDefaults: true });
+    const data = { result: 99 };
+    const { values, errors } = evaluateFormulas(schema, data, { useDefaults: true });
 
     expect(values).toEqual({ result: 0 });
+    expect(data.result).toBe(0);
     expect(errors).toHaveLength(1);
     expect(errors[0]?.defaultUsed).toBe(true);
   });
 
   it('should use custom defaults', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'result',
-        expression: '(((',
-        fieldType: 'number',
-        dependencies: [],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'result',
-      },
-    ];
+    const schema = createSchema({
+      result: { type: 'number', formula: '(((' },
+    });
 
-    const { values } = evaluateFormulas(
-      formulas,
-      {},
-      { useDefaults: true, defaults: { result: 42 } },
-    );
+    const data = { result: 0 };
+    const { values } = evaluateFormulas(schema, data, {
+      useDefaults: true,
+      defaults: { result: 42 },
+    });
 
     expect(values).toEqual({ result: 42 });
   });
 
   it('should propagate failure to dependent formulas', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'a',
-        expression: '(((',
-        fieldType: 'number',
-        dependencies: [],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'a',
-      },
-      {
-        fieldName: 'b',
-        expression: 'a * 2',
-        fieldType: 'number',
-        dependencies: ['a'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'b',
-      },
-    ];
+    const schema = createSchema({
+      a: { type: 'number', formula: '(((' },
+      b: { type: 'number', formula: 'a * 2' },
+    });
 
-    const { errors } = evaluateFormulas(formulas, {}, { useDefaults: true });
+    const data = { a: 0, b: 0 };
+    const { errors } = evaluateFormulas(schema, data, { useDefaults: true });
 
     expect(errors).toHaveLength(2);
     expect(errors[1]).toMatchObject({
@@ -278,17 +269,29 @@ describe('evaluateFormulas', () => {
   });
 
   it('should compute array item formulas', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'items[].doubled',
-        expression: 'price * 2',
-        fieldType: 'number',
-        dependencies: ['price'],
-        isArrayItem: true,
-        arrayPath: 'items',
-        localFieldPath: 'doubled',
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              price: { type: 'number' },
+              doubled: {
+                type: 'number',
+                readOnly: true,
+                'x-formula': { version: 1, expression: 'price * 2' },
+              },
+            },
+            additionalProperties: false,
+            required: ['price', 'doubled'],
+          },
+        },
       },
-    ];
+      additionalProperties: false,
+      required: ['items'],
+    } as JsonSchema;
 
     const data = {
       items: [
@@ -297,68 +300,195 @@ describe('evaluateFormulas', () => {
       ],
     };
 
-    const { values, errors } = evaluateFormulas(formulas, data);
+    const { values, errors } = evaluateFormulas(schema, data);
 
     expect(errors).toEqual([]);
-    expect((values['items[0]'] as Record<string, unknown>)?.doubled).toBe(20);
-    expect((values['items[1]'] as Record<string, unknown>)?.doubled).toBe(40);
-    expect((data.items[0] as Record<string, unknown>).doubled).toBe(20);
-    expect((data.items[1] as Record<string, unknown>).doubled).toBe(40);
+    expect(values['items[0].doubled']).toBe(20);
+    expect(values['items[1].doubled']).toBe(40);
+    expect(data.items[0]?.doubled).toBe(20);
+    expect(data.items[1]?.doubled).toBe(40);
   });
 
   it('should compute boolean formula', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'isExpensive',
-        expression: 'price > 100',
-        fieldType: 'boolean',
-        dependencies: ['price'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'isExpensive',
-      },
-    ];
+    const schema = createSchema({
+      price: { type: 'number' },
+      isExpensive: { type: 'boolean', formula: 'price > 100' },
+    });
 
-    const { values: values1 } = evaluateFormulas(formulas, { price: 50 });
+    const { values: values1 } = evaluateFormulas(schema, { price: 50, isExpensive: true });
     expect(values1).toEqual({ isExpensive: false });
 
-    const { values: values2 } = evaluateFormulas(formulas, { price: 150 });
+    const { values: values2 } = evaluateFormulas(schema, { price: 150, isExpensive: false });
     expect(values2).toEqual({ isExpensive: true });
   });
 
   it('should compute string formula with concat', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'fullName',
-        expression: 'concat(firstName, " ", lastName)',
-        fieldType: 'string',
-        dependencies: ['firstName', 'lastName'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'fullName',
-      },
-    ];
-
-    const { values } = evaluateFormulas(formulas, {
-      firstName: 'John',
-      lastName: 'Doe',
+    const schema = createSchema({
+      firstName: { type: 'string' },
+      lastName: { type: 'string' },
+      fullName: { type: 'string', formula: 'concat(firstName, " ", lastName)' },
     });
+
+    const data = { firstName: 'John', lastName: 'Doe', fullName: '' };
+    const { values } = evaluateFormulas(schema, data);
 
     expect(values).toEqual({ fullName: 'John Doe' });
   });
 
-  it('should resolve root path /field in array item formula', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'items[].priceWithTax',
-        expression: 'price * (1 + /taxRate)',
-        fieldType: 'number',
-        dependencies: [],
-        isArrayItem: true,
-        arrayPath: 'items',
-        localFieldPath: 'priceWithTax',
+  it('should handle empty array', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              doubled: {
+                type: 'number',
+                'x-formula': { version: 1, expression: 'price * 2' },
+              },
+            },
+          },
+        },
       },
-    ];
+    } as JsonSchema;
+
+    const { values, errors } = evaluateFormulas(schema, { items: [] });
+
+    expect(values).toEqual({});
+    expect(errors).toEqual([]);
+  });
+
+  it('should return empty result when no formulas', () => {
+    const schema = createSchema({
+      name: { type: 'string' },
+      price: { type: 'number' },
+    });
+
+    const { values, errors } = evaluateFormulas(schema, { name: 'test', price: 10 });
+
+    expect(values).toEqual({});
+    expect(errors).toEqual([]);
+  });
+
+  it('should provide correct defaults for each type', () => {
+    const schema = createSchema({
+      num: { type: 'number', formula: '(((' },
+      str: { type: 'string', formula: '(((' },
+      bool: { type: 'boolean', formula: '(((' },
+    });
+
+    const data = { num: 99, str: 'old', bool: true };
+    const { values } = evaluateFormulas(schema, data, { useDefaults: true });
+
+    expect(values.num).toBe(0);
+    expect(values.str).toBe('');
+    expect(values.bool).toBe(false);
+  });
+});
+
+describe('nested object formulas', () => {
+  it('should compute nested object formula referencing root field', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        rootValue: { type: 'number' },
+        nested: {
+          type: 'object',
+          properties: {
+            computed: {
+              type: 'number',
+              'x-formula': { version: 1, expression: 'rootValue * 2' },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = { rootValue: 50, nested: { computed: 0 } };
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['nested.computed']).toBe(100);
+  });
+
+  it('should compute nested object formula referencing sibling field', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            sourceValue: { type: 'number' },
+            computed: {
+              type: 'number',
+              'x-formula': { version: 1, expression: 'sourceValue * 2' },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = { nested: { sourceValue: 25, computed: 0 } };
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['nested.computed']).toBe(50);
+    expect(data.nested.computed).toBe(50);
+  });
+
+  it('should compute deeply nested object formula', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        level1: {
+          type: 'object',
+          properties: {
+            level2: {
+              type: 'object',
+              properties: {
+                value: { type: 'number' },
+                result: {
+                  type: 'number',
+                  'x-formula': { version: 1, expression: 'value * 3' },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = { level1: { level2: { value: 10, result: 0 } } };
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['level1.level2.result']).toBe(30);
+  });
+});
+
+describe('root path formulas', () => {
+  it('should resolve root path /field in array item formula', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        taxRate: { type: 'number' },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              price: { type: 'number' },
+              priceWithTax: {
+                type: 'number',
+                'x-formula': { version: 1, expression: 'price * (1 + /taxRate)' },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
 
     const data = {
       taxRate: 0.1,
@@ -368,137 +498,677 @@ describe('evaluateFormulas', () => {
       ],
     };
 
-    const { values, errors } = evaluateFormulas(formulas, data);
+    const { values, errors } = evaluateFormulas(schema, data);
 
     expect(errors).toEqual([]);
-    expect(
-      (values['items[0]'] as Record<string, unknown>)?.priceWithTax,
-    ).toBeCloseTo(110);
-    expect(
-      (values['items[1]'] as Record<string, unknown>)?.priceWithTax,
-    ).toBeCloseTo(220);
+    expect(values['items[0].priceWithTax']).toBeCloseTo(110);
+    expect(values['items[1].priceWithTax']).toBeCloseTo(220);
   });
 
-  it('should handle empty array', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'items[].doubled',
-        expression: 'price * 2',
-        fieldType: 'number',
-        dependencies: ['price'],
-        isArrayItem: true,
-        arrayPath: 'items',
-        localFieldPath: 'doubled',
+  it('should resolve nested root path /config.multiplier in array item formula', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        config: {
+          type: 'object',
+          properties: {
+            multiplier: { type: 'number' },
+          },
+        },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              value: { type: 'number' },
+              result: {
+                type: 'number',
+                'x-formula': { version: 1, expression: 'value * /config.multiplier' },
+              },
+            },
+          },
+        },
       },
-    ];
+    } as JsonSchema;
 
-    const { values, errors } = evaluateFormulas(formulas, { items: [] });
+    const data = {
+      config: { multiplier: 3 },
+      items: [
+        { value: 10, result: 0 },
+        { value: 20, result: 0 },
+      ],
+    };
 
-    expect(values).toEqual({});
-    expect(errors).toEqual([]);
-  });
-
-  it('should compute nested object formula referencing root field', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'nested.computed',
-        expression: 'rootValue * 2',
-        fieldType: 'number',
-        dependencies: ['rootValue'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'nested.computed',
-      },
-    ];
-
-    const data = { rootValue: 50, nested: { computed: 0 } };
-
-    const { values, errors } = evaluateFormulas(formulas, data);
-
-    expect(errors).toEqual([]);
-    expect((values.nested as Record<string, unknown>)?.computed).toBe(100);
-  });
-
-  it('should compute nested object formula referencing sibling field', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'nested.computed',
-        expression: 'sourceValue * 2',
-        fieldType: 'number',
-        dependencies: ['sourceValue'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'nested.computed',
-      },
-    ];
-
-    const data = { nested: { sourceValue: 25, computed: 0 } };
-
-    const { values, errors } = evaluateFormulas(formulas, data);
+    const { values, errors } = evaluateFormulas(schema, data);
 
     expect(errors).toEqual([]);
-    expect((values.nested as Record<string, unknown>)?.computed).toBe(50);
-    expect((data.nested as Record<string, unknown>).computed).toBe(50);
-  });
-
-  it('should compute deeply nested object formula referencing sibling field', () => {
-    const formulas: PreparedFormula[] = [
-      {
-        fieldName: 'level1.level2.result',
-        expression: 'value * 3',
-        fieldType: 'number',
-        dependencies: ['value'],
-        isArrayItem: false,
-        arrayPath: null,
-        localFieldPath: 'level1.level2.result',
-      },
-    ];
-
-    const data = { level1: { level2: { value: 10, result: 0 } } };
-
-    const { values, errors } = evaluateFormulas(formulas, data);
-
-    expect(errors).toEqual([]);
-    expect(
-      ((values.level1 as Record<string, unknown>)?.level2 as Record<string, unknown>)?.result,
-    ).toBe(30);
+    expect(values['items[0].result']).toBe(30);
+    expect(values['items[1].result']).toBe(60);
   });
 });
 
-describe('prepareFormulas + evaluateFormulas integration', () => {
-  it('should work together', () => {
-    const schema = createSchema({
-      price: { type: 'number' },
-      quantity: { type: 'number' },
-      total: { type: 'number', formula: 'price * quantity' },
-    });
+describe('relative path formulas', () => {
+  it('should compute formula with ../field from array item to root', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        discount: { type: 'number' },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              price: { type: 'number' },
+              discounted: {
+                type: 'number',
+                'x-formula': { version: 1, expression: 'price * (1 - ../discount)' },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
 
-    const formulas = prepareFormulas(schema);
-    const { values, errors } = evaluateFormulas(formulas, {
-      price: 10,
-      quantity: 5,
-    });
+    const data = {
+      discount: 0.2,
+      items: [{ price: 100, discounted: 0 }],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
 
     expect(errors).toEqual([]);
-    expect(values).toEqual({ total: 50 });
+    expect(values['items[0].discounted']).toBe(80);
   });
 
-  it('should handle complex chained formulas', () => {
-    const schema = createSchema({
-      price: { type: 'number' },
-      taxRate: { type: 'number' },
-      subtotal: { type: 'number', formula: 'price' },
-      tax: { type: 'number', formula: 'subtotal * taxRate' },
-      total: { type: 'number', formula: 'subtotal + tax' },
-    });
+  it('should compute formula with ../field from nested object in array', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              itemVal: { type: 'number' },
+              inner: {
+                type: 'object',
+                properties: {
+                  price: { type: 'number' },
+                  calc: {
+                    type: 'number',
+                    'x-formula': { version: 1, expression: 'price * ../itemVal' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
 
-    const formulas = prepareFormulas(schema);
-    const { values, errors } = evaluateFormulas(formulas, {
-      price: 100,
-      taxRate: 0.2,
-    });
+    const data = {
+      items: [{ itemVal: 10, inner: { price: 5, calc: 0 } }],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
 
     expect(errors).toEqual([]);
-    expect(values).toEqual({ subtotal: 100, tax: 20, total: 120 });
+    expect(values['items[0].inner.calc']).toBe(50);
+  });
+
+  it('should compute formula with ../../field from nested object in array to root', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        rootRate: { type: 'number' },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              inner: {
+                type: 'object',
+                properties: {
+                  price: { type: 'number' },
+                  rootCalc: {
+                    type: 'number',
+                    'x-formula': { version: 1, expression: 'price * ../../rootRate' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      rootRate: 2,
+      items: [{ inner: { price: 5, rootCalc: 0 } }],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].inner.rootCalc']).toBe(10);
+  });
+
+  it('should compute formula with ../containerRate from array inside object', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        container: {
+          type: 'object',
+          properties: {
+            containerRate: { type: 'number' },
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  price: { type: 'number' },
+                  parentTotal: {
+                    type: 'number',
+                    'x-formula': { version: 1, expression: 'price * ../containerRate' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      container: {
+        containerRate: 2,
+        items: [{ price: 10, parentTotal: 0 }],
+      },
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['container.items[0].parentTotal']).toBe(20);
+  });
+
+  it('should compute formula with ../../rootVal from array inside object', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        rootVal: { type: 'number' },
+        container: {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  price: { type: 'number' },
+                  rootTotal: {
+                    type: 'number',
+                    'x-formula': { version: 1, expression: 'price * ../../rootVal' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      rootVal: 3,
+      container: {
+        items: [{ price: 10, rootTotal: 0 }],
+      },
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['container.items[0].rootTotal']).toBe(30);
+  });
+
+  it('should compute formula with ../../factor from deep nested non-array path', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        factor: { type: 'number' },
+        nested: {
+          type: 'object',
+          properties: {
+            deep: {
+              type: 'object',
+              properties: {
+                value: { type: 'number' },
+                result: {
+                  type: 'number',
+                  'x-formula': { version: 1, expression: 'value * ../../factor' },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      factor: 5,
+      nested: { deep: { value: 10, result: 0 } },
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['nested.deep.result']).toBe(50);
+  });
+
+  it('should compute formula with ../../../multiplier triple relative path', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        multiplier: { type: 'number' },
+        a: {
+          type: 'object',
+          properties: {
+            b: {
+              type: 'object',
+              properties: {
+                c: {
+                  type: 'object',
+                  properties: {
+                    val: { type: 'number' },
+                    result: {
+                      type: 'number',
+                      'x-formula': { version: 1, expression: 'val * ../../../multiplier' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      multiplier: 3,
+      a: { b: { c: { val: 7, result: 0 } } },
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['a.b.c.result']).toBe(21);
+  });
+
+  it('should compute formula with ../sibling.nested path', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        config: {
+          type: 'object',
+          properties: {
+            discount: { type: 'number' },
+          },
+        },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              price: { type: 'number' },
+              discountedPrice: {
+                type: 'number',
+                'x-formula': { version: 1, expression: 'price * ../config.discount' },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      config: { discount: 0.9 },
+      items: [{ price: 100, discountedPrice: 0 }],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].discountedPrice']).toBe(90);
+  });
+
+  it('should compute formula with ../../settings.tax.rate deep sibling path', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        settings: {
+          type: 'object',
+          properties: {
+            tax: {
+              type: 'object',
+              properties: {
+                rate: { type: 'number' },
+              },
+            },
+          },
+        },
+        orders: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              inner: {
+                type: 'object',
+                properties: {
+                  amount: { type: 'number' },
+                  taxAmount: {
+                    type: 'number',
+                    'x-formula': { version: 1, expression: 'amount * ../../settings.tax.rate' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      settings: { tax: { rate: 0.1 } },
+      orders: [{ inner: { amount: 200, taxAmount: 0 } }],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['orders[0].inner.taxAmount']).toBe(20);
+  });
+});
+
+describe('nested arrays', () => {
+  it('should compute formulas in nested arrays (items[].subItems[])', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              subItems: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    qty: { type: 'number' },
+                    price: { type: 'number' },
+                    total: {
+                      type: 'number',
+                      'x-formula': { version: 1, expression: 'qty * price' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      items: [
+        { subItems: [{ qty: 2, price: 10, total: 0 }, { qty: 3, price: 5, total: 0 }] },
+        { subItems: [{ qty: 1, price: 20, total: 0 }] },
+      ],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].subItems[0].total']).toBe(20);
+    expect(values['items[0].subItems[1].total']).toBe(15);
+    expect(values['items[1].subItems[0].total']).toBe(20);
+    expect(data.items[0]?.subItems[0]?.total).toBe(20);
+    expect(data.items[0]?.subItems[1]?.total).toBe(15);
+    expect(data.items[1]?.subItems[0]?.total).toBe(20);
+  });
+
+  it('should compute formula with ../itemPrice from nested array to parent array item', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              itemPrice: { type: 'number' },
+              subItems: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    qty: { type: 'number' },
+                    lineTotal: {
+                      type: 'number',
+                      'x-formula': { version: 1, expression: 'qty * ../itemPrice' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      items: [
+        { itemPrice: 10, subItems: [{ qty: 3, lineTotal: 0 }] },
+      ],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].subItems[0].lineTotal']).toBe(30);
+  });
+
+  it('should compute formula with ../../globalRate from nested array to root', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        globalRate: { type: 'number' },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              subItems: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    qty: { type: 'number' },
+                    adjusted: {
+                      type: 'number',
+                      'x-formula': { version: 1, expression: 'qty * ../../globalRate' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      globalRate: 2,
+      items: [
+        { subItems: [{ qty: 5, adjusted: 0 }] },
+      ],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].subItems[0].adjusted']).toBe(10);
+  });
+
+  it('should compute formula in array inside object inside array (items[].container.subItems[])', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              container: {
+                type: 'object',
+                properties: {
+                  containerMultiplier: { type: 'number' },
+                  subItems: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        val: { type: 'number' },
+                        result: {
+                          type: 'number',
+                          'x-formula': { version: 1, expression: 'val * ../containerMultiplier' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      items: [
+        { container: { containerMultiplier: 4, subItems: [{ val: 3, result: 0 }] } },
+      ],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].container.subItems[0].result']).toBe(12);
+  });
+
+  it('should compute formula with ../../itemRate from array in object in array to parent array item', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              itemRate: { type: 'number' },
+              container: {
+                type: 'object',
+                properties: {
+                  subItems: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        val: { type: 'number' },
+                        result: {
+                          type: 'number',
+                          'x-formula': { version: 1, expression: 'val * ../../itemRate' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      items: [
+        { itemRate: 5, container: { subItems: [{ val: 2, result: 0 }] } },
+      ],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].container.subItems[0].result']).toBe(10);
+  });
+
+  it('should compute formula with ../../../rootFactor from array in object in array to root', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        rootFactor: { type: 'number' },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              container: {
+                type: 'object',
+                properties: {
+                  subItems: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        val: { type: 'number' },
+                        result: {
+                          type: 'number',
+                          'x-formula': { version: 1, expression: 'val * ../../../rootFactor' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as JsonSchema;
+
+    const data = {
+      rootFactor: 3,
+      items: [
+        { container: { subItems: [{ val: 7, result: 0 }] } },
+      ],
+    };
+
+    const { values, errors } = evaluateFormulas(schema, data);
+
+    expect(errors).toEqual([]);
+    expect(values['items[0].container.subItems[0].result']).toBe(21);
+  });
+});
+
+describe('cyclic dependencies', () => {
+  it('should throw on cyclic dependencies', () => {
+    const schema = createSchema({
+      a: { type: 'number', formula: 'b + 1' },
+      b: { type: 'number', formula: 'a + 1' },
+    });
+
+    expect(() => evaluateFormulas(schema, { a: 0, b: 0 })).toThrow(
+      'Cyclic dependency detected in formulas',
+    );
   });
 });

--- a/src/lib/formula.ts
+++ b/src/lib/formula.ts
@@ -289,28 +289,33 @@ type PathSegment = { type: 'field'; name: string } | { type: 'index'; index: num
 function parsePath(path: string): PathSegment[] {
   const segments: PathSegment[] = [];
   let current = '';
+  let position = 0;
 
-  for (let i = 0; i < path.length; i++) {
-    const char = path[i];
+  while (position < path.length) {
+    const char = path[position];
 
     if (char === '.') {
       if (current) {
         segments.push({ type: 'field', name: current });
         current = '';
       }
+      position++;
     } else if (char === '[') {
       if (current) {
         segments.push({ type: 'field', name: current });
         current = '';
       }
-      const endBracket = path.indexOf(']', i);
+      const endBracket = path.indexOf(']', position);
       if (endBracket !== -1) {
-        const indexStr = path.slice(i + 1, endBracket);
+        const indexStr = path.slice(position + 1, endBracket);
         segments.push({ type: 'index', index: Number.parseInt(indexStr, 10) });
-        i = endBracket;
+        position = endBracket + 1;
+      } else {
+        position++;
       }
     } else {
       current += char;
+      position++;
     }
   }
 

--- a/src/lib/formula.ts
+++ b/src/lib/formula.ts
@@ -3,17 +3,14 @@ import {
   buildDependencyGraph,
   getTopologicalOrder,
   evaluateWithContext,
-  type EvaluateContextOptions,
 } from '@revisium/formula';
 import { type JsonSchema } from '../types/index.js';
-import {
+
+export { formulaSpec } from '@revisium/formula/spec';
+export {
   extractSchemaFormulas,
   type ExtractedFormula,
 } from './extract-schema-formulas.js';
-
-export { formulaSpec } from '@revisium/formula/spec';
-export { extractSchemaFormulas };
-export type { ExtractedFormula };
 export {
   validateSchemaFormulas,
   validateFormulaAgainstSchema,
@@ -21,14 +18,12 @@ export {
   type FormulaValidationError,
 } from './validate-schema-formulas.js';
 
-export interface PreparedFormula {
-  fieldName: string;
+export interface FormulaNode {
+  path: string;
   expression: string;
-  fieldType: string;
+  fieldType: 'number' | 'string' | 'boolean';
+  currentPath: string;
   dependencies: string[];
-  isArrayItem: boolean;
-  arrayPath: string | null;
-  localFieldPath: string;
 }
 
 export interface FormulaError {
@@ -48,65 +43,60 @@ export interface EvaluateFormulasOptions {
   defaults?: Record<string, unknown>;
 }
 
-export function prepareFormulas(schema: JsonSchema): PreparedFormula[] {
-  const formulas = extractSchemaFormulas(schema as Record<string, unknown>);
-
-  if (formulas.length === 0) {
-    return [];
-  }
-
-  const formulasWithMeta = formulas.map((f) => enrichFormula(f));
-
-  if (formulas.length <= 1) {
-    return formulasWithMeta;
-  }
-
-  return orderByDependencies(formulasWithMeta);
+interface SchemaNode {
+  type?: string;
+  properties?: Record<string, SchemaNode>;
+  items?: SchemaNode;
+  'x-formula'?: { version: number; expression: string };
 }
 
-export function evaluateFormulas(
-  formulas: PreparedFormula[],
+const FORMULA_TYPES = new Set(['number', 'string', 'boolean']);
+
+export function collectFormulaNodes(
+  schema: JsonSchema,
   data: Record<string, unknown>,
-  options: EvaluateFormulasOptions = {},
-): EvaluateFormulasResult {
-  const values: Record<string, unknown> = {};
-  const errors: FormulaError[] = [];
-  const failedFields = new Set<string>();
+): FormulaNode[] {
+  const nodes: FormulaNode[] = [];
+  traverseAndCollect(schema as SchemaNode, data, '', nodes);
+  return nodes;
+}
 
-  for (const formula of formulas) {
-    const hasDependencyFailure = formula.dependencies.some((dep) =>
-      failedFields.has(dep),
-    );
+function traverseAndCollect(
+  schema: SchemaNode,
+  data: unknown,
+  currentPath: string,
+  nodes: FormulaNode[],
+): void {
+  if (schema.type === 'object' && schema.properties && typeof data === 'object' && data !== null) {
+    const record = data as Record<string, unknown>;
 
-    if (hasDependencyFailure) {
-      failedFields.add(formula.fieldName);
-      if (options.useDefaults) {
-        const defaultValue = getDefaultValue(formula, options.defaults);
-        setValueByPath(values, formula.fieldName, defaultValue);
-        setValueByPath(data, formula.fieldName, defaultValue);
+    for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
+      const fieldPath = currentPath ? `${currentPath}.${fieldName}` : fieldName;
+      const fieldValue = record[fieldName];
+
+      if (fieldSchema['x-formula'] && FORMULA_TYPES.has(fieldSchema.type ?? '')) {
+        const expression = fieldSchema['x-formula'].expression;
+        const parentPath = getParentPath(fieldPath);
+
+        nodes.push({
+          path: fieldPath,
+          expression,
+          fieldType: fieldSchema.type as 'number' | 'string' | 'boolean',
+          currentPath: parentPath,
+          dependencies: parseDependencies(expression),
+        });
       }
-      errors.push(
-        createError(formula, 'Dependency formula failed', options.useDefaults ?? false),
-      );
-      continue;
-    }
 
-    const formulaErrors = evaluateFormula(formula, data, values, options);
-
-    if (formulaErrors.length > 0) {
-      errors.push(...formulaErrors);
-      failedFields.add(formula.fieldName);
+      traverseAndCollect(fieldSchema, fieldValue, fieldPath, nodes);
     }
   }
 
-  return { values, errors };
-}
-
-function enrichFormula(formula: ExtractedFormula): PreparedFormula {
-  const dependencies = parseDependencies(formula.expression);
-  const pathInfo = parseArrayItemPath(formula.fieldName);
-
-  return { ...formula, dependencies, ...pathInfo };
+  if (schema.type === 'array' && schema.items && Array.isArray(data)) {
+    for (let i = 0; i < data.length; i++) {
+      const itemPath = `${currentPath}[${i}]`;
+      traverseAndCollect(schema.items, data[i], itemPath, nodes);
+    }
+  }
 }
 
 function parseDependencies(expression: string): string[] {
@@ -117,29 +107,61 @@ function parseDependencies(expression: string): string[] {
   }
 }
 
-function parseArrayItemPath(fieldName: string): {
-  isArrayItem: boolean;
-  arrayPath: string | null;
-  localFieldPath: string;
-} {
-  const bracketIndex = fieldName.indexOf('[]');
-
-  if (bracketIndex === -1) {
-    return { isArrayItem: false, arrayPath: null, localFieldPath: fieldName };
+function getParentPath(fieldPath: string): string {
+  const lastDotIndex = fieldPath.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    return '';
   }
-
-  const arrayPath = fieldName.slice(0, bracketIndex);
-  const afterBrackets = fieldName.slice(bracketIndex + 2);
-  const localFieldPath = afterBrackets.startsWith('.')
-    ? afterBrackets.slice(1)
-    : afterBrackets;
-
-  return { isArrayItem: true, arrayPath, localFieldPath };
+  return fieldPath.substring(0, lastDotIndex);
 }
 
-function orderByDependencies(formulas: PreparedFormula[]): PreparedFormula[] {
+export function evaluateFormulas(
+  schema: JsonSchema,
+  data: Record<string, unknown>,
+  options: EvaluateFormulasOptions = {},
+): EvaluateFormulasResult {
+  const nodes = collectFormulaNodes(schema, data);
+
+  if (nodes.length === 0) {
+    return { values: {}, errors: [] };
+  }
+
+  const sortedNodes = orderByDependencies(nodes);
+  const values: Record<string, unknown> = {};
+  const errors: FormulaError[] = [];
+  const failedPaths = new Set<string>();
+
+  for (const node of sortedNodes) {
+    const hasDependencyFailure = hasFailedDependency(node, failedPaths);
+
+    if (hasDependencyFailure) {
+      failedPaths.add(node.path);
+      handleError(node, 'Dependency formula failed', data, values, errors, options);
+      continue;
+    }
+
+    const result = evaluateNode(node, data);
+
+    if (!result.success) {
+      failedPaths.add(node.path);
+      handleError(node, result.error, data, values, errors, options);
+      continue;
+    }
+
+    setValueByPath(data, node.path, result.value);
+    values[node.path] = result.value;
+  }
+
+  return { values, errors };
+}
+
+function orderByDependencies(nodes: FormulaNode[]): FormulaNode[] {
+  if (nodes.length <= 1) {
+    return nodes;
+  }
+
   const dependencies = Object.fromEntries(
-    formulas.map((f) => [f.fieldName, f.dependencies]),
+    nodes.map((n) => [n.path, n.dependencies]),
   );
 
   const result = getTopologicalOrder(buildDependencyGraph(dependencies));
@@ -150,169 +172,153 @@ function orderByDependencies(formulas: PreparedFormula[]): PreparedFormula[] {
     );
   }
 
-  const formulaMap = new Map(formulas.map((f) => [f.fieldName, f]));
+  const nodeMap = new Map(nodes.map((n) => [n.path, n]));
 
   return result.order
-    .map((name) => formulaMap.get(name))
-    .filter((f): f is PreparedFormula => f !== undefined);
+    .map((path) => nodeMap.get(path))
+    .filter((n): n is FormulaNode => n !== undefined);
 }
 
-function evaluateFormula(
-  formula: PreparedFormula,
-  data: Record<string, unknown>,
-  values: Record<string, unknown>,
-  options: EvaluateFormulasOptions,
-): FormulaError[] {
-  if (formula.isArrayItem && formula.arrayPath) {
-    return evaluateArrayFormula(formula, data, values, options);
-  }
-
-  return evaluateSingleFormula(formula, data, values, options);
+function hasFailedDependency(node: FormulaNode, failedPaths: Set<string>): boolean {
+  return node.dependencies.some((dep) => {
+    for (const failedPath of failedPaths) {
+      if (failedPath === dep || failedPath.endsWith(`.${dep}`)) {
+        return true;
+      }
+    }
+    return false;
+  });
 }
 
-function evaluateSingleFormula(
-  formula: PreparedFormula,
+function evaluateNode(
+  node: FormulaNode,
   data: Record<string, unknown>,
-  values: Record<string, unknown>,
-  options: EvaluateFormulasOptions,
-): FormulaError[] {
-  const parentPath = getParentPath(formula.fieldName);
-  const itemData = parentPath
-    ? (getValueByPath(data, parentPath) as Record<string, unknown> | undefined)
-    : undefined;
-
-  const context: EvaluateContextOptions = {
-    rootData: data,
-    ...(itemData && { itemData, currentPath: parentPath }),
-  };
-
+): { success: true; value: unknown } | { success: false; error: string } {
   try {
-    const result = evaluateWithContext(formula.expression, context);
+    const itemData = node.currentPath
+      ? getValueByPath(data, node.currentPath) as Record<string, unknown> | undefined
+      : undefined;
+
+    const result = evaluateWithContext(node.expression, {
+      rootData: data,
+      ...(itemData && { itemData, currentPath: node.currentPath }),
+    });
 
     if (result === undefined) {
-      if (options.useDefaults) {
-        const defaultValue = getDefaultValue(formula, options.defaults);
-        setValueByPath(values, formula.fieldName, defaultValue);
-        setValueByPath(data, formula.fieldName, defaultValue);
-      }
-      return [
-        createError(
-          formula,
-          'Formula returned undefined',
-          options.useDefaults ?? false,
-        ),
-      ];
+      return { success: false, error: 'Formula returned undefined' };
     }
 
-    setValueByPath(values, formula.fieldName, result);
-    setValueByPath(data, formula.fieldName, result);
-    return [];
+    return { success: true, value: result };
   } catch (error) {
-    if (options.useDefaults) {
-      const defaultValue = getDefaultValue(formula, options.defaults);
-      setValueByPath(values, formula.fieldName, defaultValue);
-      setValueByPath(data, formula.fieldName, defaultValue);
-    }
-    return [
-      createError(
-        formula,
-        error instanceof Error ? error.message : String(error),
-        options.useDefaults ?? false,
-      ),
-    ];
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
-function evaluateArrayFormula(
-  formula: PreparedFormula,
+function handleError(
+  node: FormulaNode,
+  errorMessage: string,
   data: Record<string, unknown>,
   values: Record<string, unknown>,
+  errors: FormulaError[],
   options: EvaluateFormulasOptions,
-): FormulaError[] {
-  const errors: FormulaError[] = [];
-  const arrayPath = formula.arrayPath!;
-  const array = getValueByPath(data, arrayPath) as unknown[];
+): void {
+  const defaultUsed = options.useDefaults ?? false;
 
-  if (!Array.isArray(array)) {
-    return errors;
+  if (defaultUsed) {
+    const defaultValue = getDefaultValue(node, options.defaults);
+    setValueByPath(data, node.path, defaultValue);
+    values[node.path] = defaultValue;
   }
 
-  for (let i = 0; i < array.length; i++) {
-    const item = array[i];
-    if (typeof item !== 'object' || item === null) {
-      continue;
-    }
-
-    const itemData = item as Record<string, unknown>;
-    const fieldPath = `${arrayPath}[${i}].${formula.localFieldPath}`;
-
-    const context: EvaluateContextOptions = {
-      rootData: data,
-      itemData,
-      currentPath: `${arrayPath}[${i}]`,
-    };
-
-    try {
-      const result = evaluateWithContext(formula.expression, context);
-
-      if (result === undefined) {
-        if (options.useDefaults) {
-          const defaultValue = getDefaultValue(formula, options.defaults);
-          setValueByPath(values, fieldPath, defaultValue);
-          setValueByPath(itemData, formula.localFieldPath, defaultValue);
-        }
-        errors.push({
-          field: fieldPath,
-          expression: formula.expression,
-          error: 'Formula returned undefined',
-          defaultUsed: options.useDefaults ?? false,
-        });
-        continue;
-      }
-
-      setValueByPath(values, fieldPath, result);
-      setValueByPath(itemData, formula.localFieldPath, result);
-    } catch (error) {
-      if (options.useDefaults) {
-        const defaultValue = getDefaultValue(formula, options.defaults);
-        setValueByPath(values, fieldPath, defaultValue);
-        setValueByPath(itemData, formula.localFieldPath, defaultValue);
-      }
-      errors.push({
-        field: fieldPath,
-        expression: formula.expression,
-        error: error instanceof Error ? error.message : String(error),
-        defaultUsed: options.useDefaults ?? false,
-      });
-    }
-  }
-
-  return errors;
+  errors.push({
+    field: node.path,
+    expression: node.expression,
+    error: errorMessage,
+    defaultUsed,
+  });
 }
 
-function getParentPath(fieldPath: string): string {
-  const lastDotIndex = fieldPath.lastIndexOf('.');
-  if (lastDotIndex === -1) {
-    return '';
+function getDefaultValue(
+  node: FormulaNode,
+  defaults?: Record<string, unknown>,
+): unknown {
+  if (defaults && node.path in defaults) {
+    return defaults[node.path];
   }
-  return fieldPath.substring(0, lastDotIndex);
+
+  switch (node.fieldType) {
+    case 'number':
+      return 0;
+    case 'string':
+      return '';
+    case 'boolean':
+      return false;
+  }
 }
 
 function getValueByPath(
   obj: Record<string, unknown>,
   path: string,
 ): unknown {
-  const segments = path.split('.');
+  const segments = parsePath(path);
   let current: unknown = obj;
 
   for (const segment of segments) {
     if (current === null || current === undefined) {
       return undefined;
     }
-    current = (current as Record<string, unknown>)[segment];
+
+    if (segment.type === 'field') {
+      current = (current as Record<string, unknown>)[segment.name];
+    } else {
+      if (!Array.isArray(current)) {
+        return undefined;
+      }
+      current = current[segment.index];
+    }
   }
 
   return current;
+}
+
+type PathSegment = { type: 'field'; name: string } | { type: 'index'; index: number };
+
+function parsePath(path: string): PathSegment[] {
+  const segments: PathSegment[] = [];
+  let current = '';
+
+  for (let i = 0; i < path.length; i++) {
+    const char = path[i];
+
+    if (char === '.') {
+      if (current) {
+        segments.push({ type: 'field', name: current });
+        current = '';
+      }
+    } else if (char === '[') {
+      if (current) {
+        segments.push({ type: 'field', name: current });
+        current = '';
+      }
+      const endBracket = path.indexOf(']', i);
+      if (endBracket !== -1) {
+        const indexStr = path.slice(i + 1, endBracket);
+        segments.push({ type: 'index', index: Number.parseInt(indexStr, 10) });
+        i = endBracket;
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    segments.push({ type: 'field', name: current });
+  }
+
+  return segments;
 }
 
 function isSafeKey(key: string): boolean {
@@ -324,56 +330,41 @@ function setValueByPath(
   path: string,
   value: unknown,
 ): void {
-  const segments = path.split('.');
-  let current = obj;
+  const segments = parsePath(path);
+  let current: unknown = obj;
 
   for (let i = 0; i < segments.length - 1; i++) {
     const segment = segments[i]!;
-    if (!isSafeKey(segment)) {
-      return;
+
+    if (segment.type === 'field') {
+      if (!isSafeKey(segment.name)) {
+        return;
+      }
+      const record = current as Record<string, unknown>;
+      if (!(segment.name in record)) {
+        record[segment.name] = {};
+      }
+      current = record[segment.name];
+    } else {
+      const arr = current as unknown[];
+      if (!arr[segment.index]) {
+        arr[segment.index] = {};
+      }
+      current = arr[segment.index];
     }
-    if (!(segment in current)) {
-      current[segment] = {};
-    }
-    current = current[segment] as Record<string, unknown>;
   }
 
-  const lastSegment = segments.at(-1)!;
-  if (!isSafeKey(lastSegment)) {
+  const lastSegment = segments.at(-1);
+  if (!lastSegment) {
     return;
   }
-  current[lastSegment] = value;
-}
 
-function getDefaultValue(
-  formula: PreparedFormula,
-  defaults?: Record<string, unknown>,
-): unknown {
-  if (defaults && formula.fieldName in defaults) {
-    return defaults[formula.fieldName];
+  if (lastSegment.type === 'field') {
+    if (!isSafeKey(lastSegment.name)) {
+      return;
+    }
+    (current as Record<string, unknown>)[lastSegment.name] = value;
+  } else {
+    (current as unknown[])[lastSegment.index] = value;
   }
-
-  switch (formula.fieldType) {
-    case 'number':
-      return 0;
-    case 'string':
-      return '';
-    case 'boolean':
-      return false;
-    default:
-      return null;
-  }
-}
-
-function createError(
-  formula: PreparedFormula,
-  error: string,
-  defaultUsed: boolean,
-): FormulaError {
-  return {
-    field: formula.fieldName,
-    expression: formula.expression,
-    error,
-    defaultUsed,
-  };
 }

--- a/src/lib/formula.ts
+++ b/src/lib/formula.ts
@@ -306,12 +306,12 @@ function parsePath(path: string): PathSegment[] {
         current = '';
       }
       const endBracket = path.indexOf(']', position);
-      if (endBracket !== -1) {
+      if (endBracket === -1) {
+        position++;
+      } else {
         const indexStr = path.slice(position + 1, endBracket);
         segments.push({ type: 'index', index: Number.parseInt(indexStr, 10) });
         position = endBracket + 1;
-      } else {
-        position++;
       }
     } else {
       current += char;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     'model/index': 'src/model/index.ts',
     'lib/index': 'src/lib/index.ts',
     'validation-schemas/index': 'src/validation-schemas/index.ts',
+    'formula/index': 'src/formula/index.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a path-aware formula engine that evaluates directly from the schema and data. Supports nested arrays/objects, root and relative paths, better defaults, and clearer error reporting.

- **New Features**
  - Added collectFormulaNodes(schema, data) to find formulas with concrete array indices.
  - evaluateFormulas(schema, data, options) now handles chained deps, nested arrays/objects, root (/field) and relative (../, ../../) paths, and cyclic dependency detection.
  - Returns values keyed by exact paths (e.g., "orders[0].items[1].total"); applies type-specific defaults when enabled.
  - Improved schema validation for relative paths; ignores formulas on non-primitive fields.
  - Exported formula build entry and bumped @revisium/formula to 0.6.2.

- **Migration**
  - Replace prepareFormulas(...) usage with evaluateFormulas(schema, data). collectFormulaNodes is optional.
  - Update consumers to read results by full paths (e.g., values['items[0].doubled']) instead of nested objects like values['items[0]'].

<sup>Written for commit 8c70a0d341726a96eee8fa48ea2449ef1ec58ccd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

