### PR TITLE
feat: data model 2

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from './types/index.js';
 export * from './reactivity/index.js';
 export * from './path/index.js';
+export * from './validation/index.js';

--- a/src/core/types/README.md
+++ b/src/core/types/README.md
@@ -15,7 +15,7 @@ type AnnotationsMap<T> = { [K in keyof T]?: AnnotationType };
 ## Usage
 
 ```typescript
-import { AnnotationsMap } from '@revisium/schema-toolkit/core';
+import { AnnotationsMap, noopAdapter } from '@revisium/schema-toolkit/core';
 
 class MyNode {
   private _value = 0;
@@ -31,5 +31,6 @@ const annotations: AnnotationsMap<MyNode> = {
   setValue: 'action',
 };
 
-reactivity.makeObservable(instance, annotations);
+const instance = new MyNode();
+noopAdapter.makeObservable(instance, annotations);
 ```

--- a/src/core/validation/README.md
+++ b/src/core/validation/README.md
@@ -32,16 +32,16 @@ interface ValidatorRule {
 
 ## Built-in Validators
 
-| Validator | Rule | Description |
-|-----------|------|-------------|
-| RequiredValidator | `required: true` | Empty/null/undefined check |
-| PatternValidator | `pattern: string` | Regex pattern matching |
-| MinLengthValidator | `minLength: number` | String min length |
-| MaxLengthValidator | `maxLength: number` | String max length |
-| MinimumValidator | `minimum: number` | Number min value |
-| MaximumValidator | `maximum: number` | Number max value |
-| EnumValidator | `enum: array` | Allowed values list |
-| ForeignKeyValidator | `foreignKey: string` | FK reference required |
+|Validator|Rule|Description|
+|---|---|---|
+|RequiredValidator|`required: true`|Empty/null/undefined check|
+|PatternValidator|`pattern: string`|Regex pattern matching|
+|MinLengthValidator|`minLength: number`|String min length|
+|MaxLengthValidator|`maxLength: number`|String max length|
+|MinimumValidator|`minimum: number`|Number min value|
+|MaximumValidator|`maximum: number`|Number max value|
+|EnumValidator|`enum: array`|Allowed values list|
+|ForeignKeyValidator|`foreignKey: string`|FK reference required|
 
 ## Usage
 
@@ -82,7 +82,7 @@ const engine = createValidationEngine(registry);
 
 ## Architecture
 
-```
+```text
 ValidatorRegistry    ← registers validators + rules
        ↓
 ValidatorResolver    ← resolves which validators apply

--- a/src/core/validation/README.md
+++ b/src/core/validation/README.md
@@ -1,0 +1,91 @@
+# Validation Module
+
+Value validation engine with pluggable validators and rules.
+
+## API
+
+```typescript
+interface ValidationContext {
+  value: unknown;
+  schema: SchemaLike;
+  nodeName: string;
+}
+
+interface Diagnostic {
+  severity: 'error' | 'warning';
+  type: string;
+  message: string;
+  path: string;
+  params?: Record<string, unknown>;
+}
+
+interface Validator {
+  type: string;
+  validate(context: ValidationContext): Diagnostic | null;
+}
+
+interface ValidatorRule {
+  validatorType: string;
+  shouldApply(context: ValidationContext): boolean;
+}
+```
+
+## Built-in Validators
+
+| Validator | Rule | Description |
+|-----------|------|-------------|
+| RequiredValidator | `required: true` | Empty/null/undefined check |
+| PatternValidator | `pattern: string` | Regex pattern matching |
+| MinLengthValidator | `minLength: number` | String min length |
+| MaxLengthValidator | `maxLength: number` | String max length |
+| MinimumValidator | `minimum: number` | Number min value |
+| MaximumValidator | `maximum: number` | Number max value |
+| EnumValidator | `enum: array` | Allowed values list |
+| ForeignKeyValidator | `foreignKey: string` | FK reference required |
+
+## Usage
+
+```typescript
+import { createValidationEngine } from '@revisium/schema-toolkit/core';
+
+const engine = createValidationEngine();
+
+const diagnostics = engine.validate({
+  value: '',
+  schema: { type: 'string', required: true, minLength: 3 },
+  nodeName: 'username',
+});
+// [{ severity: 'error', type: 'required', message: 'Field is required', path: 'username' }]
+```
+
+## Custom Validators
+
+```typescript
+import { ValidatorRegistry, createValidationEngine } from '@revisium/schema-toolkit/core';
+
+const registry = new ValidatorRegistry();
+
+registry.register('custom', () => ({
+  type: 'custom',
+  validate: (ctx) => ctx.value === 'bad'
+    ? { severity: 'error', type: 'custom', message: 'Bad value', path: ctx.nodeName }
+    : null,
+}));
+
+registry.addRule({
+  validatorType: 'custom',
+  shouldApply: () => true,
+});
+
+const engine = createValidationEngine(registry);
+```
+
+## Architecture
+
+```
+ValidatorRegistry    ← registers validators + rules
+       ↓
+ValidatorResolver    ← resolves which validators apply
+       ↓
+ValidationEngine     ← runs validators, collects diagnostics
+```

--- a/src/core/validation/ValidationEngine.ts
+++ b/src/core/validation/ValidationEngine.ts
@@ -1,0 +1,20 @@
+import type { Diagnostic, ValidationContext } from './types.js';
+import type { ValidatorResolver } from './ValidatorResolver.js';
+
+export class ValidationEngine {
+  constructor(private readonly resolver: ValidatorResolver) {}
+
+  validate(context: ValidationContext): readonly Diagnostic[] {
+    const validators = this.resolver.resolve(context);
+    const diagnostics: Diagnostic[] = [];
+
+    for (const validator of validators) {
+      const diagnostic = validator.validate(context);
+      if (diagnostic) {
+        diagnostics.push(diagnostic);
+      }
+    }
+
+    return diagnostics;
+  }
+}

--- a/src/core/validation/ValidatorRegistry.ts
+++ b/src/core/validation/ValidatorRegistry.ts
@@ -1,0 +1,33 @@
+import type { Validator, ValidatorFactoryFn, ValidatorRule } from './types.js';
+
+export class ValidatorRegistry {
+  private readonly validators = new Map<string, ValidatorFactoryFn>();
+  private readonly rules: ValidatorRule[] = [];
+
+  register(type: string, factory: ValidatorFactoryFn): this {
+    this.validators.set(type, factory);
+    return this;
+  }
+
+  addRule(rule: ValidatorRule): this {
+    this.rules.push(rule);
+    return this;
+  }
+
+  get(type: string): Validator | undefined {
+    const factory = this.validators.get(type);
+    return factory ? factory() : undefined;
+  }
+
+  has(type: string): boolean {
+    return this.validators.has(type);
+  }
+
+  getRules(): readonly ValidatorRule[] {
+    return this.rules;
+  }
+
+  getValidatorTypes(): string[] {
+    return Array.from(this.validators.keys());
+  }
+}

--- a/src/core/validation/ValidatorResolver.ts
+++ b/src/core/validation/ValidatorResolver.ts
@@ -1,0 +1,22 @@
+import type { Validator, ValidationContext } from './types.js';
+import type { ValidatorRegistry } from './ValidatorRegistry.js';
+
+export class ValidatorResolver {
+  constructor(private readonly registry: ValidatorRegistry) {}
+
+  resolve(context: ValidationContext): Validator[] {
+    const validators: Validator[] = [];
+    const rules = this.registry.getRules();
+
+    for (const rule of rules) {
+      if (rule.shouldApply(context)) {
+        const validator = this.registry.get(rule.validatorType);
+        if (validator) {
+          validators.push(validator);
+        }
+      }
+    }
+
+    return validators;
+  }
+}

--- a/src/core/validation/__tests__/ValidationEngine.spec.ts
+++ b/src/core/validation/__tests__/ValidationEngine.spec.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  ValidatorRegistry,
+  ValidatorResolver,
+  ValidationEngine,
+  createValidationEngine,
+  createDefaultValidatorRegistry,
+} from '../index';
+import {
+  RequiredValidator,
+  MinLengthValidator,
+} from '../validators';
+import { SchemaTruthyRule, SchemaPropertyRule, CompositeRule } from '../rules';
+import type { ValidationContext } from '../types';
+
+describe('ValidatorRegistry', () => {
+  it('registers and retrieves validator', () => {
+    const registry = new ValidatorRegistry();
+    const factory = () => new RequiredValidator();
+
+    registry.register('required', factory);
+
+    const validator = registry.get('required');
+    expect(validator).toBeInstanceOf(RequiredValidator);
+  });
+
+  it('returns undefined for unknown validator', () => {
+    const registry = new ValidatorRegistry();
+    expect(registry.get('unknown')).toBeUndefined();
+  });
+
+  it('supports chaining', () => {
+    const registry = new ValidatorRegistry();
+
+    const result = registry
+      .register('a', () => new RequiredValidator())
+      .register('b', () => new MinLengthValidator());
+
+    expect(result).toBe(registry);
+  });
+
+  it('has returns true for registered type', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+
+    expect(registry.has('required')).toBe(true);
+    expect(registry.has('unknown')).toBe(false);
+  });
+
+  it('adds and retrieves rules', () => {
+    const registry = new ValidatorRegistry();
+    const rule = new SchemaTruthyRule('required', 'required');
+
+    registry.addRule(rule);
+
+    expect(registry.getRules()).toContain(rule);
+  });
+
+  it('lists validator types', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+    registry.register('minLength', () => new MinLengthValidator());
+
+    const types = registry.getValidatorTypes();
+    expect(types).toContain('required');
+    expect(types).toContain('minLength');
+  });
+});
+
+describe('ValidatorResolver', () => {
+  it('resolves validators based on rules', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+    registry.addRule(new SchemaTruthyRule('required', 'required'));
+
+    const resolver = new ValidatorResolver(registry);
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const validators = resolver.resolve(context);
+    expect(validators).toHaveLength(1);
+    expect(validators[0]).toBeInstanceOf(RequiredValidator);
+  });
+
+  it('returns empty array when no rules match', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+    registry.addRule(new SchemaTruthyRule('required', 'required'));
+
+    const resolver = new ValidatorResolver(registry);
+    const context: ValidationContext = {
+      value: 'test',
+      schema: { type: 'string' },
+      nodeName: 'name',
+    };
+
+    const validators = resolver.resolve(context);
+    expect(validators).toHaveLength(0);
+  });
+
+  it('resolves multiple validators when multiple rules match', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+    registry.register('minLength', () => new MinLengthValidator());
+    registry.addRule(new SchemaTruthyRule('required', 'required'));
+    registry.addRule(new SchemaPropertyRule('minLength', 'minLength'));
+
+    const resolver = new ValidatorResolver(registry);
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', required: true, minLength: 3 },
+      nodeName: 'name',
+    };
+
+    const validators = resolver.resolve(context);
+    expect(validators).toHaveLength(2);
+  });
+});
+
+describe('ValidationEngine', () => {
+  it('runs validators and collects diagnostics', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+    registry.addRule(new SchemaTruthyRule('required', 'required'));
+
+    const resolver = new ValidatorResolver(registry);
+    const engine = new ValidationEngine(resolver);
+
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.type).toBe('required');
+  });
+
+  it('returns empty array when validation passes', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('required', () => new RequiredValidator());
+    registry.addRule(new SchemaTruthyRule('required', 'required'));
+
+    const resolver = new ValidatorResolver(registry);
+    const engine = new ValidationEngine(resolver);
+
+    const context: ValidationContext = {
+      value: 'John',
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+describe('createDefaultValidatorRegistry', () => {
+  it('registers all built-in validators', () => {
+    const registry = createDefaultValidatorRegistry();
+
+    expect(registry.has('required')).toBe(true);
+    expect(registry.has('foreignKey')).toBe(true);
+    expect(registry.has('minLength')).toBe(true);
+    expect(registry.has('maxLength')).toBe(true);
+    expect(registry.has('pattern')).toBe(true);
+    expect(registry.has('enum')).toBe(true);
+    expect(registry.has('minimum')).toBe(true);
+    expect(registry.has('maximum')).toBe(true);
+  });
+
+  it('has rules for all validators', () => {
+    const registry = createDefaultValidatorRegistry();
+    const rules = registry.getRules();
+
+    expect(rules.length).toBeGreaterThan(0);
+  });
+});
+
+describe('createValidationEngine', () => {
+  it('creates engine with default registry', () => {
+    const engine = createValidationEngine();
+
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.type).toBe('required');
+  });
+
+  it('accepts custom registry', () => {
+    const registry = new ValidatorRegistry();
+    registry.register('custom', () => ({
+      type: 'custom',
+      validate: () => ({
+        severity: 'error',
+        type: 'custom',
+        message: 'Custom error',
+        path: '',
+      }),
+    }));
+    registry.addRule({
+      validatorType: 'custom',
+      shouldApply: () => true,
+    });
+
+    const engine = createValidationEngine(registry);
+
+    const context: ValidationContext = {
+      value: 'test',
+      schema: { type: 'string' },
+      nodeName: 'field',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.type).toBe('custom');
+  });
+});
+
+describe('Rules', () => {
+  describe('SchemaPropertyRule', () => {
+    it('applies when property exists', () => {
+      const rule = new SchemaPropertyRule('minLength', 'minLength');
+      const context: ValidationContext = {
+        value: 'test',
+        schema: { type: 'string', minLength: 3 },
+        nodeName: 'name',
+      };
+
+      expect(rule.shouldApply(context)).toBe(true);
+    });
+
+    it('does not apply when property is undefined', () => {
+      const rule = new SchemaPropertyRule('minLength', 'minLength');
+      const context: ValidationContext = {
+        value: 'test',
+        schema: { type: 'string' },
+        nodeName: 'name',
+      };
+
+      expect(rule.shouldApply(context)).toBe(false);
+    });
+  });
+
+  describe('SchemaTruthyRule', () => {
+    it('applies when property is true', () => {
+      const rule = new SchemaTruthyRule('required', 'required');
+      const context: ValidationContext = {
+        value: '',
+        schema: { type: 'string', required: true },
+        nodeName: 'name',
+      };
+
+      expect(rule.shouldApply(context)).toBe(true);
+    });
+
+    it('does not apply when property is false', () => {
+      const rule = new SchemaTruthyRule('required', 'required');
+      const context: ValidationContext = {
+        value: '',
+        schema: { type: 'string', required: false },
+        nodeName: 'name',
+      };
+
+      expect(rule.shouldApply(context)).toBe(false);
+    });
+
+    it('does not apply when property is undefined', () => {
+      const rule = new SchemaTruthyRule('required', 'required');
+      const context: ValidationContext = {
+        value: '',
+        schema: { type: 'string' },
+        nodeName: 'name',
+      };
+
+      expect(rule.shouldApply(context)).toBe(false);
+    });
+  });
+
+  describe('CompositeRule', () => {
+    it('applies when all conditions match', () => {
+      const rule = new CompositeRule('minLength', [
+        (ctx) => ctx.schema.type === 'string',
+        (ctx) => ctx.schema.minLength !== undefined,
+      ]);
+      const context: ValidationContext = {
+        value: 'test',
+        schema: { type: 'string', minLength: 3 },
+        nodeName: 'name',
+      };
+
+      expect(rule.shouldApply(context)).toBe(true);
+    });
+
+    it('does not apply when any condition fails', () => {
+      const rule = new CompositeRule('minLength', [
+        (ctx) => ctx.schema.type === 'string',
+        (ctx) => ctx.schema.minLength !== undefined,
+      ]);
+      const context: ValidationContext = {
+        value: 123,
+        schema: { type: 'number', minLength: 3 },
+        nodeName: 'count',
+      };
+
+      expect(rule.shouldApply(context)).toBe(false);
+    });
+  });
+});
+
+describe('Integration tests', () => {
+  it('validates pattern', () => {
+    const engine = createValidationEngine();
+
+    const context: ValidationContext = {
+      value: 'invalid',
+      schema: { type: 'string', pattern: '^[0-9]+$' },
+      nodeName: 'code',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.type).toBe('pattern');
+  });
+
+  it('validates string with multiple constraints', () => {
+    const engine = createValidationEngine();
+
+    const context: ValidationContext = {
+      value: 'ab',
+      schema: { type: 'string', required: true, minLength: 3, maxLength: 10 },
+      nodeName: 'username',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.type).toBe('minLength');
+  });
+
+  it('returns multiple errors when multiple validations fail', () => {
+    const engine = createValidationEngine();
+
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', required: true, foreignKey: 'users' },
+      nodeName: 'userId',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics.length).toBeGreaterThanOrEqual(2);
+    expect(diagnostics.map((d) => d.type)).toContain('required');
+    expect(diagnostics.map((d) => d.type)).toContain('foreignKey');
+  });
+
+  it('validates number with min/max', () => {
+    const engine = createValidationEngine();
+
+    const context: ValidationContext = {
+      value: 150,
+      schema: { type: 'number', minimum: 0, maximum: 100 },
+      nodeName: 'percentage',
+    };
+
+    const diagnostics = engine.validate(context);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.type).toBe('maximum');
+  });
+
+  it('validates enum for both string and number', () => {
+    const engine = createValidationEngine();
+
+    const stringContext: ValidationContext = {
+      value: 'invalid',
+      schema: { type: 'string', enum: ['active', 'inactive'] },
+      nodeName: 'status',
+    };
+
+    const numberContext: ValidationContext = {
+      value: 5,
+      schema: { type: 'number', enum: [1, 2, 3] },
+      nodeName: 'priority',
+    };
+
+    expect(engine.validate(stringContext)).toHaveLength(1);
+    expect(engine.validate(numberContext)).toHaveLength(1);
+  });
+});

