### PR TITLE
feat: data model 4

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,4 @@ export * from './reactivity/index.js';
 export * from './path/index.js';
 export * from './validation/index.js';
 export * from './schema-node/index.js';
+export * from './schema-tree/index.js';

--- a/src/core/schema-tree/README.md
+++ b/src/core/schema-tree/README.md
@@ -1,0 +1,81 @@
+# Schema Tree Module
+
+Tree structure for schema nodes with path-based navigation and indexing.
+
+## API
+
+```typescript
+interface SchemaTree {
+  root(): SchemaNode;
+  nodeById(id: string): SchemaNode;
+  nodeAt(path: Path): SchemaNode;
+  pathOf(id: string): Path;
+  nodeIds(): IterableIterator<string>;
+  countNodes(): number;
+  clone(): SchemaTree;
+}
+```
+
+## Usage
+
+```typescript
+import {
+  createSchemaTree,
+  createObjectNode,
+  createStringNode,
+  jsonPointerToPath,
+  EMPTY_PATH,
+} from '@revisium/schema-toolkit/core';
+
+const root = createObjectNode('root-id', 'root', [
+  createStringNode('name-id', 'name'),
+  createObjectNode('address-id', 'address', [
+    createStringNode('city-id', 'city'),
+  ]),
+]);
+
+const tree = createSchemaTree(root);
+
+// Lookup by ID
+tree.nodeById('city-id');           // cityNode
+tree.nodeById('unknown');           // NULL_NODE
+
+// Get path of node
+tree.pathOf('city-id');             // Path: /properties/address/properties/city
+
+// Navigate by path
+const path = jsonPointerToPath('/properties/address/properties/city');
+tree.nodeAt(path);                  // cityNode
+tree.nodeAt(EMPTY_PATH);            // root
+
+// Iterate all nodes
+for (const id of tree.nodeIds()) {
+  console.log(id, tree.pathOf(id).asSimple());
+}
+
+// Count nodes
+tree.countNodes();                  // 4
+```
+
+## Cloning for Base/Current State
+
+```typescript
+const baseTree = tree.clone();
+
+// baseTree is independent - modifications to tree don't affect it
+// Use for diff generation between versions
+```
+
+## Architecture
+
+```text
+SchemaTree
+    │
+    ├── root (SchemaNode)
+    │
+    └── TreeNodeIndex
+        ├── nodeIndex: Map<id, SchemaNode>
+        └── pathIndex: Map<id, Path>
+```
+
+TreeNodeIndex provides O(1) lookup by ID and path computation.

--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -1,0 +1,63 @@
+import type { SchemaNode } from '../schema-node/index.js';
+import { NULL_NODE } from '../schema-node/index.js';
+import type { Path } from '../path/index.js';
+import type { SchemaTree } from './types.js';
+import { TreeNodeIndex } from './TreeNodeIndex.js';
+
+export class SchemaTreeImpl implements SchemaTree {
+  private readonly index = new TreeNodeIndex();
+
+  constructor(private readonly rootNode: SchemaNode) {
+    this.index.rebuild(rootNode);
+  }
+
+  root(): SchemaNode {
+    return this.rootNode;
+  }
+
+  nodeById(id: string): SchemaNode {
+    return this.index.getNode(id);
+  }
+
+  pathOf(id: string): Path {
+    return this.index.getPath(id);
+  }
+
+  nodeAt(path: Path): SchemaNode {
+    if (path.isEmpty()) {
+      return this.rootNode;
+    }
+
+    let current: SchemaNode = this.rootNode;
+
+    for (const segment of path.segments()) {
+      if (current.isNull()) {
+        return NULL_NODE;
+      }
+
+      if (segment.isItems()) {
+        current = current.items();
+      } else {
+        current = current.property(segment.propertyName());
+      }
+    }
+
+    return current;
+  }
+
+  nodeIds(): IterableIterator<string> {
+    return this.index.nodeIds();
+  }
+
+  countNodes(): number {
+    return this.index.countNodes();
+  }
+
+  clone(): SchemaTree {
+    return new SchemaTreeImpl(this.rootNode.clone());
+  }
+}
+
+export function createSchemaTree(root: SchemaNode): SchemaTree {
+  return new SchemaTreeImpl(root);
+}

