### PR TITLE
feat: data model 1

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,32 @@
+# Core Module
+
+Foundation layer for unified-toolkit. Contains base abstractions used by all other modules.
+
+## Submodules
+
+| Module | Purpose |
+|--------|---------|
+| `types` | Annotation types for reactivity |
+| `reactivity` | ReactivityAdapter interface + noopAdapter |
+| `path` | Path value object for JSON Schema navigation |
+
+## Installation
+
+```typescript
+import {
+  noopAdapter,
+  EMPTY_PATH,
+  jsonPointerToPath,
+} from '@revisium/schema-toolkit/core';
+```
+
+## Architecture
+
+```
+core/
+├── types/       # No dependencies
+├── reactivity/  # Depends on types
+└── path/        # No dependencies
+```
+
+All other unified-toolkit modules depend on core.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,3 @@
+export * from './types/index.js';
+export * from './reactivity/index.js';
+export * from './path/index.js';

--- a/src/core/path/Path.ts
+++ b/src/core/path/Path.ts
@@ -22,11 +22,15 @@ class PathImpl implements Path {
     for (const seg of this.segs) {
       if (seg.isProperty()) {
         parts.push(seg.propertyName());
-      } else if (seg.isItems() && parts.length > 0) {
-        const lastIndex = parts.length - 1;
-        const lastPart = parts[lastIndex];
-        if (lastPart !== undefined) {
-          parts[lastIndex] = lastPart + '[*]';
+      } else if (seg.isItems()) {
+        if (parts.length > 0) {
+          const lastIndex = parts.length - 1;
+          const lastPart = parts[lastIndex];
+          if (lastPart !== undefined) {
+            parts[lastIndex] = lastPart + '[*]';
+          }
+        } else {
+          parts.push('[*]');
         }
       }
     }

--- a/src/core/path/Path.ts
+++ b/src/core/path/Path.ts
@@ -1,0 +1,95 @@
+import type { Path, PathSegment } from './types.js';
+import { PropertySegment, ItemsSegment } from './PathSegment.js';
+
+class PathImpl implements Path {
+  constructor(private readonly segs: readonly PathSegment[]) {}
+
+  segments(): readonly PathSegment[] {
+    return this.segs;
+  }
+
+  asJsonPointer(): string {
+    return this.segs
+      .map((seg) =>
+        seg.isProperty() ? `/properties/${seg.propertyName()}` : '/items',
+      )
+      .join('');
+  }
+
+  asSimple(): string {
+    const parts: string[] = [];
+
+    for (const seg of this.segs) {
+      if (seg.isProperty()) {
+        parts.push(seg.propertyName());
+      } else if (seg.isItems() && parts.length > 0) {
+        const lastIndex = parts.length - 1;
+        const lastPart = parts[lastIndex];
+        if (lastPart !== undefined) {
+          parts[lastIndex] = lastPart + '[*]';
+        }
+      }
+    }
+
+    return parts.join('.');
+  }
+
+  parent(): Path {
+    if (this.segs.length <= 1) {
+      return EMPTY_PATH;
+    }
+    return new PathImpl(this.segs.slice(0, -1));
+  }
+
+  child(name: string): Path {
+    return new PathImpl([...this.segs, new PropertySegment(name)]);
+  }
+
+  childItems(): Path {
+    return new PathImpl([...this.segs, new ItemsSegment()]);
+  }
+
+  equals(other: Path): boolean {
+    const otherSegs = other.segments();
+    if (this.segs.length !== otherSegs.length) {
+      return false;
+    }
+    for (let i = 0; i < this.segs.length; i++) {
+      const a = this.segs[i];
+      const b = otherSegs[i];
+      if (!a || !b || !a.equals(b)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  isEmpty(): boolean {
+    return this.segs.length === 0;
+  }
+
+  length(): number {
+    return this.segs.length;
+  }
+
+  isChildOf(parent: Path): boolean {
+    const parentSegs = parent.segments();
+    if (this.segs.length <= parentSegs.length) {
+      return false;
+    }
+    for (let i = 0; i < parentSegs.length; i++) {
+      const a = this.segs[i];
+      const b = parentSegs[i];
+      if (!a || !b || !a.equals(b)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+export const EMPTY_PATH: Path = new PathImpl([]);
+
+export function createPath(segments: readonly PathSegment[]): Path {
+  return segments.length === 0 ? EMPTY_PATH : new PathImpl(segments);
+}

--- a/src/core/path/PathParser.ts
+++ b/src/core/path/PathParser.ts
@@ -14,15 +14,14 @@ export function jsonPointerToSegments(pointer: string): PathSegment[] {
   while (i < parts.length) {
     const part = parts[i];
     if (part === 'properties') {
-      if (i + 1 < parts.length) {
-        const name = parts[i + 1];
-        if (name !== undefined) {
-          segments.push(new PropertySegment(name));
-        }
-        i += 2;
-      } else {
-        i += 1;
+      const name = parts[i + 1];
+      if (name === undefined || name === '') {
+        throw new Error(
+          `Invalid path: 'properties' segment requires a name in path ${pointer}`,
+        );
       }
+      segments.push(new PropertySegment(name));
+      i += 2;
     } else if (part === 'items') {
       segments.push(new ItemsSegment());
       i += 1;

--- a/src/core/path/PathParser.ts
+++ b/src/core/path/PathParser.ts
@@ -1,0 +1,43 @@
+import type { Path, PathSegment } from './types.js';
+import { createPath } from './Path.js';
+import { PropertySegment, ItemsSegment } from './PathSegment.js';
+
+export function jsonPointerToSegments(pointer: string): PathSegment[] {
+  if (pointer === '' || pointer === '/') {
+    return [];
+  }
+
+  const parts = pointer.split('/').filter(Boolean);
+  const segments: PathSegment[] = [];
+
+  let i = 0;
+  while (i < parts.length) {
+    const part = parts[i];
+    if (part === 'properties') {
+      if (i + 1 < parts.length) {
+        const name = parts[i + 1];
+        if (name !== undefined) {
+          segments.push(new PropertySegment(name));
+        }
+        i += 2;
+      } else {
+        i += 1;
+      }
+    } else if (part === 'items') {
+      segments.push(new ItemsSegment());
+      i += 1;
+    } else {
+      throw new Error(`Invalid path segment: ${part} in path ${pointer}`);
+    }
+  }
+
+  return segments;
+}
+
+export function jsonPointerToPath(pointer: string): Path {
+  return createPath(jsonPointerToSegments(pointer));
+}
+
+export function jsonPointerToSimplePath(pointer: string): string {
+  return jsonPointerToPath(pointer).asSimple();
+}

--- a/src/core/path/PathSegment.ts
+++ b/src/core/path/PathSegment.ts
@@ -1,0 +1,39 @@
+import type { PathSegment } from './types.js';
+
+export class PropertySegment implements PathSegment {
+  constructor(private readonly name: string) {}
+
+  isProperty(): boolean {
+    return true;
+  }
+
+  isItems(): boolean {
+    return false;
+  }
+
+  propertyName(): string {
+    return this.name;
+  }
+
+  equals(other: PathSegment): boolean {
+    return other.isProperty() && other.propertyName() === this.name;
+  }
+}
+
+export class ItemsSegment implements PathSegment {
+  isProperty(): boolean {
+    return false;
+  }
+
+  isItems(): boolean {
+    return true;
+  }
+
+  propertyName(): string {
+    throw new Error('Items segment has no property name');
+  }
+
+  equals(other: PathSegment): boolean {
+    return other.isItems();
+  }
+}

--- a/src/core/path/README.md
+++ b/src/core/path/README.md
@@ -1,0 +1,72 @@
+# Path Module
+
+Immutable value object for JSON Schema paths. Encapsulates path operations instead of raw string manipulation.
+
+## API
+
+```typescript
+interface Path {
+  segments(): readonly PathSegment[];
+  asJsonPointer(): string;  // "/properties/user/properties/name"
+  asSimple(): string;       // "user.name" or "items[*].value"
+  parent(): Path;
+  child(name: string): Path;
+  childItems(): Path;
+  equals(other: Path): boolean;
+  isEmpty(): boolean;
+  length(): number;
+  isChildOf(parent: Path): boolean;
+}
+
+interface PathSegment {
+  isProperty(): boolean;
+  isItems(): boolean;
+  propertyName(): string;
+  equals(other: PathSegment): boolean;
+}
+
+// Factory functions
+const EMPTY_PATH: Path;
+function createPath(segments: readonly PathSegment[]): Path;
+function jsonPointerToPath(pointer: string): Path;
+function jsonPointerToSimplePath(pointer: string): string;
+```
+
+## Usage
+
+**Building paths:**
+```typescript
+import { EMPTY_PATH } from '@revisium/schema-toolkit/core';
+
+const path = EMPTY_PATH.child('user').child('name');
+path.asJsonPointer(); // "/properties/user/properties/name"
+path.asSimple();      // "user.name"
+```
+
+**Array paths:**
+```typescript
+const path = EMPTY_PATH.child('items').childItems().child('price');
+path.asSimple(); // "items[*].price"
+```
+
+**Parsing from JSON Pointer:**
+```typescript
+import { jsonPointerToPath } from '@revisium/schema-toolkit/core';
+
+const path = jsonPointerToPath('/properties/user/items/properties/name');
+path.asSimple(); // "user[*].name"
+```
+
+**Navigation:**
+```typescript
+const parent = path.parent();
+const nested = path.child('email');
+const isChild = nested.isChildOf(path); // true
+```
+
+## Design Notes
+
+- All Path instances are immutable
+- EMPTY_PATH is a singleton for root/empty paths
+- PropertySegment represents object properties
+- ItemsSegment represents array items (`[*]`)

--- a/src/core/path/__tests__/Path.spec.ts
+++ b/src/core/path/__tests__/Path.spec.ts
@@ -121,6 +121,16 @@ describe('Path', () => {
       const path = EMPTY_PATH.child('items').childItems().child('name');
       expect(path.asSimple()).toBe('items[*].name');
     });
+
+    it('converts root array path', () => {
+      const path = EMPTY_PATH.childItems();
+      expect(path.asSimple()).toBe('[*]');
+    });
+
+    it('converts root array with nested property', () => {
+      const path = EMPTY_PATH.childItems().child('name');
+      expect(path.asSimple()).toBe('[*].name');
+    });
   });
 
   describe('equals', () => {

--- a/src/core/path/__tests__/Path.spec.ts
+++ b/src/core/path/__tests__/Path.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from '@jest/globals';
+import { EMPTY_PATH } from '../Path';
+import { jsonPointerToPath } from '../PathParser';
+
+describe('Path', () => {
+  describe('EMPTY_PATH', () => {
+    it('has no segments', () => {
+      expect(EMPTY_PATH.segments()).toEqual([]);
+    });
+
+    it('is empty', () => {
+      expect(EMPTY_PATH.isEmpty()).toBe(true);
+    });
+
+    it('has zero length', () => {
+      expect(EMPTY_PATH.length()).toBe(0);
+    });
+
+    it('returns empty json pointer', () => {
+      expect(EMPTY_PATH.asJsonPointer()).toBe('');
+    });
+
+    it('returns empty simple path', () => {
+      expect(EMPTY_PATH.asSimple()).toBe('');
+    });
+
+    it('equals another empty path', () => {
+      expect(EMPTY_PATH.equals(EMPTY_PATH)).toBe(true);
+    });
+
+    it('is not child of itself', () => {
+      expect(EMPTY_PATH.isChildOf(EMPTY_PATH)).toBe(false);
+    });
+
+    it('parent returns empty path', () => {
+      expect(EMPTY_PATH.parent().isEmpty()).toBe(true);
+    });
+
+    it('childItems creates items path for array root', () => {
+      const itemsPath = EMPTY_PATH.childItems();
+      expect(itemsPath.asJsonPointer()).toBe('/items');
+      expect(itemsPath.isEmpty()).toBe(false);
+    });
+  });
+
+  describe('child', () => {
+    it('creates property path from empty', () => {
+      const path = EMPTY_PATH.child('name');
+
+      expect(path.isEmpty()).toBe(false);
+      expect(path.length()).toBe(1);
+      expect(path.segments()[0]?.isProperty()).toBe(true);
+      expect(path.segments()[0]?.propertyName()).toBe('name');
+    });
+
+    it('creates nested path', () => {
+      const path = EMPTY_PATH.child('user').child('name');
+
+      expect(path.length()).toBe(2);
+      expect(path.segments()[0]?.propertyName()).toBe('user');
+      expect(path.segments()[1]?.propertyName()).toBe('name');
+    });
+  });
+
+  describe('childItems', () => {
+    it('adds items segment after property', () => {
+      const path = EMPTY_PATH.child('items').childItems();
+
+      expect(path.length()).toBe(2);
+      expect(path.segments()[0]?.isProperty()).toBe(true);
+      expect(path.segments()[1]?.isItems()).toBe(true);
+    });
+  });
+
+  describe('parent', () => {
+    it('returns empty for single-segment path', () => {
+      const path = EMPTY_PATH.child('name');
+      expect(path.parent().isEmpty()).toBe(true);
+    });
+
+    it('returns parent for nested path', () => {
+      const path = EMPTY_PATH.child('user').child('name');
+      const parent = path.parent();
+
+      expect(parent.length()).toBe(1);
+      expect(parent.segments()[0]?.propertyName()).toBe('user');
+    });
+  });
+
+  describe('asJsonPointer', () => {
+    it('converts property path', () => {
+      const path = EMPTY_PATH.child('name');
+      expect(path.asJsonPointer()).toBe('/properties/name');
+    });
+
+    it('converts nested path', () => {
+      const path = EMPTY_PATH.child('user').child('name');
+      expect(path.asJsonPointer()).toBe('/properties/user/properties/name');
+    });
+
+    it('converts path with items', () => {
+      const path = EMPTY_PATH.child('items').childItems().child('name');
+      expect(path.asJsonPointer()).toBe(
+        '/properties/items/items/properties/name',
+      );
+    });
+  });
+
+  describe('asSimple', () => {
+    it('converts property path', () => {
+      const path = EMPTY_PATH.child('name');
+      expect(path.asSimple()).toBe('name');
+    });
+
+    it('converts nested path with dot', () => {
+      const path = EMPTY_PATH.child('user').child('name');
+      expect(path.asSimple()).toBe('user.name');
+    });
+
+    it('converts array path with wildcard', () => {
+      const path = EMPTY_PATH.child('items').childItems().child('name');
+      expect(path.asSimple()).toBe('items[*].name');
+    });
+  });
+
+  describe('equals', () => {
+    it('returns true for equal paths', () => {
+      const a = EMPTY_PATH.child('user').child('name');
+      const b = EMPTY_PATH.child('user').child('name');
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('returns false for different paths', () => {
+      const a = EMPTY_PATH.child('user');
+      const b = EMPTY_PATH.child('name');
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('returns false for different lengths', () => {
+      const a = EMPTY_PATH.child('user');
+      const b = EMPTY_PATH.child('user').child('name');
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('returns false when comparing property and items segments', () => {
+      const a = EMPTY_PATH.child('arr').childItems();
+      const b = EMPTY_PATH.child('arr').child('x');
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe('isChildOf', () => {
+    it('returns true for direct child', () => {
+      const parent = EMPTY_PATH.child('user');
+      const child = EMPTY_PATH.child('user').child('name');
+      expect(child.isChildOf(parent)).toBe(true);
+    });
+
+    it('returns true for deep child', () => {
+      const parent = EMPTY_PATH.child('user');
+      const child = EMPTY_PATH.child('user').child('profile').child('age');
+      expect(child.isChildOf(parent)).toBe(true);
+    });
+
+    it('returns false for same path', () => {
+      const path = EMPTY_PATH.child('user');
+      expect(path.isChildOf(path)).toBe(false);
+    });
+
+    it('returns false for unrelated paths', () => {
+      const a = EMPTY_PATH.child('user');
+      const b = EMPTY_PATH.child('name');
+      expect(a.isChildOf(b)).toBe(false);
+    });
+
+    it('returns false when child is shorter', () => {
+      const parent = EMPTY_PATH.child('user').child('name');
+      const child = EMPTY_PATH.child('user');
+      expect(child.isChildOf(parent)).toBe(false);
+    });
+
+    it('returns false when prefix differs', () => {
+      const parent = EMPTY_PATH.child('user').child('name');
+      const child = EMPTY_PATH.child('other').child('name').child('x');
+      expect(child.isChildOf(parent)).toBe(false);
+    });
+  });
+
+  describe('roundtrip with jsonPointerToPath', () => {
+    it('preserves path through json pointer conversion', () => {
+      const pointer =
+        '/properties/user/properties/profile/items/properties/name';
+      const path = jsonPointerToPath(pointer);
+      expect(path.asJsonPointer()).toBe(pointer);
+    });
+  });
+});

--- a/src/core/path/__tests__/PathParser.spec.ts
+++ b/src/core/path/__tests__/PathParser.spec.ts
@@ -53,9 +53,16 @@ describe('PathParser', () => {
       );
     });
 
-    it('handles trailing properties without name', () => {
-      const segments = jsonPointerToSegments('/properties');
-      expect(segments.length).toBe(0);
+    it('throws for properties without name', () => {
+      expect(() => jsonPointerToSegments('/properties')).toThrow(
+        "Invalid path: 'properties' segment requires a name",
+      );
+    });
+
+    it('throws for properties with empty name', () => {
+      expect(() => jsonPointerToSegments('/properties/')).toThrow(
+        "Invalid path: 'properties' segment requires a name",
+      );
     });
   });
 

--- a/src/core/path/__tests__/PathParser.spec.ts
+++ b/src/core/path/__tests__/PathParser.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  jsonPointerToPath,
+  jsonPointerToSegments,
+  jsonPointerToSimplePath,
+} from '../PathParser';
+
+describe('PathParser', () => {
+  describe('jsonPointerToSegments', () => {
+    it('returns empty array for empty string', () => {
+      expect(jsonPointerToSegments('')).toEqual([]);
+    });
+
+    it('returns empty array for root slash', () => {
+      expect(jsonPointerToSegments('/')).toEqual([]);
+    });
+
+    it('parses single property', () => {
+      const segments = jsonPointerToSegments('/properties/name');
+      expect(segments.length).toBe(1);
+      expect(segments[0]?.isProperty()).toBe(true);
+      expect(segments[0]?.propertyName()).toBe('name');
+    });
+
+    it('parses nested properties', () => {
+      const segments = jsonPointerToSegments(
+        '/properties/user/properties/name',
+      );
+      expect(segments.length).toBe(2);
+      expect(segments[0]?.propertyName()).toBe('user');
+      expect(segments[1]?.propertyName()).toBe('name');
+    });
+
+    it('parses items segment', () => {
+      const segments = jsonPointerToSegments('/items');
+      expect(segments.length).toBe(1);
+      expect(segments[0]?.isItems()).toBe(true);
+    });
+
+    it('parses property with items', () => {
+      const segments = jsonPointerToSegments(
+        '/properties/arr/items/properties/value',
+      );
+      expect(segments.length).toBe(3);
+      expect(segments[0]?.propertyName()).toBe('arr');
+      expect(segments[1]?.isItems()).toBe(true);
+      expect(segments[2]?.propertyName()).toBe('value');
+    });
+
+    it('throws for invalid segment', () => {
+      expect(() => jsonPointerToSegments('/unknown/field')).toThrow(
+        'Invalid path segment: unknown',
+      );
+    });
+
+    it('handles trailing properties without name', () => {
+      const segments = jsonPointerToSegments('/properties');
+      expect(segments.length).toBe(0);
+    });
+  });
+
+  describe('jsonPointerToPath', () => {
+    it('returns empty path for empty string', () => {
+      const path = jsonPointerToPath('');
+      expect(path.isEmpty()).toBe(true);
+    });
+
+    it('returns path with property', () => {
+      const path = jsonPointerToPath('/properties/name');
+      expect(path.length()).toBe(1);
+      expect(path.asSimple()).toBe('name');
+    });
+
+    it('returns path with nested properties', () => {
+      const path = jsonPointerToPath('/properties/user/properties/name');
+      expect(path.length()).toBe(2);
+      expect(path.asSimple()).toBe('user.name');
+    });
+
+    it('returns path with items', () => {
+      const path = jsonPointerToPath('/properties/arr/items/properties/value');
+      expect(path.asSimple()).toBe('arr[*].value');
+    });
+  });
+
+  describe('jsonPointerToSimplePath', () => {
+    it('converts to simple path', () => {
+      expect(jsonPointerToSimplePath('/properties/name')).toBe('name');
+      expect(jsonPointerToSimplePath('/properties/user/properties/name')).toBe(
+        'user.name',
+      );
+      expect(
+        jsonPointerToSimplePath('/properties/arr/items/properties/value'),
+      ).toBe('arr[*].value');
+    });
+  });
+});

--- a/src/core/path/__tests__/PathSegment.spec.ts
+++ b/src/core/path/__tests__/PathSegment.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from '@jest/globals';
+import { PropertySegment, ItemsSegment } from '../PathSegment';
+
+describe('PathSegment', () => {
+  describe('PropertySegment', () => {
+    it('is a property segment', () => {
+      const segment = new PropertySegment('name');
+      expect(segment.isProperty()).toBe(true);
+      expect(segment.isItems()).toBe(false);
+    });
+
+    it('returns property name', () => {
+      const segment = new PropertySegment('name');
+      expect(segment.propertyName()).toBe('name');
+    });
+
+    it('equals another property segment with same name', () => {
+      const a = new PropertySegment('name');
+      const b = new PropertySegment('name');
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('does not equal property segment with different name', () => {
+      const a = new PropertySegment('name');
+      const b = new PropertySegment('other');
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('does not equal items segment', () => {
+      const property = new PropertySegment('name');
+      const items = new ItemsSegment();
+      expect(property.equals(items)).toBe(false);
+    });
+  });
+
+  describe('ItemsSegment', () => {
+    it('is an items segment', () => {
+      const segment = new ItemsSegment();
+      expect(segment.isItems()).toBe(true);
+      expect(segment.isProperty()).toBe(false);
+    });
+
+    it('throws when accessing property name', () => {
+      const segment = new ItemsSegment();
+      expect(() => segment.propertyName()).toThrow(
+        'Items segment has no property name',
+      );
+    });
+
+    it('equals another items segment', () => {
+      const a = new ItemsSegment();
+      const b = new ItemsSegment();
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('does not equal property segment', () => {
+      const items = new ItemsSegment();
+      const property = new PropertySegment('name');
+      expect(items.equals(property)).toBe(false);
+    });
+  });
+});

--- a/src/core/path/index.ts
+++ b/src/core/path/index.ts
@@ -1,0 +1,8 @@
+export type { Path, PathSegment } from './types.js';
+export { EMPTY_PATH, createPath } from './Path.js';
+export { PropertySegment, ItemsSegment } from './PathSegment.js';
+export {
+  jsonPointerToPath,
+  jsonPointerToSegments,
+  jsonPointerToSimplePath,
+} from './PathParser.js';

--- a/src/core/path/types.ts
+++ b/src/core/path/types.ts
@@ -1,0 +1,19 @@
+export interface PathSegment {
+  isProperty(): boolean;
+  isItems(): boolean;
+  propertyName(): string;
+  equals(other: PathSegment): boolean;
+}
+
+export interface Path {
+  segments(): readonly PathSegment[];
+  asJsonPointer(): string;
+  asSimple(): string;
+  parent(): Path;
+  child(name: string): Path;
+  childItems(): Path;
+  equals(other: Path): boolean;
+  isEmpty(): boolean;
+  length(): number;
+  isChildOf(parent: Path): boolean;
+}

--- a/src/core/reactivity/README.md
+++ b/src/core/reactivity/README.md
@@ -1,0 +1,48 @@
+# Reactivity Module
+
+Adapter pattern for optional MobX reactivity. Allows models to work both in backend (no reactivity) and UI (with MobX).
+
+## API
+
+```typescript
+interface ReactivityAdapter {
+  makeObservable<T>(target: T, annotations: AnnotationsMap<T>): void;
+  observableArray<T>(): T[];
+  observableMap<K, V>(): Map<K, V>;
+  reaction<T>(expr: () => T, effect: (v: T) => void): () => void;
+  runInAction<T>(fn: () => T): T;
+}
+
+// No-op implementation for backend/testing
+const noopAdapter: ReactivityAdapter;
+```
+
+## Usage
+
+**Backend (no reactivity):**
+```typescript
+import { noopAdapter } from '@revisium/schema-toolkit/core';
+
+const model = createValueModel(schema, data, {
+  reactivity: noopAdapter,
+});
+```
+
+**UI (with MobX):**
+```typescript
+import { mobxAdapter } from '@revisium/schema-toolkit-ui';
+
+const model = createValueModel(schema, data, {
+  reactivity: mobxAdapter,
+});
+```
+
+## noopAdapter Behavior
+
+| Method | Behavior |
+|--------|----------|
+| `makeObservable()` | No-op |
+| `observableArray()` | Returns `[]` |
+| `observableMap()` | Returns `new Map()` |
+| `reaction()` | Returns no-op dispose |
+| `runInAction(fn)` | Calls `fn()` directly |

--- a/src/core/reactivity/__tests__/noop-adapter.spec.ts
+++ b/src/core/reactivity/__tests__/noop-adapter.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from '@jest/globals';
+import { noopAdapter } from '../noop-adapter';
+
+describe('noopAdapter', () => {
+  describe('makeObservable', () => {
+    it('does nothing', () => {
+      const target = { value: 1 };
+      noopAdapter.makeObservable(target, { value: 'observable' });
+      expect(target.value).toBe(1);
+    });
+  });
+
+  describe('observableArray', () => {
+    it('returns regular array', () => {
+      const arr = noopAdapter.observableArray<number>();
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr.length).toBe(0);
+
+      arr.push(1, 2, 3);
+      expect(arr).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('observableMap', () => {
+    it('returns regular Map', () => {
+      const map = noopAdapter.observableMap<string, number>();
+      expect(map instanceof Map).toBe(true);
+      expect(map.size).toBe(0);
+
+      map.set('a', 1);
+      expect(map.get('a')).toBe(1);
+    });
+  });
+
+  describe('reaction', () => {
+    it('returns noop dispose function', () => {
+      let called = false;
+      const dispose = noopAdapter.reaction(
+        () => 1,
+        () => {
+          called = true;
+        },
+      );
+
+      expect(typeof dispose).toBe('function');
+      expect(called).toBe(false);
+
+      dispose();
+      expect(called).toBe(false);
+    });
+  });
+
+  describe('runInAction', () => {
+    it('executes function and returns result', () => {
+      const result = noopAdapter.runInAction(() => 42);
+      expect(result).toBe(42);
+    });
+
+    it('executes function with side effects', () => {
+      let value = 0;
+      noopAdapter.runInAction(() => {
+        value = 10;
+      });
+      expect(value).toBe(10);
+    });
+  });
+});

--- a/src/core/reactivity/index.ts
+++ b/src/core/reactivity/index.ts
@@ -1,0 +1,2 @@
+export type { ReactivityAdapter } from './types.js';
+export { noopAdapter } from './noop-adapter.js';

--- a/src/core/reactivity/noop-adapter.ts
+++ b/src/core/reactivity/noop-adapter.ts
@@ -1,0 +1,32 @@
+import type { AnnotationsMap } from '../types/index.js';
+import type { ReactivityAdapter } from './types.js';
+
+class NoopReactivityAdapter implements ReactivityAdapter {
+  makeObservable<T extends object>(
+    _target: T,
+    _annotations: AnnotationsMap<T>,
+  ): void {
+    // noop
+  }
+
+  observableArray<T>(): T[] {
+    return [];
+  }
+
+  observableMap<K, V>(): Map<K, V> {
+    return new Map();
+  }
+
+  reaction<T>(
+    _expression: () => T,
+    _effect: (value: T) => void,
+  ): () => void {
+    return () => {};
+  }
+
+  runInAction<T>(fn: () => T): T {
+    return fn();
+  }
+}
+
+export const noopAdapter: ReactivityAdapter = new NoopReactivityAdapter();

--- a/src/core/reactivity/types.ts
+++ b/src/core/reactivity/types.ts
@@ -1,0 +1,19 @@
+import type { AnnotationsMap } from '../types/index.js';
+
+export interface ReactivityAdapter {
+  makeObservable<T extends object>(
+    target: T,
+    annotations: AnnotationsMap<T>,
+  ): void;
+
+  observableArray<T>(): T[];
+
+  observableMap<K, V>(): Map<K, V>;
+
+  reaction<T>(
+    expression: () => T,
+    effect: (value: T) => void,
+  ): () => void;
+
+  runInAction<T>(fn: () => T): T;
+}

--- a/src/core/types/README.md
+++ b/src/core/types/README.md
@@ -1,0 +1,35 @@
+# Core Types
+
+Type definitions for MobX-style annotations.
+
+## API
+
+```typescript
+// Annotation type for observable properties
+type AnnotationType = 'observable' | 'computed' | 'action';
+
+// Map of property names to their annotation types
+type AnnotationsMap<T> = { [K in keyof T]?: AnnotationType };
+```
+
+## Usage
+
+```typescript
+import { AnnotationsMap } from '@revisium/schema-toolkit/core';
+
+class MyNode {
+  private _value = 0;
+
+  get value() { return this._value; }
+
+  setValue(v: number) { this._value = v; }
+}
+
+const annotations: AnnotationsMap<MyNode> = {
+  _value: 'observable',
+  value: 'computed',
+  setValue: 'action',
+};
+
+reactivity.makeObservable(instance, annotations);
+```

--- a/src/core/types/annotations.ts
+++ b/src/core/types/annotations.ts
@@ -1,0 +1,5 @@
+export type AnnotationType = 'observable' | 'computed' | 'action';
+
+export type AnnotationsMap<T> = {
+  [K in keyof T]?: AnnotationType;
+};

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,0 +1,1 @@
+export type { AnnotationType, AnnotationsMap } from './annotations.js';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces the core module with JSON Schema path utilities and a pluggable reactivity adapter. Establishes the base layer other modules will use.

- **New Features**
  - Path value object with property/items segments, JSON Pointer and simple path conversion (e.g., "items[*].name"), plus parent/child navigation and equality checks.
  - JSON Pointer parser helpers: jsonPointerToPath, jsonPointerToSimplePath, and EMPTY_PATH factory.
  - ReactivityAdapter interface with a backend-friendly noopAdapter (makeObservable, observableArray/map, reaction, runInAction).
  - Public exports via src/core/index.ts, with docs and tests for path and reactivity.

<sup>Written for commit db2cc797a8e027c092b2a75f50544123be98095f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