--- a/src/core/validation/__tests__/validators.spec.ts
+++ b/src/core/validation/__tests__/validators.spec.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  RequiredValidator,
+  PatternValidator,
+  MinLengthValidator,
+  MaxLengthValidator,
+  MinimumValidator,
+  MaximumValidator,
+  EnumValidator,
+  ForeignKeyValidator,
+} from '../validators';
+import type { ValidationContext } from '../types';
+
+describe('RequiredValidator', () => {
+  const validator = new RequiredValidator();
+
+  it('returns error for empty string', () => {
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('required');
+  });
+
+  it('returns error for null', () => {
+    const context: ValidationContext = {
+      value: null,
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+  });
+
+  it('returns error for undefined', () => {
+    const context: ValidationContext = {
+      value: undefined,
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+  });
+
+  it('returns null for non-empty value', () => {
+    const context: ValidationContext = {
+      value: 'John',
+      schema: { type: 'string', required: true },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null for zero', () => {
+    const context: ValidationContext = {
+      value: 0,
+      schema: { type: 'number', required: true },
+      nodeName: 'count',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null for false', () => {
+    const context: ValidationContext = {
+      value: false,
+      schema: { type: 'boolean', required: true },
+      nodeName: 'active',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});
+
+describe('PatternValidator', () => {
+  const validator = new PatternValidator();
+
+  it('returns null for non-string value', () => {
+    const context: ValidationContext = {
+      value: 123,
+      schema: { type: 'number', pattern: '^[0-9]+$' },
+      nodeName: 'code',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns error when value does not match pattern', () => {
+    const context: ValidationContext = {
+      value: 'invalid',
+      schema: { type: 'string', pattern: '^[0-9]+$' },
+      nodeName: 'code',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('pattern');
+    expect(diagnostic?.params?.pattern).toBe('^[0-9]+$');
+  });
+
+  it('returns null when value matches pattern', () => {
+    const context: ValidationContext = {
+      value: '12345',
+      schema: { type: 'string', pattern: '^[0-9]+$' },
+      nodeName: 'code',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', pattern: '^[0-9]+$' },
+      nodeName: 'code',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no pattern in schema', () => {
+    const context: ValidationContext = {
+      value: 'anything',
+      schema: { type: 'string' },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns error for invalid regex pattern', () => {
+    const context: ValidationContext = {
+      value: 'test',
+      schema: { type: 'string', pattern: '[' },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('invalidPattern');
+  });
+});
+
+describe('MinLengthValidator', () => {
+  const validator = new MinLengthValidator();
+
+  it('returns null for non-string value', () => {
+    const context: ValidationContext = {
+      value: 123,
+      schema: { type: 'number', minLength: 3 },
+      nodeName: 'count',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns error when value is too short', () => {
+    const context: ValidationContext = {
+      value: 'ab',
+      schema: { type: 'string', minLength: 3 },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('minLength');
+    expect(diagnostic?.params?.min).toBe(3);
+    expect(diagnostic?.params?.actual).toBe(2);
+  });
+
+  it('returns null when value meets minLength', () => {
+    const context: ValidationContext = {
+      value: 'abc',
+      schema: { type: 'string', minLength: 3 },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', minLength: 3 },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no minLength in schema', () => {
+    const context: ValidationContext = {
+      value: 'a',
+      schema: { type: 'string' },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});
+
+describe('MaxLengthValidator', () => {
+  const validator = new MaxLengthValidator();
+
+  it('returns null for non-string value', () => {
+    const context: ValidationContext = {
+      value: 123456,
+      schema: { type: 'number', maxLength: 5 },
+      nodeName: 'count',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns error when value exceeds maxLength', () => {
+    const context: ValidationContext = {
+      value: 'abcdef',
+      schema: { type: 'string', maxLength: 5 },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('maxLength');
+    expect(diagnostic?.params?.max).toBe(5);
+    expect(diagnostic?.params?.actual).toBe(6);
+  });
+
+  it('returns null when value meets maxLength', () => {
+    const context: ValidationContext = {
+      value: 'abcde',
+      schema: { type: 'string', maxLength: 5 },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no maxLength in schema', () => {
+    const context: ValidationContext = {
+      value: 'very long string',
+      schema: { type: 'string' },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});
+
+describe('MinimumValidator', () => {
+  const validator = new MinimumValidator();
+
+  it('returns error when value below minimum', () => {
+    const context: ValidationContext = {
+      value: 5,
+      schema: { type: 'number', minimum: 10 },
+      nodeName: 'age',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('minimum');
+    expect(diagnostic?.params?.min).toBe(10);
+    expect(diagnostic?.params?.actual).toBe(5);
+  });
+
+  it('returns null when value equals minimum', () => {
+    const context: ValidationContext = {
+      value: 10,
+      schema: { type: 'number', minimum: 10 },
+      nodeName: 'age',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when value above minimum', () => {
+    const context: ValidationContext = {
+      value: 15,
+      schema: { type: 'number', minimum: 10 },
+      nodeName: 'age',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no minimum in schema', () => {
+    const context: ValidationContext = {
+      value: -100,
+      schema: { type: 'number' },
+      nodeName: 'age',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null for non-number value', () => {
+    const context: ValidationContext = {
+      value: 'not a number',
+      schema: { type: 'number', minimum: 10 },
+      nodeName: 'age',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});
+
+describe('MaximumValidator', () => {
+  const validator = new MaximumValidator();
+
+  it('returns error when value above maximum', () => {
+    const context: ValidationContext = {
+      value: 150,
+      schema: { type: 'number', maximum: 100 },
+      nodeName: 'percentage',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('maximum');
+    expect(diagnostic?.params?.max).toBe(100);
+    expect(diagnostic?.params?.actual).toBe(150);
+  });
+
+  it('returns null when value equals maximum', () => {
+    const context: ValidationContext = {
+      value: 100,
+      schema: { type: 'number', maximum: 100 },
+      nodeName: 'percentage',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when value below maximum', () => {
+    const context: ValidationContext = {
+      value: 50,
+      schema: { type: 'number', maximum: 100 },
+      nodeName: 'percentage',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no maximum in schema', () => {
+    const context: ValidationContext = {
+      value: 1000000,
+      schema: { type: 'number' },
+      nodeName: 'count',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null for non-number value', () => {
+    const context: ValidationContext = {
+      value: 'not a number',
+      schema: { type: 'number', maximum: 100 },
+      nodeName: 'count',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});
+
+describe('EnumValidator', () => {
+  const validator = new EnumValidator();
+
+  it('returns error when value not in enum', () => {
+    const context: ValidationContext = {
+      value: 'invalid',
+      schema: { type: 'string', enum: ['a', 'b', 'c'] },
+      nodeName: 'status',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('enum');
+    expect(diagnostic?.params?.allowed).toEqual(['a', 'b', 'c']);
+    expect(diagnostic?.params?.actual).toBe('invalid');
+  });
+
+  it('returns null when value in enum', () => {
+    const context: ValidationContext = {
+      value: 'b',
+      schema: { type: 'string', enum: ['a', 'b', 'c'] },
+      nodeName: 'status',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('works with numbers', () => {
+    const context: ValidationContext = {
+      value: 2,
+      schema: { type: 'number', enum: [1, 2, 3] },
+      nodeName: 'priority',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no enum in schema', () => {
+    const context: ValidationContext = {
+      value: 'anything',
+      schema: { type: 'string' },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});
+
+describe('ForeignKeyValidator', () => {
+  const validator = new ForeignKeyValidator();
+
+  it('returns error when foreignKey is empty', () => {
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string', foreignKey: 'users' },
+      nodeName: 'userId',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('foreignKey');
+    expect(diagnostic?.params?.table).toBe('users');
+  });
+
+  it('returns null when foreignKey has value', () => {
+    const context: ValidationContext = {
+      value: 'user-123',
+      schema: { type: 'string', foreignKey: 'users' },
+      nodeName: 'userId',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+
+  it('returns null when no foreignKey in schema', () => {
+    const context: ValidationContext = {
+      value: '',
+      schema: { type: 'string' },
+      nodeName: 'name',
+    };
+
+    const diagnostic = validator.validate(context);
+    expect(diagnostic).toBeNull();
+  });
+});

--- a/src/core/validation/__tests__/validators.spec.ts
+++ b/src/core/validation/__tests__/validators.spec.ts
@@ -194,7 +194,7 @@ describe('MinLengthValidator', () => {
     expect(diagnostic).toBeNull();
   });
 
-  it('returns null for empty string', () => {
+  it('returns error for empty string when minLength > 0', () => {
     const context: ValidationContext = {
       value: '',
       schema: { type: 'string', minLength: 3 },
@@ -202,7 +202,10 @@ describe('MinLengthValidator', () => {
     };
 
     const diagnostic = validator.validate(context);
-    expect(diagnostic).toBeNull();
+    expect(diagnostic).not.toBeNull();
+    expect(diagnostic?.type).toBe('minLength');
+    expect(diagnostic?.params?.min).toBe(3);
+    expect(diagnostic?.params?.actual).toBe(0);
   });
 
   it('returns null when no minLength in schema', () => {

--- a/src/core/validation/createValidationEngine.ts
+++ b/src/core/validation/createValidationEngine.ts
@@ -1,0 +1,48 @@
+import { ValidatorRegistry } from './ValidatorRegistry.js';
+import { ValidatorResolver } from './ValidatorResolver.js';
+import { ValidationEngine } from './ValidationEngine.js';
+import { SchemaPropertyRule, SchemaTruthyRule } from './rules/index.js';
+import {
+  RequiredValidator,
+  PatternValidator,
+  MinLengthValidator,
+  MaxLengthValidator,
+  MinimumValidator,
+  MaximumValidator,
+  EnumValidator,
+  ForeignKeyValidator,
+} from './validators/index.js';
+
+export function createDefaultValidatorRegistry(): ValidatorRegistry {
+  const registry = new ValidatorRegistry();
+
+  registry
+    .register('required', () => new RequiredValidator())
+    .register('pattern', () => new PatternValidator())
+    .register('minLength', () => new MinLengthValidator())
+    .register('maxLength', () => new MaxLengthValidator())
+    .register('minimum', () => new MinimumValidator())
+    .register('maximum', () => new MaximumValidator())
+    .register('enum', () => new EnumValidator())
+    .register('foreignKey', () => new ForeignKeyValidator());
+
+  registry
+    .addRule(new SchemaTruthyRule('required', 'required'))
+    .addRule(new SchemaPropertyRule('pattern', 'pattern'))
+    .addRule(new SchemaPropertyRule('minLength', 'minLength'))
+    .addRule(new SchemaPropertyRule('maxLength', 'maxLength'))
+    .addRule(new SchemaPropertyRule('minimum', 'minimum'))
+    .addRule(new SchemaPropertyRule('maximum', 'maximum'))
+    .addRule(new SchemaPropertyRule('enum', 'enum'))
+    .addRule(new SchemaPropertyRule('foreignKey', 'foreignKey'));
+
+  return registry;
+}
+
+export function createValidationEngine(
+  registry?: ValidatorRegistry,
+): ValidationEngine {
+  const validatorRegistry = registry ?? createDefaultValidatorRegistry();
+  const resolver = new ValidatorResolver(validatorRegistry);
+  return new ValidationEngine(resolver);
+}

--- a/src/core/validation/index.ts
+++ b/src/core/validation/index.ts
@@ -1,0 +1,20 @@
+export type {
+  Diagnostic,
+  DiagnosticSeverity,
+  SchemaLike,
+  ValidationContext,
+  Validator,
+  ValidatorRule,
+  ValidatorFactoryFn,
+} from './types.js';
+
+export { ValidatorRegistry } from './ValidatorRegistry.js';
+export { ValidatorResolver } from './ValidatorResolver.js';
+export { ValidationEngine } from './ValidationEngine.js';
+export {
+  createDefaultValidatorRegistry,
+  createValidationEngine,
+} from './createValidationEngine.js';
+
+export * from './validators/index.js';
+export * from './rules/index.js';

--- a/src/core/validation/rules/SchemaBasedRule.ts
+++ b/src/core/validation/rules/SchemaBasedRule.ts
@@ -1,0 +1,35 @@
+import type { ValidatorRule, ValidationContext, SchemaLike } from '../types.js';
+
+export class SchemaPropertyRule implements ValidatorRule {
+  constructor(
+    readonly validatorType: string,
+    private readonly propertyName: keyof SchemaLike,
+  ) {}
+
+  shouldApply(context: ValidationContext): boolean {
+    const value = context.schema[this.propertyName];
+    return value !== undefined && value !== null;
+  }
+}
+
+export class SchemaTruthyRule implements ValidatorRule {
+  constructor(
+    readonly validatorType: string,
+    private readonly propertyName: keyof SchemaLike,
+  ) {}
+
+  shouldApply(context: ValidationContext): boolean {
+    return context.schema[this.propertyName] === true;
+  }
+}
+
+export class CompositeRule implements ValidatorRule {
+  constructor(
+    readonly validatorType: string,
+    private readonly conditions: Array<(context: ValidationContext) => boolean>,
+  ) {}
+
+  shouldApply(context: ValidationContext): boolean {
+    return this.conditions.every((condition) => condition(context));
+  }
+}

--- a/src/core/validation/rules/index.ts
+++ b/src/core/validation/rules/index.ts
@@ -1,0 +1,5 @@
+export {
+  SchemaPropertyRule,
+  SchemaTruthyRule,
+  CompositeRule,
+} from './SchemaBasedRule.js';

--- a/src/core/validation/types.ts
+++ b/src/core/validation/types.ts
@@ -1,0 +1,40 @@
+export type DiagnosticSeverity = 'error' | 'warning';
+
+export interface Diagnostic {
+  readonly severity: DiagnosticSeverity;
+  readonly type: string;
+  readonly message: string;
+  readonly path: string;
+  readonly params?: Record<string, unknown>;
+}
+
+export interface SchemaLike {
+  readonly type?: string;
+  readonly required?: boolean;
+  readonly pattern?: string;
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minimum?: number;
+  readonly maximum?: number;
+  readonly enum?: readonly (string | number)[];
+  readonly foreignKey?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface ValidationContext {
+  readonly value: unknown;
+  readonly schema: SchemaLike;
+  readonly nodeName: string;
+}
+
+export interface Validator {
+  readonly type: string;
+  validate(context: ValidationContext): Diagnostic | null;
+}
+
+export interface ValidatorRule {
+  readonly validatorType: string;
+  shouldApply(context: ValidationContext): boolean;
+}
+
+export type ValidatorFactoryFn = () => Validator;

--- a/src/core/validation/validators/EnumValidator.ts
+++ b/src/core/validation/validators/EnumValidator.ts
@@ -11,7 +11,7 @@ export class EnumValidator implements Validator {
       return null;
     }
 
-    if (!enumValues.some((allowed) => allowed === value)) {
+    if (!(enumValues as readonly unknown[]).includes(value)) {
       return {
         severity: 'error',
         type: this.type,

--- a/src/core/validation/validators/EnumValidator.ts
+++ b/src/core/validation/validators/EnumValidator.ts
@@ -11,7 +11,7 @@ export class EnumValidator implements Validator {
       return null;
     }
 
-    if (!enumValues.includes(value as string | number)) {
+    if (!enumValues.some((allowed) => allowed === value)) {
       return {
         severity: 'error',
         type: this.type,

--- a/src/core/validation/validators/EnumValidator.ts
+++ b/src/core/validation/validators/EnumValidator.ts
@@ -1,0 +1,26 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class EnumValidator implements Validator {
+  readonly type = 'enum';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const enumValues = schema.enum;
+
+    if (!enumValues || enumValues.length === 0) {
+      return null;
+    }
+
+    if (!enumValues.includes(value as string | number)) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: 'Value must be one of the allowed values',
+        path: nodeName,
+        params: { allowed: [...enumValues], actual: value },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/ForeignKeyValidator.ts
+++ b/src/core/validation/validators/ForeignKeyValidator.ts
@@ -1,0 +1,26 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class ForeignKeyValidator implements Validator {
+  readonly type = 'foreignKey';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const foreignKey = schema.foreignKey;
+
+    if (!foreignKey) {
+      return null;
+    }
+
+    if (value === '' || value === null || value === undefined) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: 'Foreign key reference is required',
+        path: nodeName,
+        params: { table: foreignKey },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/MaxLengthValidator.ts
+++ b/src/core/validation/validators/MaxLengthValidator.ts
@@ -1,0 +1,30 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class MaxLengthValidator implements Validator {
+  readonly type = 'maxLength';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const maxLength = schema.maxLength;
+
+    if (maxLength === undefined) {
+      return null;
+    }
+
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    if (value.length > maxLength) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: `Value must be at most ${maxLength} characters`,
+        path: nodeName,
+        params: { max: maxLength, actual: value.length },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/MaximumValidator.ts
+++ b/src/core/validation/validators/MaximumValidator.ts
@@ -1,0 +1,30 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class MaximumValidator implements Validator {
+  readonly type = 'maximum';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const maximum = schema.maximum;
+
+    if (maximum === undefined) {
+      return null;
+    }
+
+    if (typeof value !== 'number') {
+      return null;
+    }
+
+    if (value > maximum) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: `Value must be at most ${maximum}`,
+        path: nodeName,
+        params: { max: maximum, actual: value },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/MinLengthValidator.ts
+++ b/src/core/validation/validators/MinLengthValidator.ts
@@ -15,10 +15,6 @@ export class MinLengthValidator implements Validator {
       return null;
     }
 
-    if (value.length === 0) {
-      return null;
-    }
-
     if (value.length < minLength) {
       return {
         severity: 'error',

--- a/src/core/validation/validators/MinLengthValidator.ts
+++ b/src/core/validation/validators/MinLengthValidator.ts
@@ -1,0 +1,34 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class MinLengthValidator implements Validator {
+  readonly type = 'minLength';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const minLength = schema.minLength;
+
+    if (minLength === undefined) {
+      return null;
+    }
+
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    if (value.length === 0) {
+      return null;
+    }
+
+    if (value.length < minLength) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: `Value must be at least ${minLength} characters`,
+        path: nodeName,
+        params: { min: minLength, actual: value.length },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/MinimumValidator.ts
+++ b/src/core/validation/validators/MinimumValidator.ts
@@ -1,0 +1,30 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class MinimumValidator implements Validator {
+  readonly type = 'minimum';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const minimum = schema.minimum;
+
+    if (minimum === undefined) {
+      return null;
+    }
+
+    if (typeof value !== 'number') {
+      return null;
+    }
+
+    if (value < minimum) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: `Value must be at least ${minimum}`,
+        path: nodeName,
+        params: { min: minimum, actual: value },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/PatternValidator.ts
+++ b/src/core/validation/validators/PatternValidator.ts
@@ -1,0 +1,44 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class PatternValidator implements Validator {
+  readonly type = 'pattern';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, schema, nodeName } = context;
+    const pattern = schema.pattern;
+
+    if (!pattern) {
+      return null;
+    }
+
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    if (value.length === 0) {
+      return null;
+    }
+
+    try {
+      if (!new RegExp(pattern).test(value)) {
+        return {
+          severity: 'error',
+          type: this.type,
+          message: 'Value does not match pattern',
+          path: nodeName,
+          params: { pattern },
+        };
+      }
+    } catch {
+      return {
+        severity: 'error',
+        type: 'invalidPattern',
+        message: 'Invalid regex pattern in schema',
+        path: nodeName,
+        params: { pattern },
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/RequiredValidator.ts
+++ b/src/core/validation/validators/RequiredValidator.ts
@@ -1,0 +1,20 @@
+import type { Diagnostic, Validator, ValidationContext } from '../types.js';
+
+export class RequiredValidator implements Validator {
+  readonly type = 'required';
+
+  validate(context: ValidationContext): Diagnostic | null {
+    const { value, nodeName } = context;
+
+    if (value === '' || value === null || value === undefined) {
+      return {
+        severity: 'error',
+        type: this.type,
+        message: 'Field is required',
+        path: nodeName,
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/core/validation/validators/index.ts
+++ b/src/core/validation/validators/index.ts
@@ -1,0 +1,8 @@
+export { RequiredValidator } from './RequiredValidator.js';
+export { PatternValidator } from './PatternValidator.js';
+export { MinLengthValidator } from './MinLengthValidator.js';
+export { MaxLengthValidator } from './MaxLengthValidator.js';
+export { MinimumValidator } from './MinimumValidator.js';
+export { MaximumValidator } from './MaximumValidator.js';
+export { EnumValidator } from './EnumValidator.js';
+export { ForeignKeyValidator } from './ForeignKeyValidator.js';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a schema-driven, pluggable validation engine to power Data Model v2. Adds built-in validators, rules, and a simple factory, exported from core for easy use.

- **New Features**
  - New core/validation module: ValidatorRegistry, ValidatorResolver, ValidationEngine.
  - createValidationEngine and createDefaultValidatorRegistry for quick setup.
  - Built-in validators: required, pattern, minLength, maxLength, minimum, maximum, enum, foreignKey.
  - Schema-based rules (truthy/property/composite) to auto-resolve applicable validators.
  - Public exports wired in src/core/index.ts and a README with API and examples.
  - Comprehensive unit tests for engine, rules, and validators.

<sup>Written for commit 22c6daecaf2257942e68d89588808d2d4a6752e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

