### PR TITLE
feat: data model 3

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,3 +2,4 @@ export * from './types/index.js';
 export * from './reactivity/index.js';
 export * from './path/index.js';
 export * from './validation/index.js';
+export * from './schema-node/index.js';

--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -1,0 +1,98 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { EMPTY_METADATA } from './types.js';
+import { NULL_NODE } from './NullNode.js';
+
+export class ArrayNode implements SchemaNode {
+  constructor(
+    private readonly _id: string,
+    private readonly _name: string,
+    private readonly _items: SchemaNode,
+    private readonly _metadata: NodeMetadata = EMPTY_METADATA,
+  ) {}
+
+  id(): string {
+    return this._id;
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  nodeType(): NodeType {
+    return 'array';
+  }
+
+  metadata(): NodeMetadata {
+    return this._metadata;
+  }
+
+  isObject(): boolean {
+    return false;
+  }
+
+  isArray(): boolean {
+    return true;
+  }
+
+  isPrimitive(): boolean {
+    return false;
+  }
+
+  isRef(): boolean {
+    return false;
+  }
+
+  isNull(): boolean {
+    return false;
+  }
+
+  property(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  properties(): readonly SchemaNode[] {
+    return [this._items];
+  }
+
+  items(): SchemaNode {
+    return this._items;
+  }
+
+  ref(): string | undefined {
+    return undefined;
+  }
+
+  formula(): Formula | undefined {
+    return undefined;
+  }
+
+  hasFormula(): boolean {
+    return false;
+  }
+
+  defaultValue(): unknown {
+    return undefined;
+  }
+
+  foreignKey(): string | undefined {
+    return undefined;
+  }
+
+  clone(): SchemaNode {
+    return new ArrayNode(
+      this._id,
+      this._name,
+      this._items.clone(),
+      this._metadata,
+    );
+  }
+}
+
+export function createArrayNode(
+  id: string,
+  name: string,
+  items: SchemaNode,
+  metadata: NodeMetadata = EMPTY_METADATA,
+): SchemaNode {
+  return new ArrayNode(id, name, items, metadata);
+}

--- a/src/core/schema-node/BooleanNode.ts
+++ b/src/core/schema-node/BooleanNode.ts
@@ -1,0 +1,34 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { PrimitiveNode } from './PrimitiveNode.js';
+
+export interface BooleanNodeOptions {
+  readonly defaultValue?: boolean;
+  readonly formula?: Formula;
+  readonly metadata?: NodeMetadata;
+}
+
+export class BooleanNode extends PrimitiveNode {
+  constructor(
+    id: string,
+    name: string,
+    options: BooleanNodeOptions = {},
+  ) {
+    super(id, name, options);
+  }
+
+  nodeType(): NodeType {
+    return 'boolean';
+  }
+
+  clone(): SchemaNode {
+    return new BooleanNode(this.id(), this.name(), this._options as BooleanNodeOptions);
+  }
+}
+
+export function createBooleanNode(
+  id: string,
+  name: string,
+  options: BooleanNodeOptions = {},
+): SchemaNode {
+  return new BooleanNode(id, name, options);
+}

--- a/src/core/schema-node/NullNode.ts
+++ b/src/core/schema-node/NullNode.ts
@@ -1,0 +1,78 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { EMPTY_METADATA } from './types.js';
+
+class NullNodeImpl implements SchemaNode {
+  id(): string {
+    return '';
+  }
+
+  name(): string {
+    return '';
+  }
+
+  nodeType(): NodeType {
+    return 'null';
+  }
+
+  metadata(): NodeMetadata {
+    return EMPTY_METADATA;
+  }
+
+  isObject(): boolean {
+    return false;
+  }
+
+  isArray(): boolean {
+    return false;
+  }
+
+  isPrimitive(): boolean {
+    return false;
+  }
+
+  isRef(): boolean {
+    return false;
+  }
+
+  isNull(): boolean {
+    return true;
+  }
+
+  property(): SchemaNode {
+    return this;
+  }
+
+  properties(): readonly SchemaNode[] {
+    return [];
+  }
+
+  items(): SchemaNode {
+    return this;
+  }
+
+  ref(): string | undefined {
+    return undefined;
+  }
+
+  formula(): Formula | undefined {
+    return undefined;
+  }
+
+  hasFormula(): boolean {
+    return false;
+  }
+
+  defaultValue(): unknown {
+    return undefined;
+  }
+
+  foreignKey(): string | undefined {
+    return undefined;
+  }
+
+  clone(): SchemaNode {
+    return this;
+  }
+}
+
+export const NULL_NODE: SchemaNode = new NullNodeImpl();

--- a/src/core/schema-node/NumberNode.ts
+++ b/src/core/schema-node/NumberNode.ts
@@ -1,0 +1,34 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { PrimitiveNode } from './PrimitiveNode.js';
+
+export interface NumberNodeOptions {
+  readonly defaultValue?: number;
+  readonly formula?: Formula;
+  readonly metadata?: NodeMetadata;
+}
+
+export class NumberNode extends PrimitiveNode {
+  constructor(
+    id: string,
+    name: string,
+    options: NumberNodeOptions = {},
+  ) {
+    super(id, name, options);
+  }
+
+  nodeType(): NodeType {
+    return 'number';
+  }
+
+  clone(): SchemaNode {
+    return new NumberNode(this.id(), this.name(), this._options as NumberNodeOptions);
+  }
+}
+
+export function createNumberNode(
+  id: string,
+  name: string,
+  options: NumberNodeOptions = {},
+): SchemaNode {
+  return new NumberNode(id, name, options);
+}

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -1,0 +1,98 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { EMPTY_METADATA } from './types.js';
+import { NULL_NODE } from './NullNode.js';
+
+export class ObjectNode implements SchemaNode {
+  constructor(
+    private readonly _id: string,
+    private readonly _name: string,
+    private readonly _children: readonly SchemaNode[] = [],
+    private readonly _metadata: NodeMetadata = EMPTY_METADATA,
+  ) {}
+
+  id(): string {
+    return this._id;
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  nodeType(): NodeType {
+    return 'object';
+  }
+
+  metadata(): NodeMetadata {
+    return this._metadata;
+  }
+
+  isObject(): boolean {
+    return true;
+  }
+
+  isArray(): boolean {
+    return false;
+  }
+
+  isPrimitive(): boolean {
+    return false;
+  }
+
+  isRef(): boolean {
+    return false;
+  }
+
+  isNull(): boolean {
+    return false;
+  }
+
+  property(name: string): SchemaNode {
+    return this._children.find((child) => child.name() === name) ?? NULL_NODE;
+  }
+
+  properties(): readonly SchemaNode[] {
+    return this._children;
+  }
+
+  items(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  ref(): string | undefined {
+    return undefined;
+  }
+
+  formula(): Formula | undefined {
+    return undefined;
+  }
+
+  hasFormula(): boolean {
+    return false;
+  }
+
+  defaultValue(): unknown {
+    return undefined;
+  }
+
+  foreignKey(): string | undefined {
+    return undefined;
+  }
+
+  clone(): SchemaNode {
+    return new ObjectNode(
+      this._id,
+      this._name,
+      this._children.map((child) => child.clone()),
+      this._metadata,
+    );
+  }
+}
+
+export function createObjectNode(
+  id: string,
+  name: string,
+  children: readonly SchemaNode[] = [],
+  metadata: NodeMetadata = EMPTY_METADATA,
+): SchemaNode {
+  return new ObjectNode(id, name, children, metadata);
+}

--- a/src/core/schema-node/PrimitiveNode.ts
+++ b/src/core/schema-node/PrimitiveNode.ts
@@ -1,0 +1,86 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { EMPTY_METADATA } from './types.js';
+import { NULL_NODE } from './NullNode.js';
+
+export interface PrimitiveNodeOptions {
+  readonly defaultValue?: unknown;
+  readonly foreignKey?: string;
+  readonly formula?: Formula;
+  readonly metadata?: NodeMetadata;
+}
+
+export abstract class PrimitiveNode implements SchemaNode {
+  constructor(
+    private readonly _id: string,
+    private readonly _name: string,
+    protected readonly _options: PrimitiveNodeOptions = {},
+  ) {}
+
+  id(): string {
+    return this._id;
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  abstract nodeType(): NodeType;
+
+  metadata(): NodeMetadata {
+    return this._options.metadata ?? EMPTY_METADATA;
+  }
+
+  isObject(): boolean {
+    return false;
+  }
+
+  isArray(): boolean {
+    return false;
+  }
+
+  isPrimitive(): boolean {
+    return true;
+  }
+
+  isRef(): boolean {
+    return false;
+  }
+
+  isNull(): boolean {
+    return false;
+  }
+
+  property(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  properties(): readonly SchemaNode[] {
+    return [];
+  }
+
+  items(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  ref(): string | undefined {
+    return undefined;
+  }
+
+  formula(): Formula | undefined {
+    return this._options.formula;
+  }
+
+  hasFormula(): boolean {
+    return this._options.formula !== undefined;
+  }
+
+  defaultValue(): unknown {
+    return this._options.defaultValue;
+  }
+
+  foreignKey(): string | undefined {
+    return this._options.foreignKey;
+  }
+
+  abstract clone(): SchemaNode;
+}

--- a/src/core/schema-node/README.md
+++ b/src/core/schema-node/README.md
@@ -1,0 +1,98 @@
+# Schema Node Module
+
+Immutable node wrappers for JSON Schema tree representation.
+
+## API
+
+```typescript
+interface SchemaNode {
+  id(): string;
+  name(): string;
+  nodeType(): NodeType;
+  metadata(): NodeMetadata;
+
+  isObject(): boolean;
+  isArray(): boolean;
+  isPrimitive(): boolean;
+  isRef(): boolean;
+  isNull(): boolean;
+
+  property(name: string): SchemaNode;
+  properties(): readonly SchemaNode[];
+  items(): SchemaNode;
+
+  ref(): string | undefined;
+  formula(): Formula | undefined;
+  hasFormula(): boolean;
+  defaultValue(): unknown;
+  foreignKey(): string | undefined;
+
+  clone(): SchemaNode;
+}
+
+type NodeType = 'object' | 'array' | 'string' | 'number' | 'boolean' | 'ref' | 'null';
+```
+
+## Node Types
+
+|Type|Factory|Description|
+|---|---|---|
+|ObjectNode|`createObjectNode(id, name, children?, metadata?)`|Container with named properties|
+|ArrayNode|`createArrayNode(id, name, items, metadata?)`|Array with item schema|
+|StringNode|`createStringNode(id, name, options?)`|String with default, foreignKey, formula|
+|NumberNode|`createNumberNode(id, name, options?)`|Number with default, formula|
+|BooleanNode|`createBooleanNode(id, name, options?)`|Boolean with default, formula|
+|RefNode|`createRefNode(id, name, ref, metadata?)`|Schema reference ($ref)|
+|NULL_NODE|singleton|Null object for safe chaining|
+
+## Usage
+
+```typescript
+import {
+  createObjectNode,
+  createStringNode,
+  createArrayNode,
+  NULL_NODE,
+} from '@revisium/schema-toolkit/core';
+
+const user = createObjectNode('user-id', 'user', [
+  createStringNode('name-id', 'name', { defaultValue: '' }),
+  createStringNode('email-id', 'email', { foreignKey: 'emails' }),
+  createArrayNode('tags-id', 'tags',
+    createStringNode('tag-id', 'item', { defaultValue: '' })
+  ),
+]);
+
+user.property('name').defaultValue();  // ''
+user.property('tags').items().nodeType();  // 'string'
+user.property('missing');  // NULL_NODE
+```
+
+## Formula Support
+
+```typescript
+const computed = createNumberNode('total-id', 'total', {
+  formula: { version: 1, expression: 'price * quantity' },
+});
+
+computed.hasFormula();  // true
+computed.formula();  // { version: 1, expression: 'price * quantity' }
+```
+
+## Cloning
+
+All nodes support deep cloning for base/current state management:
+
+```typescript
+const base = user.clone();
+// base is a deep copy, modifications to user don't affect base
+```
+
+## Null Object Pattern
+
+`NULL_NODE` enables safe method chaining:
+
+```typescript
+user.property('missing').property('also-missing').items();  // NULL_NODE
+NULL_NODE.isNull();  // true
+```

--- a/src/core/schema-node/RefNode.ts
+++ b/src/core/schema-node/RefNode.ts
@@ -1,0 +1,97 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { EMPTY_METADATA } from './types.js';
+import { NULL_NODE } from './NullNode.js';
+
+export class RefNode implements SchemaNode {
+  constructor(
+    private readonly _id: string,
+    private readonly _name: string,
+    private readonly _ref: string,
+    private readonly _metadata: NodeMetadata = EMPTY_METADATA,
+  ) {
+    if (!_ref) {
+      throw new Error('RefNode requires a non-empty ref');
+    }
+  }
+
+  id(): string {
+    return this._id;
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  nodeType(): NodeType {
+    return 'ref';
+  }
+
+  metadata(): NodeMetadata {
+    return this._metadata;
+  }
+
+  isObject(): boolean {
+    return false;
+  }
+
+  isArray(): boolean {
+    return false;
+  }
+
+  isPrimitive(): boolean {
+    return false;
+  }
+
+  isRef(): boolean {
+    return true;
+  }
+
+  isNull(): boolean {
+    return false;
+  }
+
+  property(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  properties(): readonly SchemaNode[] {
+    return [];
+  }
+
+  items(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  ref(): string | undefined {
+    return this._ref;
+  }
+
+  formula(): Formula | undefined {
+    return undefined;
+  }
+
+  hasFormula(): boolean {
+    return false;
+  }
+
+  defaultValue(): unknown {
+    return undefined;
+  }
+
+  foreignKey(): string | undefined {
+    return undefined;
+  }
+
+  clone(): SchemaNode {
+    return new RefNode(this._id, this._name, this._ref, this._metadata);
+  }
+}
+
+export function createRefNode(
+  id: string,
+  name: string,
+  ref: string,
+  metadata: NodeMetadata = EMPTY_METADATA,
+): SchemaNode {
+  return new RefNode(id, name, ref, metadata);
+}

--- a/src/core/schema-node/StringNode.ts
+++ b/src/core/schema-node/StringNode.ts
@@ -1,0 +1,35 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { PrimitiveNode } from './PrimitiveNode.js';
+
+export interface StringNodeOptions {
+  readonly defaultValue?: string;
+  readonly foreignKey?: string;
+  readonly formula?: Formula;
+  readonly metadata?: NodeMetadata;
+}
+
+export class StringNode extends PrimitiveNode {
+  constructor(
+    id: string,
+    name: string,
+    options: StringNodeOptions = {},
+  ) {
+    super(id, name, options);
+  }
+
+  nodeType(): NodeType {
+    return 'string';
+  }
+
+  clone(): SchemaNode {
+    return new StringNode(this.id(), this.name(), this._options as StringNodeOptions);
+  }
+}
+
+export function createStringNode(
+  id: string,
+  name: string,
+  options: StringNodeOptions = {},
+): SchemaNode {
+  return new StringNode(id, name, options);
+}

--- a/src/core/schema-node/__tests__/ArrayNode.spec.ts
+++ b/src/core/schema-node/__tests__/ArrayNode.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  createArrayNode,
+  createStringNode,
+  NULL_NODE,
+  EMPTY_METADATA,
+} from '../index.js';
+
+describe('ArrayNode', () => {
+  it('creates node with id and name', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.id()).toBe('arr-1');
+    expect(node.name()).toBe('tags');
+    expect(node.nodeType()).toBe('array');
+  });
+
+  it('isArray returns true', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.isObject()).toBe(false);
+    expect(node.isArray()).toBe(true);
+    expect(node.isPrimitive()).toBe(false);
+    expect(node.isRef()).toBe(false);
+    expect(node.isNull()).toBe(false);
+  });
+
+  it('items returns item schema', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.items()).toBe(items);
+  });
+
+  it('properties returns items as single-element array', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.properties()).toHaveLength(1);
+    expect(node.properties()[0]).toBe(items);
+  });
+
+  it('property returns NULL_NODE', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.property('any')).toBe(NULL_NODE);
+  });
+
+  it('clones with items', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    const cloned = node.clone();
+
+    expect(cloned.id()).toBe('arr-1');
+    expect(cloned.items()).not.toBe(items);
+    expect(cloned.items().id()).toBe('str-1');
+  });
+
+  it('returns undefined for primitive properties', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.ref()).toBeUndefined();
+    expect(node.formula()).toBeUndefined();
+    expect(node.hasFormula()).toBe(false);
+    expect(node.defaultValue()).toBeUndefined();
+    expect(node.foreignKey()).toBeUndefined();
+  });
+
+  it('returns EMPTY_METADATA when no metadata provided', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items);
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+
+  it('supports metadata', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items, {
+      title: 'Tags',
+      deprecated: true,
+    });
+
+    expect(node.metadata().title).toBe('Tags');
+    expect(node.metadata().deprecated).toBe(true);
+  });
+
+  it('creates node with explicit EMPTY_METADATA', () => {
+    const items = createStringNode('str-1', 'item');
+    const node = createArrayNode('arr-1', 'tags', items, EMPTY_METADATA);
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+});