--- a/src/core/schema-tree/TreeNodeIndex.ts
+++ b/src/core/schema-tree/TreeNodeIndex.ts
@@ -1,0 +1,44 @@
+import type { SchemaNode } from '../schema-node/index.js';
+import { NULL_NODE } from '../schema-node/index.js';
+import type { Path } from '../path/index.js';
+import { EMPTY_PATH } from '../path/index.js';
+
+export class TreeNodeIndex {
+  private readonly nodeIndex = new Map<string, SchemaNode>();
+  private readonly pathIndex = new Map<string, Path>();
+
+  rebuild(rootNode: SchemaNode): void {
+    this.nodeIndex.clear();
+    this.pathIndex.clear();
+    this.collectNodes(rootNode, EMPTY_PATH);
+  }
+
+  getNode(id: string): SchemaNode {
+    return this.nodeIndex.get(id) ?? NULL_NODE;
+  }
+
+  getPath(id: string): Path {
+    return this.pathIndex.get(id) ?? EMPTY_PATH;
+  }
+
+  countNodes(): number {
+    return this.nodeIndex.size;
+  }
+
+  nodeIds(): IterableIterator<string> {
+    return this.nodeIndex.keys();
+  }
+
+  private collectNodes(node: SchemaNode, path: Path): void {
+    this.nodeIndex.set(node.id(), node);
+    this.pathIndex.set(node.id(), path);
+
+    if (node.isObject()) {
+      for (const child of node.properties()) {
+        this.collectNodes(child, path.child(child.name()));
+      }
+    } else if (node.isArray()) {
+      this.collectNodes(node.items(), path.childItems());
+    }
+  }
+}

--- a/src/core/schema-tree/__tests__/SchemaTree.spec.ts
+++ b/src/core/schema-tree/__tests__/SchemaTree.spec.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaTree } from '../index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  NULL_NODE,
+} from '../../schema-node/index.js';
+import { jsonPointerToPath, EMPTY_PATH } from '../../path/index.js';
+
+describe('SchemaTree', () => {
+  describe('root', () => {
+    it('returns root node', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('name-id', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.root()).toBe(root);
+    });
+  });
+
+  describe('nodeById', () => {
+    it('returns node by id', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.nodeById('name-id')).toBe(nameNode);
+    });
+
+    it('returns root by id', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      expect(tree.nodeById('root-id')).toBe(root);
+    });
+
+    it('returns NULL_NODE for unknown id', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      expect(tree.nodeById('unknown')).toBe(NULL_NODE);
+    });
+
+    it('finds nested nodes', () => {
+      const cityNode = createStringNode('city-id', 'city');
+      const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+      const root = createObjectNode('root-id', 'root', [addressNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.nodeById('city-id')).toBe(cityNode);
+      expect(tree.nodeById('address-id')).toBe(addressNode);
+    });
+
+    it('finds array items', () => {
+      const itemNode = createStringNode('item-id', 'item');
+      const tagsNode = createArrayNode('tags-id', 'tags', itemNode);
+      const root = createObjectNode('root-id', 'root', [tagsNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.nodeById('item-id')).toBe(itemNode);
+    });
+  });
+
+  describe('pathOf', () => {
+    it('returns EMPTY_PATH for root', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      expect(tree.pathOf('root-id').isEmpty()).toBe(true);
+    });
+
+    it('returns path for direct child', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      const path = tree.pathOf('name-id');
+      expect(path.asJsonPointer()).toBe('/properties/name');
+    });
+
+    it('returns path for nested child', () => {
+      const cityNode = createStringNode('city-id', 'city');
+      const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+      const root = createObjectNode('root-id', 'root', [addressNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.pathOf('city-id').asJsonPointer()).toBe(
+        '/properties/address/properties/city',
+      );
+    });
+
+    it('returns path for array items', () => {
+      const itemNode = createStringNode('item-id', 'item');
+      const tagsNode = createArrayNode('tags-id', 'tags', itemNode);
+      const root = createObjectNode('root-id', 'root', [tagsNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.pathOf('item-id').asJsonPointer()).toBe(
+        '/properties/tags/items',
+      );
+    });
+
+    it('returns EMPTY_PATH for unknown id', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      expect(tree.pathOf('unknown').isEmpty()).toBe(true);
+    });
+  });
+
+  describe('nodeAt', () => {
+    it('returns root for empty path', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      expect(tree.nodeAt(EMPTY_PATH)).toBe(root);
+    });
+
+    it('returns node at path', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      const path = jsonPointerToPath('/properties/name');
+      expect(tree.nodeAt(path)).toBe(nameNode);
+    });
+
+    it('returns nested node at path', () => {
+      const cityNode = createStringNode('city-id', 'city');
+      const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+      const root = createObjectNode('root-id', 'root', [addressNode]);
+      const tree = createSchemaTree(root);
+
+      const path = jsonPointerToPath('/properties/address/properties/city');
+      expect(tree.nodeAt(path)).toBe(cityNode);
+    });
+
+    it('returns array items at path', () => {
+      const itemNode = createStringNode('item-id', 'item');
+      const tagsNode = createArrayNode('tags-id', 'tags', itemNode);
+      const root = createObjectNode('root-id', 'root', [tagsNode]);
+      const tree = createSchemaTree(root);
+
+      const path = jsonPointerToPath('/properties/tags/items');
+      expect(tree.nodeAt(path)).toBe(itemNode);
+    });
+
+    it('returns NULL_NODE for invalid path', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      const path = jsonPointerToPath('/properties/missing');
+      expect(tree.nodeAt(path)).toBe(NULL_NODE);
+    });
+
+    it('returns NULL_NODE for deeply invalid path', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      const path = jsonPointerToPath('/properties/missing/properties/nested');
+      expect(tree.nodeAt(path)).toBe(NULL_NODE);
+    });
+  });
+
+  describe('nodeIds', () => {
+    it('iterates over all node ids', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const ageNode = createNumberNode('age-id', 'age');
+      const root = createObjectNode('root-id', 'root', [nameNode, ageNode]);
+      const tree = createSchemaTree(root);
+
+      const ids = [...tree.nodeIds()];
+      expect(ids).toContain('root-id');
+      expect(ids).toContain('name-id');
+      expect(ids).toContain('age-id');
+      expect(ids).toHaveLength(3);
+    });
+
+    it('includes nested node ids', () => {
+      const cityNode = createStringNode('city-id', 'city');
+      const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+      const root = createObjectNode('root-id', 'root', [addressNode]);
+      const tree = createSchemaTree(root);
+
+      const ids = [...tree.nodeIds()];
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain('city-id');
+    });
+  });
+
+  describe('countNodes', () => {
+    it('returns total node count', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const ageNode = createNumberNode('age-id', 'age');
+      const root = createObjectNode('root-id', 'root', [nameNode, ageNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.countNodes()).toBe(3);
+    });
+
+    it('counts nested nodes', () => {
+      const cityNode = createStringNode('city-id', 'city');
+      const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+      const itemNode = createStringNode('item-id', 'item');
+      const tagsNode = createArrayNode('tags-id', 'tags', itemNode);
+      const root = createObjectNode('root-id', 'root', [addressNode, tagsNode]);
+      const tree = createSchemaTree(root);
+
+      expect(tree.countNodes()).toBe(5);
+    });
+  });
+
+  describe('clone', () => {
+    it('creates deep copy of tree', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      const cloned = tree.clone();
+
+      expect(cloned).not.toBe(tree);
+      expect(cloned.root()).not.toBe(root);
+      expect(cloned.root().id()).toBe('root-id');
+    });
+
+    it('cloned tree has same structure', () => {
+      const cityNode = createStringNode('city-id', 'city');
+      const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+      const root = createObjectNode('root-id', 'root', [addressNode]);
+      const tree = createSchemaTree(root);
+
+      const cloned = tree.clone();
+
+      expect(cloned.nodeById('city-id').id()).toBe('city-id');
+      expect(cloned.pathOf('city-id').asJsonPointer()).toBe(
+        '/properties/address/properties/city',
+      );
+    });
+
+    it('cloned tree nodes are independent', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      const cloned = tree.clone();
+
+      expect(cloned.nodeById('name-id')).not.toBe(nameNode);
+    });
+  });
+});
+
+describe('TreeNodeIndex', () => {
+  it('indexes complex tree structure', () => {
+    const innerItem = createObjectNode('inner-item-id', 'innerItem', [
+      createStringNode('value-id', 'value'),
+    ]);
+    const itemNode = createArrayNode('item-id', 'item', innerItem);
+    const listNode = createArrayNode('list-id', 'list', itemNode);
+    const root = createObjectNode('root-id', 'root', [listNode]);
+    const tree = createSchemaTree(root);
+
+    expect(tree.countNodes()).toBe(5);
+    expect(tree.pathOf('value-id').asJsonPointer()).toBe(
+      '/properties/list/items/items/properties/value',
+    );
+  });
+});

