### PR TITLE
fix: validate formulas

### DIFF
--- a/src/lib/__tests__/validate-schema-formulas.spec.ts
+++ b/src/lib/__tests__/validate-schema-formulas.spec.ts
@@ -791,7 +791,7 @@ describe('validateSchemaFormulas', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should not flag @next on computed field outside array context', () => {
+    it('should skip array validation for formulas outside array context', () => {
       const schema: JsonSchema = {
         type: 'object',
         properties: {

--- a/src/lib/validate-schema-formulas.ts
+++ b/src/lib/validate-schema-formulas.ts
@@ -9,10 +9,16 @@ import {
 } from '@revisium/formula';
 import { extractSchemaFormulas } from './extract-schema-formulas.js';
 
+interface XFormula {
+  version: number;
+  expression: string;
+}
+
 interface SchemaProperty {
   type?: string;
   properties?: Record<string, SchemaProperty>;
   items?: SchemaProperty;
+  'x-formula'?: XFormula;
   [key: string]: unknown;
 }
 
@@ -165,6 +171,19 @@ function validateFormulaInContext(
       field: fieldPath,
       error: `Formula cannot reference itself`,
     };
+  }
+
+  const isInsideArray = fieldPath.includes('[');
+  if (isInsideArray) {
+    const computedFields = getComputedFieldsInContext(contextSchema);
+    const arrayRefError = validateArrayReferences(
+      expression,
+      fieldPath,
+      computedFields,
+    );
+    if (arrayRefError) {
+      return arrayRefError;
+    }
   }
 
   const fieldSchema = contextSchema.properties?.[localFieldName];
@@ -426,6 +445,56 @@ function validateRelativePath(
       field: fieldPath,
       error: `Unknown field '${targetField}' in formula`,
     };
+  }
+
+  return null;
+}
+
+function getComputedFieldsInContext(
+  schema: SchemaProperty | JsonSchemaInput,
+): Set<string> {
+  const computedFields = new Set<string>();
+  const properties = schema.properties ?? {};
+
+  for (const [fieldName, fieldSchema] of Object.entries(properties)) {
+    if (fieldSchema['x-formula']) {
+      computedFields.add(fieldName);
+    }
+  }
+
+  return computedFields;
+}
+
+function validateArrayReferences(
+  expression: string,
+  fieldPath: string,
+  computedFields: Set<string>,
+): FormulaValidationError | null {
+  const atNextComputedMatch = expression.match(/@next\.(\w+)/);
+  if (atNextComputedMatch) {
+    const fieldName = atNextComputedMatch[1];
+    if (fieldName && computedFields.has(fieldName)) {
+      return {
+        field: fieldPath,
+        error: `Cannot reference computed field '${fieldName}' via @next. Use @prev instead for cross-element computed field references.`,
+      };
+    }
+  }
+
+  const absoluteIndexMatch = expression.match(/\/[\w[\]]+\[(\d+)\]\.(\w+)/g);
+  if (absoluteIndexMatch) {
+    for (const match of absoluteIndexMatch) {
+      const fieldMatch = match.match(/\.(\w+)$/);
+      if (fieldMatch) {
+        const fieldName = fieldMatch[1];
+        if (fieldName && computedFields.has(fieldName)) {
+          return {
+            field: fieldPath,
+            error: `Absolute index reference to computed field '${fieldName}' may cause forward reference issues. Consider using @prev pattern instead.`,
+          };
+        }
+      }
+    }
   }
 
   return null;

--- a/src/lib/validate-schema-formulas.ts
+++ b/src/lib/validate-schema-formulas.ts
@@ -470,9 +470,9 @@ function validateArrayReferences(
   fieldPath: string,
   computedFields: Set<string>,
 ): FormulaValidationError | null {
-  const atNextComputedMatch = expression.match(/@next\.(\w+)/);
-  if (atNextComputedMatch) {
-    const fieldName = atNextComputedMatch[1];
+  const atNextMatches = expression.matchAll(/@next\.(\w+)/g);
+  for (const match of atNextMatches) {
+    const fieldName = match[1];
     if (fieldName && computedFields.has(fieldName)) {
       return {
         field: fieldPath,

--- a/src/lib/validate-schema-formulas.ts
+++ b/src/lib/validate-schema-formulas.ts
@@ -481,19 +481,14 @@ function validateArrayReferences(
     }
   }
 
-  const absoluteIndexMatch = expression.match(/\/[\w[\]]+\[(\d+)\]\.(\w+)/g);
-  if (absoluteIndexMatch) {
-    for (const match of absoluteIndexMatch) {
-      const fieldMatch = match.match(/\.(\w+)$/);
-      if (fieldMatch) {
-        const fieldName = fieldMatch[1];
-        if (fieldName && computedFields.has(fieldName)) {
-          return {
-            field: fieldPath,
-            error: `Absolute index reference to computed field '${fieldName}' may cause forward reference issues. Consider using @prev pattern instead.`,
-          };
-        }
-      }
+  const absoluteIndexMatches = expression.matchAll(/\/[\w[\]]+\[\d+\]\.(\w+)/g);
+  for (const match of absoluteIndexMatches) {
+    const fieldName = match[1];
+    if (fieldName && computedFields.has(fieldName)) {
+      return {
+        field: fieldPath,
+        error: `Absolute index reference to computed field '${fieldName}' may cause forward reference issues. Consider using @prev pattern instead.`,
+      };
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightens formula validation for array evaluation (v1.1) to prevent forward references to computed fields and unsafe absolute index lookups. Keeps valid @prev/@next cases working and adds tests to cover the new rules.

- **Bug Fixes**
  - Rejects @next.<computedField> in array item formulas with a clear error.
  - Rejects absolute index references to computed fields (e.g., /items[1].computed).
  - Allows @prev on computed fields and @prev/@next on regular fields; non-array contexts unaffected.

- **Migration**
  - Replace @next.<computedField> with @prev-based patterns or refactor to reference regular fields.
  - Avoid absolute index access to computed fields; reference regular fields or use relative @prev where possible.

<sup>Written for commit 04ac8590f0efdb7f78d4ae14eba7e645ee203bbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