--- a/src/core/schema-node/__tests__/NullNode.spec.ts
+++ b/src/core/schema-node/__tests__/NullNode.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from '@jest/globals';
+import { NULL_NODE, EMPTY_METADATA } from '../index.js';
+
+describe('NULL_NODE', () => {
+  it('has null type', () => {
+    expect(NULL_NODE.nodeType()).toBe('null');
+  });
+
+  it('isNull returns true', () => {
+    expect(NULL_NODE.isNull()).toBe(true);
+    expect(NULL_NODE.isObject()).toBe(false);
+    expect(NULL_NODE.isArray()).toBe(false);
+    expect(NULL_NODE.isPrimitive()).toBe(false);
+    expect(NULL_NODE.isRef()).toBe(false);
+  });
+
+  it('id returns empty string', () => {
+    expect(NULL_NODE.id()).toBe('');
+  });
+
+  it('name returns empty string', () => {
+    expect(NULL_NODE.name()).toBe('');
+  });
+
+  it('property returns itself', () => {
+    expect(NULL_NODE.property('any')).toBe(NULL_NODE);
+  });
+
+  it('properties returns empty array', () => {
+    expect(NULL_NODE.properties()).toHaveLength(0);
+  });
+
+  it('items returns itself', () => {
+    expect(NULL_NODE.items()).toBe(NULL_NODE);
+  });
+
+  it('clone returns itself', () => {
+    expect(NULL_NODE.clone()).toBe(NULL_NODE);
+  });
+
+  it('returns undefined for primitive properties', () => {
+    expect(NULL_NODE.ref()).toBeUndefined();
+    expect(NULL_NODE.formula()).toBeUndefined();
+    expect(NULL_NODE.hasFormula()).toBe(false);
+    expect(NULL_NODE.defaultValue()).toBeUndefined();
+    expect(NULL_NODE.foreignKey()).toBeUndefined();
+  });
+
+  it('returns EMPTY_METADATA', () => {
+    expect(NULL_NODE.metadata()).toBe(EMPTY_METADATA);
+  });
+});