--- a/src/core/schema-tree/index.ts
+++ b/src/core/schema-tree/index.ts
@@ -1,0 +1,2 @@
+export type { SchemaTree } from './types.js';
+export { createSchemaTree } from './SchemaTreeImpl.js';

--- a/src/core/schema-tree/types.ts
+++ b/src/core/schema-tree/types.ts
@@ -1,0 +1,12 @@
+import type { SchemaNode } from '../schema-node/index.js';
+import type { Path } from '../path/index.js';
+
+export interface SchemaTree {
+  root(): SchemaNode;
+  nodeById(id: string): SchemaNode;
+  nodeAt(path: Path): SchemaNode;
+  pathOf(id: string): Path;
+  nodeIds(): IterableIterator<string>;
+  countNodes(): number;
+  clone(): SchemaTree;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a SchemaTree module for path-based navigation and fast ID lookups of schema nodes, with cloning to snapshot schema states. Exposes a createSchemaTree API and includes docs and tests.

- **New Features**
  - Path navigation: nodeAt(Path), pathOf(id).
  - Fast lookups and indexing: nodeById(id), nodeIds(), countNodes() via TreeNodeIndex.
  - clone() to create independent copies for base/current diffs.
  - Exported from core (core/index.ts) for public use.

<sup>Written for commit fd8ef3748dfa0c8bf58137177731be397e97085e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

