### PR TITLE
feat: array wildcard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@revisium/formula": "^0.9.0",
+        "@revisium/formula": "^0.10.0",
         "nanoid": "^3.3.7"
       },
       "devDependencies": {
@@ -1813,9 +1813,9 @@
       }
     },
     "node_modules/@revisium/formula": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@revisium/formula/-/formula-0.9.0.tgz",
-      "integrity": "sha512-Xa+He4xg7wfrMN8IBm+hQTvKXT3l3kPOvT7ZKyJPzMnxvBqUraFuAzKw3weBK9463zvXVEYCeWogFkRRKev8Eg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@revisium/formula/-/formula-0.10.0.tgz",
+      "integrity": "sha512-cyElDdrHpbWeZO6Xs4bhpCkqa8COXOBquZ0ZenzVKzOiSHTNe2QbBvmVNw7KZMTOk4vCTZMHoIDrfM+vkdnGwA==",
       "license": "MIT",
       "dependencies": {
         "ohm-js": "^17.3.0"

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "typescript-eslint": "^8.15.0"
   },
   "dependencies": {
-    "@revisium/formula": "^0.9.0",
+    "@revisium/formula": "^0.10.0",
     "nanoid": "^3.3.7"
   },
   "engines": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds array wildcard property access (items[*].field) to formulas for easier aggregation across arrays, including nested arrays. Upgrades @revisium/formula to 0.10.0 and adds tests for sum, avg, count, and empty arrays.

- **New Features**
  - Wildcard property paths: items[*].price
  - Nested wildcards: orders[*].items[*].amount
  - Handles empty arrays without errors

- **Dependencies**
  - @revisium/formula → ^0.10.0

<sup>Written for commit dfc58dc76f23ca874cf75fb2cc5c151fba2da513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