--- a/src/core/schema-node/__tests__/ObjectNode.spec.ts
+++ b/src/core/schema-node/__tests__/ObjectNode.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+  NULL_NODE,
+  EMPTY_METADATA,
+} from '../index.js';
+
+describe('ObjectNode', () => {
+  it('creates node with id and name', () => {
+    const node = createObjectNode('obj-1', 'user');
+
+    expect(node.id()).toBe('obj-1');
+    expect(node.name()).toBe('user');
+    expect(node.nodeType()).toBe('object');
+  });
+
+  it('creates node with explicit empty children', () => {
+    const node = createObjectNode('obj-1', 'user', []);
+
+    expect(node.properties()).toHaveLength(0);
+  });
+
+  it('creates node with explicit metadata', () => {
+    const node = createObjectNode('obj-1', 'user', [], EMPTY_METADATA);
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+
+  it('isObject returns true', () => {
+    const node = createObjectNode('obj-1', 'user');
+
+    expect(node.isObject()).toBe(true);
+    expect(node.isArray()).toBe(false);
+    expect(node.isPrimitive()).toBe(false);
+    expect(node.isRef()).toBe(false);
+    expect(node.isNull()).toBe(false);
+  });
+
+  it('manages children via properties', () => {
+    const child1 = createStringNode('str-1', 'name');
+    const child2 = createNumberNode('num-1', 'age');
+    const node = createObjectNode('obj-1', 'user', [child1, child2]);
+
+    expect(node.properties()).toHaveLength(2);
+    expect(node.properties()[0]).toBe(child1);
+    expect(node.properties()[1]).toBe(child2);
+  });
+
+  it('property returns child by name', () => {
+    const child = createStringNode('str-1', 'name');
+    const node = createObjectNode('obj-1', 'user', [child]);
+
+    expect(node.property('name')).toBe(child);
+  });
+
+  it('property returns NULL_NODE for missing child', () => {
+    const node = createObjectNode('obj-1', 'user');
+
+    expect(node.property('missing')).toBe(NULL_NODE);
+  });
+
+  it('items returns NULL_NODE', () => {
+    const node = createObjectNode('obj-1', 'user');
+
+    expect(node.items()).toBe(NULL_NODE);
+  });
+
+  it('returns undefined for primitive properties', () => {
+    const node = createObjectNode('obj-1', 'user');
+
+    expect(node.ref()).toBeUndefined();
+    expect(node.formula()).toBeUndefined();
+    expect(node.hasFormula()).toBe(false);
+    expect(node.defaultValue()).toBeUndefined();
+    expect(node.foreignKey()).toBeUndefined();
+  });
+
+  it('clones with children', () => {
+    const child = createStringNode('str-1', 'name');
+    const node = createObjectNode('obj-1', 'user', [child]);
+
+    const cloned = node.clone();
+
+    expect(cloned.id()).toBe('obj-1');
+    expect(cloned.name()).toBe('user');
+    expect(cloned.properties()).toHaveLength(1);
+    expect(cloned.properties()[0]).not.toBe(child);
+    expect(cloned.properties()[0]?.id()).toBe('str-1');
+  });
+
+  it('supports metadata', () => {
+    const node = createObjectNode('obj-1', 'user', [], {
+      title: 'User',
+      description: 'A user object',
+      deprecated: true,
+    });
+
+    expect(node.metadata().title).toBe('User');
+    expect(node.metadata().description).toBe('A user object');
+    expect(node.metadata().deprecated).toBe(true);
+  });
+
+  it('returns EMPTY_METADATA when no metadata provided', () => {
+    const node = createObjectNode('obj-1', 'user');
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+});

--- a/src/core/schema-node/__tests__/PrimitiveNodes.spec.ts
+++ b/src/core/schema-node/__tests__/PrimitiveNodes.spec.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+  NULL_NODE,
+  EMPTY_METADATA,
+} from '../index.js';
+import type { Formula } from '../types.js';
+
+describe('StringNode', () => {
+  it('creates node with id and name', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.id()).toBe('str-1');
+    expect(node.name()).toBe('name');
+    expect(node.nodeType()).toBe('string');
+  });
+
+  it('isPrimitive returns true', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.isObject()).toBe(false);
+    expect(node.isArray()).toBe(false);
+    expect(node.isPrimitive()).toBe(true);
+    expect(node.isRef()).toBe(false);
+    expect(node.isNull()).toBe(false);
+  });
+
+  it('supports default value', () => {
+    const node = createStringNode('str-1', 'name', { defaultValue: 'John' });
+
+    expect(node.defaultValue()).toBe('John');
+  });
+
+  it('supports foreign key', () => {
+    const node = createStringNode('str-1', 'userId', { foreignKey: 'users' });
+
+    expect(node.foreignKey()).toBe('users');
+  });
+
+  it('supports formula', () => {
+    const formula: Formula = { version: 1, expression: 'firstName + lastName' };
+    const node = createStringNode('str-1', 'fullName', { formula });
+
+    expect(node.formula()).toEqual(formula);
+    expect(node.hasFormula()).toBe(true);
+  });
+
+  it('hasFormula returns false when no formula', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.hasFormula()).toBe(false);
+  });
+
+  it('properties returns empty array', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.properties()).toHaveLength(0);
+  });
+
+  it('property returns NULL_NODE', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.property('any')).toBe(NULL_NODE);
+  });
+
+  it('items returns NULL_NODE', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.items()).toBe(NULL_NODE);
+  });
+
+  it('clones with all options', () => {
+    const formula: Formula = { version: 1, expression: 'a + b' };
+    const node = createStringNode('str-1', 'name', {
+      defaultValue: 'test',
+      foreignKey: 'users',
+      formula,
+    });
+
+    const cloned = node.clone();
+
+    expect(cloned.id()).toBe('str-1');
+    expect(cloned.defaultValue()).toBe('test');
+    expect(cloned.foreignKey()).toBe('users');
+    expect(cloned.formula()).toEqual(formula);
+  });
+
+  it('ref returns undefined', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.ref()).toBeUndefined();
+  });
+
+  it('returns EMPTY_METADATA when no metadata provided', () => {
+    const node = createStringNode('str-1', 'name');
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+
+  it('supports metadata', () => {
+    const node = createStringNode('str-1', 'name', {
+      metadata: { title: 'Name', deprecated: true },
+    });
+
+    expect(node.metadata().title).toBe('Name');
+    expect(node.metadata().deprecated).toBe(true);
+  });
+
+  it('creates node with empty options', () => {
+    const node = createStringNode('str-1', 'name', {});
+
+    expect(node.defaultValue()).toBeUndefined();
+    expect(node.foreignKey()).toBeUndefined();
+    expect(node.formula()).toBeUndefined();
+  });
+});
+
+describe('NumberNode', () => {
+  it('creates node with id and name', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.id()).toBe('num-1');
+    expect(node.name()).toBe('age');
+    expect(node.nodeType()).toBe('number');
+  });
+
+  it('isPrimitive returns true', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.isPrimitive()).toBe(true);
+  });
+
+  it('supports default value', () => {
+    const node = createNumberNode('num-1', 'age', { defaultValue: 25 });
+
+    expect(node.defaultValue()).toBe(25);
+  });
+
+  it('supports formula', () => {
+    const formula: Formula = { version: 1, expression: 'price * quantity' };
+    const node = createNumberNode('num-1', 'total', { formula });
+
+    expect(node.formula()).toEqual(formula);
+    expect(node.hasFormula()).toBe(true);
+  });
+
+  it('clones with options', () => {
+    const node = createNumberNode('num-1', 'age', { defaultValue: 25 });
+
+    const cloned = node.clone();
+
+    expect(cloned.id()).toBe('num-1');
+    expect(cloned.defaultValue()).toBe(25);
+  });
+
+  it('type predicates return correct values', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.isObject()).toBe(false);
+    expect(node.isArray()).toBe(false);
+    expect(node.isPrimitive()).toBe(true);
+    expect(node.isRef()).toBe(false);
+    expect(node.isNull()).toBe(false);
+  });
+
+  it('container methods return empty/NULL_NODE', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.property('any')).toBe(NULL_NODE);
+    expect(node.properties()).toHaveLength(0);
+    expect(node.items()).toBe(NULL_NODE);
+  });
+
+  it('ref and foreignKey return undefined', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.ref()).toBeUndefined();
+    expect(node.foreignKey()).toBeUndefined();
+  });
+
+  it('hasFormula returns false when no formula', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.hasFormula()).toBe(false);
+    expect(node.formula()).toBeUndefined();
+  });
+
+  it('returns EMPTY_METADATA when no metadata provided', () => {
+    const node = createNumberNode('num-1', 'age');
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+
+  it('supports metadata', () => {
+    const node = createNumberNode('num-1', 'age', {
+      metadata: { title: 'Age', description: 'User age' },
+    });
+
+    expect(node.metadata().title).toBe('Age');
+    expect(node.metadata().description).toBe('User age');
+  });
+
+  it('creates node with empty options', () => {
+    const node = createNumberNode('num-1', 'age', {});
+
+    expect(node.defaultValue()).toBeUndefined();
+    expect(node.formula()).toBeUndefined();
+  });
+});
+
+describe('BooleanNode', () => {
+  it('creates node with id and name', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.id()).toBe('bool-1');
+    expect(node.name()).toBe('active');
+    expect(node.nodeType()).toBe('boolean');
+  });
+
+  it('isPrimitive returns true', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.isPrimitive()).toBe(true);
+  });
+
+  it('supports default value', () => {
+    const node = createBooleanNode('bool-1', 'active', { defaultValue: true });
+
+    expect(node.defaultValue()).toBe(true);
+  });
+
+  it('supports formula', () => {
+    const formula: Formula = { version: 1, expression: 'age >= 18' };
+    const node = createBooleanNode('bool-1', 'isAdult', { formula });
+
+    expect(node.formula()).toEqual(formula);
+    expect(node.hasFormula()).toBe(true);
+  });
+
+  it('clones with options', () => {
+    const node = createBooleanNode('bool-1', 'active', { defaultValue: false });
+
+    const cloned = node.clone();
+
+    expect(cloned.id()).toBe('bool-1');
+    expect(cloned.defaultValue()).toBe(false);
+  });
+
+  it('type predicates return correct values', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.isObject()).toBe(false);
+    expect(node.isArray()).toBe(false);
+    expect(node.isPrimitive()).toBe(true);
+    expect(node.isRef()).toBe(false);
+    expect(node.isNull()).toBe(false);
+  });
+
+  it('container methods return empty/NULL_NODE', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.property('any')).toBe(NULL_NODE);
+    expect(node.properties()).toHaveLength(0);
+    expect(node.items()).toBe(NULL_NODE);
+  });
+
+  it('ref and foreignKey return undefined', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.ref()).toBeUndefined();
+    expect(node.foreignKey()).toBeUndefined();
+  });
+
+  it('hasFormula returns false when no formula', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.hasFormula()).toBe(false);
+    expect(node.formula()).toBeUndefined();
+  });
+
+  it('returns EMPTY_METADATA when no metadata provided', () => {
+    const node = createBooleanNode('bool-1', 'active');
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+
+  it('supports metadata', () => {
+    const node = createBooleanNode('bool-1', 'active', {
+      metadata: { title: 'Active', deprecated: true },
+    });
+
+    expect(node.metadata().title).toBe('Active');
+    expect(node.metadata().deprecated).toBe(true);
+  });
+
+  it('creates node with empty options', () => {
+    const node = createBooleanNode('bool-1', 'active', {});
+
+    expect(node.defaultValue()).toBeUndefined();
+    expect(node.formula()).toBeUndefined();
+  });
+});

--- a/src/core/schema-node/__tests__/RefNode.spec.ts
+++ b/src/core/schema-node/__tests__/RefNode.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from '@jest/globals';
+import { createRefNode, NULL_NODE, EMPTY_METADATA } from '../index.js';
+
+describe('RefNode', () => {
+  it('creates node with id, name and ref', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.id()).toBe('ref-1');
+    expect(node.name()).toBe('avatar');
+    expect(node.nodeType()).toBe('ref');
+  });
+
+  it('isRef returns true', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.isObject()).toBe(false);
+    expect(node.isArray()).toBe(false);
+    expect(node.isPrimitive()).toBe(false);
+    expect(node.isRef()).toBe(true);
+    expect(node.isNull()).toBe(false);
+  });
+
+  it('ref returns reference path', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.ref()).toBe('File');
+  });
+
+  it('properties returns empty array', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.properties()).toHaveLength(0);
+  });
+
+  it('property returns NULL_NODE', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.property('any')).toBe(NULL_NODE);
+  });
+
+  it('items returns NULL_NODE', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.items()).toBe(NULL_NODE);
+  });
+
+  it('clones', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    const cloned = node.clone();
+
+    expect(cloned.id()).toBe('ref-1');
+    expect(cloned.ref()).toBe('File');
+  });
+
+  it('throws on empty ref', () => {
+    expect(() => createRefNode('ref-1', 'avatar', '')).toThrow();
+  });
+
+  it('returns undefined for primitive properties', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.formula()).toBeUndefined();
+    expect(node.hasFormula()).toBe(false);
+    expect(node.defaultValue()).toBeUndefined();
+    expect(node.foreignKey()).toBeUndefined();
+  });
+
+  it('returns EMPTY_METADATA when no metadata provided', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File');
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+
+  it('supports metadata', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File', {
+      title: 'Avatar',
+      description: 'User avatar file',
+    });
+
+    expect(node.metadata().title).toBe('Avatar');
+    expect(node.metadata().description).toBe('User avatar file');
+  });
+
+  it('creates node with explicit EMPTY_METADATA', () => {
+    const node = createRefNode('ref-1', 'avatar', 'File', EMPTY_METADATA);
+
+    expect(node.metadata()).toBe(EMPTY_METADATA);
+  });
+});

--- a/src/core/schema-node/__tests__/navigation.spec.ts
+++ b/src/core/schema-node/__tests__/navigation.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  NULL_NODE,
+} from '../index.js';
+import type { SchemaNode } from '../types.js';
+
+describe('Deep cloning', () => {
+  it('clones nested object structure', () => {
+    const address = createObjectNode('obj-2', 'address', [
+      createStringNode('str-1', 'city'),
+      createStringNode('str-2', 'street'),
+    ]);
+    const user = createObjectNode('obj-1', 'user', [
+      createStringNode('str-3', 'name'),
+      address,
+    ]);
+
+    const cloned = user.clone();
+
+    expect(cloned).not.toBe(user);
+    expect(cloned.property('address')).not.toBe(address);
+    expect(cloned.property('address').property('city').id()).toBe('str-1');
+  });
+
+  it('clones array with object items', () => {
+    const itemSchema = createObjectNode('obj-1', 'item', [
+      createStringNode('str-1', 'name'),
+    ]);
+    const arr = createArrayNode('arr-1', 'items', itemSchema);
+
+    const cloned = arr.clone();
+
+    expect(cloned.items()).not.toBe(itemSchema);
+    expect(cloned.items().property('name').id()).toBe('str-1');
+  });
+});
+
+describe('Node navigation', () => {
+  let root: SchemaNode;
+
+  beforeEach(() => {
+    root = createObjectNode('root', 'root', [
+      createStringNode('name-id', 'name'),
+      createObjectNode('address-id', 'address', [
+        createStringNode('city-id', 'city'),
+      ]),
+      createArrayNode(
+        'tags-id',
+        'tags',
+        createObjectNode('tag-item-id', 'item', [
+          createStringNode('tag-name-id', 'name'),
+        ]),
+      ),
+    ]);
+  });
+
+  it('navigates to nested property', () => {
+    const city = root.property('address').property('city');
+
+    expect(city.id()).toBe('city-id');
+    expect(city.name()).toBe('city');
+  });
+
+  it('navigates to array items', () => {
+    const tagItem = root.property('tags').items();
+
+    expect(tagItem.id()).toBe('tag-item-id');
+  });
+
+  it('navigates to nested array item property', () => {
+    const tagName = root.property('tags').items().property('name');
+
+    expect(tagName.id()).toBe('tag-name-id');
+  });
+
+  it('returns NULL_NODE for invalid path', () => {
+    const result = root.property('missing').property('also-missing');
+
+    expect(result).toBe(NULL_NODE);
+  });
+});

--- a/src/core/schema-node/index.ts
+++ b/src/core/schema-node/index.ts
@@ -1,0 +1,15 @@
+export type {
+  NodeType,
+  NodeMetadata,
+  Formula,
+  SchemaNode,
+} from './types.js';
+export { EMPTY_METADATA } from './types.js';
+
+export { NULL_NODE } from './NullNode.js';
+export { createObjectNode } from './ObjectNode.js';
+export { createArrayNode } from './ArrayNode.js';
+export { createStringNode } from './StringNode.js';
+export { createNumberNode } from './NumberNode.js';
+export { createBooleanNode } from './BooleanNode.js';
+export { createRefNode } from './RefNode.js';

--- a/src/core/schema-node/types.ts
+++ b/src/core/schema-node/types.ts
@@ -1,0 +1,46 @@
+export type NodeType =
+  | 'object'
+  | 'array'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'ref'
+  | 'null';
+
+export interface NodeMetadata {
+  readonly title?: string;
+  readonly description?: string;
+  readonly deprecated?: boolean;
+}
+
+export const EMPTY_METADATA: NodeMetadata = Object.freeze({});
+
+export interface Formula {
+  readonly version: number;
+  readonly expression: string;
+}
+
+export interface SchemaNode {
+  id(): string;
+  name(): string;
+  nodeType(): NodeType;
+  metadata(): NodeMetadata;
+
+  isObject(): boolean;
+  isArray(): boolean;
+  isPrimitive(): boolean;
+  isRef(): boolean;
+  isNull(): boolean;
+
+  property(name: string): SchemaNode;
+  properties(): readonly SchemaNode[];
+  items(): SchemaNode;
+
+  ref(): string | undefined;
+  formula(): Formula | undefined;
+  hasFormula(): boolean;
+  defaultValue(): unknown;
+  foreignKey(): string | undefined;
+
+  clone(): SchemaNode;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces an immutable schema-node data model for JSON Schema trees with safe navigation, deep cloning, and formula/metadata support. The module is exported via core/index for use across the toolkit.

- **New Features**
  - Immutable node types: object, array, string, number, boolean, ref, plus NULL_NODE.
  - Factory functions to build nodes; all nodes support deep cloning.
  - Safe navigation and type checks: property(name), properties(), items(), isObject/isArray/isPrimitive/isRef/isNull.
  - Formula, defaultValue, metadata, and string foreignKey support; module exported via core/index.

<sup>Written for commit 239846e84f70116d003fad934b1c379e95ee9159. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

