### PR TITLE
feat: schema-diff

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -12,20 +12,42 @@ Foundation layer for unified-toolkit. Contains base abstractions used by all oth
 | `validation` | Schema validation engine |
 | `schema-node` | Immutable schema node wrappers |
 | `schema-tree` | Tree structure with indexing |
+| `schema-diff` | Tree comparison, change collection |
 | `value-diff` | Field-level value comparison |
 
-## Installation
+## Exports
 
 ```typescript
-import {
-  noopAdapter,
-  EMPTY_PATH,
-  jsonPointerToPath,
-  createSchemaTree,
-  createObjectNode,
-  computeValueDiff,
-  FieldChangeType,
-} from '@revisium/schema-toolkit/core';
+// types
+export type { AnnotationType, AnnotationsMap } from '@revisium/schema-toolkit/core';
+
+// reactivity
+export { noopAdapter } from '@revisium/schema-toolkit/core';
+export type { ReactivityAdapter } from '@revisium/schema-toolkit/core';
+
+// path
+export { EMPTY_PATH, createPath, jsonPointerToPath } from '@revisium/schema-toolkit/core';
+export type { Path, PathSegment } from '@revisium/schema-toolkit/core';
+
+// validation
+export { ValidationEngine, ValidatorRegistry, createValidationEngine } from '@revisium/schema-toolkit/core';
+export type { Validator, ValidatorRule, Diagnostic } from '@revisium/schema-toolkit/core';
+
+// schema-node
+export { createObjectNode, createArrayNode, createStringNode, createNumberNode, createBooleanNode, createRefNode, NULL_NODE } from '@revisium/schema-toolkit/core';
+export type { SchemaNode, NodeType, NodeMetadata, Formula } from '@revisium/schema-toolkit/core';
+
+// schema-tree
+export { createSchemaTree } from '@revisium/schema-toolkit/core';
+export type { SchemaTree } from '@revisium/schema-toolkit/core';
+
+// schema-diff
+export { SchemaDiff, ChangeCollector, ChangeCoalescer, NodePathIndex, areNodesEqual } from '@revisium/schema-toolkit/core';
+export type { RawChange, CoalescedChanges, ChangeType } from '@revisium/schema-toolkit/core';
+
+// value-diff
+export { computeValueDiff, FieldChangeType } from '@revisium/schema-toolkit/core';
+export type { FieldChange } from '@revisium/schema-toolkit/core';
 ```
 
 ## Architecture
@@ -38,6 +60,7 @@ core/
 ├── validation/   # Depends on types
 ├── schema-node/  # Depends on path
 ├── schema-tree/  # Depends on schema-node, path
+├── schema-diff/  # Depends on schema-tree, schema-node, path
 └── value-diff/   # No dependencies
 ```
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,3 +5,4 @@ export * from './validation/index.js';
 export * from './schema-node/index.js';
 export * from './schema-tree/index.js';
 export * from './value-diff/index.js';
+export * from './schema-diff/index.js';

--- a/src/core/schema-diff/ChangeCoalescer.ts
+++ b/src/core/schema-diff/ChangeCoalescer.ts
@@ -1,0 +1,145 @@
+import type { SchemaTree } from '../schema-tree/index.js';
+import type { Path } from '../path/index.js';
+import type { RawChange, CoalescedChanges } from './types.js';
+import { NodePathIndex } from './NodePathIndex.js';
+
+export class ChangeCoalescer {
+  constructor(
+    private readonly currentTree: SchemaTree,
+    private readonly index: NodePathIndex,
+  ) {}
+
+  coalesce(changes: readonly RawChange[]): CoalescedChanges {
+    const moved: RawChange[] = [];
+    const added: RawChange[] = [];
+    const removed: RawChange[] = [];
+    const modified: RawChange[] = [];
+
+    const movedPaths = this.getMovedPaths(changes);
+
+    for (const change of changes) {
+      if (this.isNestedChange(change, changes, movedPaths)) {
+        continue;
+      }
+
+      switch (change.type) {
+        case 'moved':
+          moved.push(change);
+          break;
+        case 'added':
+          added.push(change);
+          break;
+        case 'removed':
+          removed.push(change);
+          break;
+        case 'modified':
+          modified.push(change);
+          break;
+      }
+    }
+
+    return { moved, added, removed, modified };
+  }
+
+  private getMovedPaths(changes: readonly RawChange[]): Set<string> {
+    const paths = new Set<string>();
+
+    for (const change of changes) {
+      if (change.type === 'moved' && change.baseNode) {
+        const basePath = this.index.getBasePath(change.baseNode.id());
+        if (basePath) {
+          paths.add(basePath.asJsonPointer());
+        }
+      }
+    }
+
+    return paths;
+  }
+
+  private isNestedChange(
+    change: RawChange,
+    allChanges: readonly RawChange[],
+    movedPaths: Set<string>,
+  ): boolean {
+    const node = change.currentNode ?? change.baseNode;
+    if (!node) return false;
+
+    const path = this.getChangePath(change);
+    if (!path) return false;
+
+    if (this.hasParentChange(change, allChanges, path)) {
+      return true;
+    }
+
+    if (this.isAffectedByMove(change, movedPaths)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private getChangePath(change: RawChange): Path | null {
+    if (change.type === 'removed' && change.baseNode) {
+      return this.index.getBasePath(change.baseNode.id()) ?? null;
+    }
+
+    if (change.currentNode) {
+      return this.currentTree.pathOf(change.currentNode.id());
+    }
+
+    return null;
+  }
+
+  private hasParentChange(
+    change: RawChange,
+    allChanges: readonly RawChange[],
+    path: Path,
+  ): boolean {
+    for (const other of allChanges) {
+      if (other === change) continue;
+      if (other.type === 'modified') continue;
+
+      const otherPath = this.getChangePath(other);
+      if (!otherPath) continue;
+
+      if (path.isChildOf(otherPath)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private isAffectedByMove(
+    change: RawChange,
+    movedPaths: Set<string>,
+  ): boolean {
+    if (change.type === 'moved') {
+      return false;
+    }
+
+    if (change.type === 'modified' && change.baseNode) {
+      const basePath = this.index.getBasePath(change.baseNode.id());
+      if (basePath) {
+        for (const movedPath of movedPaths) {
+          if (
+            basePath.asJsonPointer().startsWith(movedPath + '/') &&
+            basePath.asJsonPointer() !== movedPath
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+}
+
+export function coalesceChanges(
+  changes: readonly RawChange[],
+  currentTree: SchemaTree,
+  index: NodePathIndex,
+): CoalescedChanges {
+  return new ChangeCoalescer(currentTree, index).coalesce(changes);
+}

--- a/src/core/schema-diff/ChangeCollector.ts
+++ b/src/core/schema-diff/ChangeCollector.ts
@@ -1,0 +1,101 @@
+import type { SchemaTree } from '../schema-tree/index.js';
+import type { RawChange } from './types.js';
+import { NodePathIndex } from './NodePathIndex.js';
+import { areNodesEqual } from './SchemaComparator.js';
+
+export class ChangeCollector {
+  constructor(
+    private readonly baseTree: SchemaTree,
+    private readonly currentTree: SchemaTree,
+    private readonly index: NodePathIndex,
+  ) {}
+
+  collect(): RawChange[] {
+    const changes: RawChange[] = [];
+
+    this.collectFromCurrentTree(changes);
+    this.collectRemovedNodes(changes);
+
+    return changes;
+  }
+
+  private collectFromCurrentTree(changes: RawChange[]): void {
+    for (const nodeId of this.currentTree.nodeIds()) {
+      const currentNode = this.currentTree.nodeById(nodeId);
+
+      if (this.index.isReplacement(nodeId)) {
+        const originalId = this.index.getOriginalNodeId(nodeId);
+        if (originalId) {
+          const baseNode = this.baseTree.nodeById(originalId);
+          changes.push({
+            type: 'modified',
+            baseNode,
+            currentNode,
+          });
+        }
+        continue;
+      }
+
+      const basePath = this.index.getBasePath(nodeId);
+      if (!basePath) {
+        changes.push({
+          type: 'added',
+          baseNode: null,
+          currentNode,
+        });
+        continue;
+      }
+
+      const currentPath = this.currentTree.pathOf(nodeId);
+      const baseNode = this.baseTree.nodeById(nodeId);
+
+      if (!basePath.equals(currentPath)) {
+        changes.push({
+          type: 'moved',
+          baseNode,
+          currentNode,
+        });
+
+        if (!areNodesEqual(baseNode, currentNode)) {
+          changes.push({
+            type: 'modified',
+            baseNode,
+            currentNode,
+          });
+        }
+      } else if (!areNodesEqual(baseNode, currentNode)) {
+        changes.push({
+          type: 'modified',
+          baseNode,
+          currentNode,
+        });
+      }
+    }
+  }
+
+  private collectRemovedNodes(changes: RawChange[]): void {
+    for (const nodeId of this.baseTree.nodeIds()) {
+      if (this.index.getReplacementNodeId(nodeId)) {
+        continue;
+      }
+
+      const currentNode = this.currentTree.nodeById(nodeId);
+      if (currentNode.isNull()) {
+        const baseNode = this.baseTree.nodeById(nodeId);
+        changes.push({
+          type: 'removed',
+          baseNode,
+          currentNode: null,
+        });
+      }
+    }
+  }
+}
+
+export function collectChanges(
+  baseTree: SchemaTree,
+  currentTree: SchemaTree,
+  index: NodePathIndex,
+): RawChange[] {
+  return new ChangeCollector(baseTree, currentTree, index).collect();
+}

--- a/src/core/schema-diff/NodePathIndex.ts
+++ b/src/core/schema-diff/NodePathIndex.ts
@@ -1,0 +1,51 @@
+import type { SchemaTree } from '../schema-tree/index.js';
+import type { Path } from '../path/index.js';
+
+export class NodePathIndex {
+  private readonly _basePaths = new Map<string, Path>();
+  private readonly _replacements = new Map<string, string>();
+
+  constructor(baseTree: SchemaTree) {
+    for (const nodeId of baseTree.nodeIds()) {
+      this._basePaths.set(nodeId, baseTree.pathOf(nodeId));
+    }
+  }
+
+  hasBasePath(nodeId: string): boolean {
+    return this._basePaths.has(nodeId);
+  }
+
+  getBasePath(nodeId: string): Path | undefined {
+    return this._basePaths.get(nodeId);
+  }
+
+  trackReplacement(oldNodeId: string, newNodeId: string): void {
+    this._replacements.set(oldNodeId, newNodeId);
+  }
+
+  getReplacementNodeId(oldNodeId: string): string | undefined {
+    return this._replacements.get(oldNodeId);
+  }
+
+  getOriginalNodeId(newNodeId: string): string | undefined {
+    for (const [oldId, newId] of this._replacements) {
+      if (newId === newNodeId) {
+        return oldId;
+      }
+    }
+    return undefined;
+  }
+
+  isReplacement(nodeId: string): boolean {
+    for (const newId of this._replacements.values()) {
+      if (newId === nodeId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  get replacements(): ReadonlyMap<string, string> {
+    return this._replacements;
+  }
+}

--- a/src/core/schema-diff/README.md
+++ b/src/core/schema-diff/README.md
@@ -1,0 +1,87 @@
+# Schema Diff Module
+
+Compares two SchemaTree instances and collects changes. Outputs node-based changes (not JSON patches).
+
+## API
+
+```typescript
+type ChangeType = 'added' | 'removed' | 'moved' | 'modified';
+
+interface RawChange {
+  type: ChangeType;
+  baseNode: SchemaNode | null;
+  currentNode: SchemaNode | null;
+}
+
+interface CoalescedChanges {
+  moved: RawChange[];
+  added: RawChange[];
+  removed: RawChange[];
+  modified: RawChange[];
+}
+
+class SchemaDiff {
+  constructor(currentTree: SchemaTree);
+
+  isDirty(): boolean;
+  collectChanges(): RawChange[];
+  coalesceChanges(changes?: RawChange[]): CoalescedChanges;
+  trackReplacement(oldNodeId: string, newNodeId: string): void;
+  markAsSaved(): void;
+
+  get baseTree(): SchemaTree;
+  get currentTree(): SchemaTree;
+  get index(): NodePathIndex;
+}
+```
+
+## Usage
+
+```typescript
+import { SchemaDiff } from '@revisium/schema-toolkit/core';
+
+const tree = createSchemaTree(rootNode);
+const diff = new SchemaDiff(tree);
+
+// Check if there are changes
+if (diff.isDirty()) {
+  // Get raw changes (includes nested)
+  const rawChanges = diff.collectChanges();
+
+  // Get top-level changes only (nested filtered out)
+  const coalesced = diff.coalesceChanges(rawChanges);
+
+  console.log('Added:', coalesced.added.length);
+  console.log('Removed:', coalesced.removed.length);
+  console.log('Moved:', coalesced.moved.length);
+  console.log('Modified:', coalesced.modified.length);
+}
+
+// After saving to backend
+diff.markAsSaved();
+```
+
+## Type Changes
+
+Track node type changes via replacement:
+
+```typescript
+const oldNodeId = stringNode.id();
+// Replace string node with number node
+const newNodeId = numberNode.id();
+
+diff.trackReplacement(oldNodeId, newNodeId);
+
+const changes = diff.collectChanges();
+// Will have 'modified' change with baseNode (string) and currentNode (number)
+```
+
+## Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `SchemaDiff` | Main facade, manages base/current trees |
+| `ChangeCollector` | Traverses trees, collects all raw changes |
+| `ChangeCoalescer` | Filters to top-level changes only |
+| `NodePathIndex` | Tracks base paths and node replacements |
+| `SchemaComparator` | Deep equality comparison of nodes |

--- a/src/core/schema-diff/SchemaComparator.ts
+++ b/src/core/schema-diff/SchemaComparator.ts
@@ -1,0 +1,88 @@
+import type { SchemaNode } from '../schema-node/index.js';
+
+export function areNodesEqual(a: SchemaNode, b: SchemaNode): boolean {
+  if (a.nodeType() !== b.nodeType()) {
+    return false;
+  }
+
+  if (a.name() !== b.name()) {
+    return false;
+  }
+
+  if (!areMetadataEqual(a, b)) {
+    return false;
+  }
+
+  if (a.isPrimitive()) {
+    return arePrimitivesEqual(a, b);
+  }
+
+  if (a.isObject()) {
+    return areObjectsEqual(a, b);
+  }
+
+  if (a.isArray()) {
+    return areArraysEqual(a, b);
+  }
+
+  if (a.isRef()) {
+    return a.ref() === b.ref();
+  }
+
+  return a.isNull() && b.isNull();
+}
+
+function areMetadataEqual(a: SchemaNode, b: SchemaNode): boolean {
+  const metaA = a.metadata();
+  const metaB = b.metadata();
+
+  return (
+    metaA.title === metaB.title &&
+    metaA.description === metaB.description &&
+    metaA.deprecated === metaB.deprecated
+  );
+}
+
+function arePrimitivesEqual(a: SchemaNode, b: SchemaNode): boolean {
+  if (a.defaultValue() !== b.defaultValue()) {
+    return false;
+  }
+
+  const formulaA = a.formula();
+  const formulaB = b.formula();
+
+  if (formulaA === undefined && formulaB === undefined) {
+    return a.foreignKey() === b.foreignKey();
+  }
+
+  if (formulaA === undefined || formulaB === undefined) {
+    return false;
+  }
+
+  return (
+    formulaA.expression === formulaB.expression &&
+    a.foreignKey() === b.foreignKey()
+  );
+}
+
+function areObjectsEqual(a: SchemaNode, b: SchemaNode): boolean {
+  const propsA = a.properties();
+  const propsB = b.properties();
+
+  if (propsA.length !== propsB.length) {
+    return false;
+  }
+
+  for (const propA of propsA) {
+    const propB = propsB.find((p) => p.name() === propA.name());
+    if (!propB || !areNodesEqual(propA, propB)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function areArraysEqual(a: SchemaNode, b: SchemaNode): boolean {
+  return areNodesEqual(a.items(), b.items());
+}

--- a/src/core/schema-diff/SchemaDiff.ts
+++ b/src/core/schema-diff/SchemaDiff.ts
@@ -1,0 +1,52 @@
+import type { SchemaTree } from '../schema-tree/index.js';
+import type { RawChange, CoalescedChanges } from './types.js';
+import { NodePathIndex } from './NodePathIndex.js';
+import { collectChanges } from './ChangeCollector.js';
+import { coalesceChanges } from './ChangeCoalescer.js';
+
+export class SchemaDiff {
+  private _baseTree: SchemaTree;
+  private readonly _currentTree: SchemaTree;
+  private _index: NodePathIndex;
+
+  constructor(currentTree: SchemaTree) {
+    this._currentTree = currentTree;
+    this._baseTree = currentTree.clone();
+    this._index = new NodePathIndex(this._baseTree);
+  }
+
+  get baseTree(): SchemaTree {
+    return this._baseTree;
+  }
+
+  get currentTree(): SchemaTree {
+    return this._currentTree;
+  }
+
+  get index(): NodePathIndex {
+    return this._index;
+  }
+
+  isDirty(): boolean {
+    const changes = this.collectChanges();
+    return changes.length > 0;
+  }
+
+  collectChanges(): RawChange[] {
+    return collectChanges(this._baseTree, this._currentTree, this._index);
+  }
+
+  coalesceChanges(changes?: readonly RawChange[]): CoalescedChanges {
+    const rawChanges = changes ?? this.collectChanges();
+    return coalesceChanges(rawChanges, this._currentTree, this._index);
+  }
+
+  trackReplacement(oldNodeId: string, newNodeId: string): void {
+    this._index.trackReplacement(oldNodeId, newNodeId);
+  }
+
+  markAsSaved(): void {
+    this._baseTree = this._currentTree.clone();
+    this._index = new NodePathIndex(this._baseTree);
+  }
+}

--- a/src/core/schema-diff/__tests__/ChangeCoalescer.spec.ts
+++ b/src/core/schema-diff/__tests__/ChangeCoalescer.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from '@jest/globals';
+import { ChangeCoalescer } from '../ChangeCoalescer.js';
+import { NodePathIndex } from '../NodePathIndex.js';
+import { collectChanges } from '../ChangeCollector.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import {
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+} from '../../schema-node/index.js';
+
+describe('ChangeCoalescer', () => {
+  describe('filtering nested changes', () => {
+    it('returns single add for parent when adding nested structure', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('existing', 'existing'),
+      ]);
+      const parentNode = createObjectNode('parent', 'parent', [
+        createStringNode('child1', 'child1'),
+        createStringNode('child2', 'child2'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('existing', 'existing'),
+        parentNode,
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      expect(coalesced.added).toHaveLength(1);
+      expect(coalesced.added[0].currentNode?.name()).toBe('parent');
+    });
+
+    it('returns single remove for parent when removing nested structure', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createObjectNode('parent', 'parent', [
+          createStringNode('child1', 'child1'),
+          createObjectNode('nested', 'nested', [
+            createStringNode('grandchild', 'grandchild'),
+          ]),
+        ]),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', []);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      expect(coalesced.removed).toHaveLength(1);
+      expect(coalesced.removed[0].baseNode?.name()).toBe('parent');
+    });
+  });
+
+  describe('move coalescing', () => {
+    it('returns single move for renamed parent with children', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createObjectNode('old-parent', 'oldParent', [
+          createStringNode('child1', 'child1'),
+          createStringNode('child2', 'child2'),
+        ]),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createObjectNode('old-parent', 'newParent', [
+          createStringNode('child1', 'child1'),
+          createStringNode('child2', 'child2'),
+        ]),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      expect(coalesced.moved).toHaveLength(1);
+      expect(coalesced.moved[0].currentNode?.name()).toBe('newParent');
+    });
+  });
+
+  describe('independent changes', () => {
+    it('preserves multiple independent top-level changes', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('fieldA', 'fieldA', { defaultValue: 'old' }),
+        createStringNode('fieldB', 'fieldB'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('fieldA', 'fieldA', { defaultValue: 'new' }),
+        createNumberNode('new-field', 'newField'),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      const fieldAModified = coalesced.modified.find(
+        (c) => c.currentNode?.name() === 'fieldA',
+      );
+      expect(fieldAModified).toBeDefined();
+
+      expect(coalesced.added).toHaveLength(1);
+      expect(coalesced.removed).toHaveLength(1);
+    });
+  });
+
+  describe('add then remove same node', () => {
+    it('results in no changes when node is added and then removed', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('existing', 'existing'),
+      ]);
+
+      const baseTree = createSchemaTree(root);
+      const currentTree = baseTree.clone();
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      expect(coalesced.added).toHaveLength(0);
+      expect(coalesced.removed).toHaveLength(0);
+      expect(coalesced.moved).toHaveLength(0);
+      expect(coalesced.modified).toHaveLength(0);
+    });
+  });
+});

--- a/src/core/schema-diff/__tests__/ChangeCollector.spec.ts
+++ b/src/core/schema-diff/__tests__/ChangeCollector.spec.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from '@jest/globals';
+import { ChangeCollector } from '../ChangeCollector.js';
+import { NodePathIndex } from '../NodePathIndex.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import {
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+  createArrayNode,
+} from '../../schema-node/index.js';
+
+describe('ChangeCollector', () => {
+  describe('no changes', () => {
+    it('returns empty array when trees are identical', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { defaultValue: 'test' }),
+      ]);
+      const baseTree = createSchemaTree(root);
+      const currentTree = baseTree.clone();
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      expect(changes).toHaveLength(0);
+    });
+  });
+
+  describe('added nodes', () => {
+    it('detects added top-level field with parent modified', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+        createStringNode('new-field', 'newField'),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const addedChanges = changes.filter((c) => c.type === 'added');
+      expect(addedChanges).toHaveLength(1);
+      expect(addedChanges[0].currentNode?.name()).toBe('newField');
+      expect(addedChanges[0].baseNode).toBeNull();
+    });
+
+    it('detects added nested field with parent modified', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createObjectNode('nested', 'nested', []),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createObjectNode('nested', 'nested', [
+          createStringNode('new-field', 'newField'),
+        ]),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const addedChanges = changes.filter((c) => c.type === 'added');
+      expect(addedChanges).toHaveLength(1);
+      expect(addedChanges[0].currentNode?.name()).toBe('newField');
+    });
+  });
+
+  describe('removed nodes', () => {
+    it('detects removed top-level field with parent modified', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+        createStringNode('age', 'age'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const removedChanges = changes.filter((c) => c.type === 'removed');
+      expect(removedChanges).toHaveLength(1);
+      expect(removedChanges[0].baseNode?.name()).toBe('age');
+      expect(removedChanges[0].currentNode).toBeNull();
+    });
+
+    it('detects removed nested field with parent modified', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createObjectNode('nested', 'nested', [
+          createStringNode('field', 'field'),
+        ]),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createObjectNode('nested', 'nested', []),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const removedChanges = changes.filter((c) => c.type === 'removed');
+      expect(removedChanges).toHaveLength(1);
+      expect(removedChanges[0].baseNode?.name()).toBe('field');
+    });
+  });
+
+  describe('modified nodes', () => {
+    it('detects modified default value', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { defaultValue: 'old' }),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { defaultValue: 'new' }),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const fieldChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'name',
+      );
+      expect(fieldChange).toBeDefined();
+      expect(fieldChange?.baseNode?.defaultValue()).toBe('old');
+      expect(fieldChange?.currentNode?.defaultValue()).toBe('new');
+    });
+
+    it('detects modified metadata', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { metadata: { description: 'new' } }),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const fieldChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'name',
+      );
+      expect(fieldChange).toBeDefined();
+    });
+  });
+
+  describe('moved nodes (renamed)', () => {
+    it('detects renamed field as moved plus modified', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'oldName'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'newName'),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const movedChanges = changes.filter((c) => c.type === 'moved');
+      expect(movedChanges).toHaveLength(1);
+      expect(movedChanges[0].baseNode?.name()).toBe('oldName');
+      expect(movedChanges[0].currentNode?.name()).toBe('newName');
+
+      const modifiedChanges = changes.filter(
+        (c) => c.type === 'modified' && c.currentNode?.name() === 'newName',
+      );
+      expect(modifiedChanges).toHaveLength(1);
+    });
+  });
+
+  describe('type changes via replacement', () => {
+    it('detects type change when tracked as replacement', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('old-field', 'field'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createNumberNode('new-field', 'field'),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+      index.trackReplacement('old-field', 'new-field');
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const typeChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'field',
+      );
+      expect(typeChange).toBeDefined();
+      expect(typeChange?.baseNode?.nodeType()).toBe('string');
+      expect(typeChange?.currentNode?.nodeType()).toBe('number');
+    });
+  });
+
+  describe('array items', () => {
+    it('detects modified array items', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createArrayNode(
+          'items',
+          'items',
+          createStringNode('item', 'item', { defaultValue: 'old' }),
+        ),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createArrayNode(
+          'items',
+          'items',
+          createStringNode('item', 'item', { defaultValue: 'new' }),
+        ),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const itemChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'item',
+      );
+      expect(itemChange).toBeDefined();
+    });
+  });
+});

--- a/src/core/schema-diff/__tests__/NodePathIndex.spec.ts
+++ b/src/core/schema-diff/__tests__/NodePathIndex.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { NodePathIndex } from '../NodePathIndex.js';
+import { createTree, stringNode, resetIdCounter } from './test-helpers.js';
+
+beforeEach(() => {
+  resetIdCounter();
+});
+
+describe('NodePathIndex', () => {
+  describe('hasBasePath', () => {
+    it('returns true for nodes in base tree', () => {
+      const node = stringNode('name');
+      const tree = createTree([node]);
+      const index = new NodePathIndex(tree);
+
+      expect(index.hasBasePath(node.id())).toBe(true);
+    });
+
+    it('returns false for unknown nodes', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      expect(index.hasBasePath('unknown-id')).toBe(false);
+    });
+  });
+
+  describe('getBasePath', () => {
+    it('returns path for known node', () => {
+      const node = stringNode('name');
+      const tree = createTree([node]);
+      const index = new NodePathIndex(tree);
+
+      const path = index.getBasePath(node.id());
+      expect(path).toBeDefined();
+      expect(path?.asSimple()).toBe('name');
+    });
+
+    it('returns undefined for unknown node', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      expect(index.getBasePath('unknown-id')).toBeUndefined();
+    });
+  });
+
+  describe('trackReplacement', () => {
+    it('tracks replacement mapping', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      index.trackReplacement('old-id', 'new-id');
+
+      expect(index.getReplacementNodeId('old-id')).toBe('new-id');
+    });
+  });
+
+  describe('getOriginalNodeId', () => {
+    it('returns original id for replacement', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      index.trackReplacement('old-id', 'new-id');
+
+      expect(index.getOriginalNodeId('new-id')).toBe('old-id');
+    });
+
+    it('returns undefined when not a replacement', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      expect(index.getOriginalNodeId('unknown-id')).toBeUndefined();
+    });
+  });
+
+  describe('isReplacement', () => {
+    it('returns true for replacement node', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      index.trackReplacement('old-id', 'new-id');
+
+      expect(index.isReplacement('new-id')).toBe(true);
+    });
+
+    it('returns false for non-replacement', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      expect(index.isReplacement('some-id')).toBe(false);
+    });
+  });
+
+  describe('replacements getter', () => {
+    it('returns empty map initially', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      expect(index.replacements.size).toBe(0);
+    });
+
+    it('returns tracked replacements', () => {
+      const tree = createTree([stringNode('name')]);
+      const index = new NodePathIndex(tree);
+
+      index.trackReplacement('old1', 'new1');
+      index.trackReplacement('old2', 'new2');
+
+      expect(index.replacements.size).toBe(2);
+      expect(index.replacements.get('old1')).toBe('new1');
+      expect(index.replacements.get('old2')).toBe('new2');
+    });
+  });
+});

--- a/src/core/schema-diff/__tests__/SchemaComparator.spec.ts
+++ b/src/core/schema-diff/__tests__/SchemaComparator.spec.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { areNodesEqual } from '../SchemaComparator.js';
+import {
+  stringNode,
+  numberNode,
+  objectNode,
+  arrayNode,
+  refNode,
+  stringNodeWithFormula,
+  nullNode,
+  resetIdCounter,
+} from './test-helpers.js';
+
+beforeEach(() => {
+  resetIdCounter();
+});
+
+describe('SchemaComparator', () => {
+  describe('areNodesEqual', () => {
+    describe('primitives', () => {
+      it('returns true for identical string nodes', () => {
+        const a = stringNode('name', 'default');
+        const b = stringNode('name', 'default');
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when default values differ', () => {
+        const a = stringNode('name', 'a');
+        const b = stringNode('name', 'b');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when types differ', () => {
+        const a = stringNode('field');
+        const b = numberNode('field');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when names differ', () => {
+        const a = stringNode('name');
+        const b = stringNode('title');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+
+    describe('metadata', () => {
+      it('returns true when metadata is identical', () => {
+        const a = stringNode('name', '', { description: 'desc' });
+        const b = stringNode('name', '', { description: 'desc' });
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when description differs', () => {
+        const a = stringNode('name', '', { description: 'old' });
+        const b = stringNode('name', '', { description: 'new' });
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when deprecated differs', () => {
+        const a = stringNode('name', '', {});
+        const b = stringNode('name', '', { deprecated: true });
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when title differs', () => {
+        const a = stringNode('name', '', { title: 'A' });
+        const b = stringNode('name', '', { title: 'B' });
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+
+    describe('objects', () => {
+      it('returns true for empty objects', () => {
+        const a = objectNode('obj');
+        const b = objectNode('obj');
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns true for objects with same children', () => {
+        const a = objectNode('obj', [stringNode('name'), numberNode('age')]);
+        const b = objectNode('obj', [stringNode('name'), numberNode('age')]);
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when child count differs', () => {
+        const a = objectNode('obj', [stringNode('name')]);
+        const b = objectNode('obj', [stringNode('name'), numberNode('age')]);
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when child differs', () => {
+        const a = objectNode('obj', [stringNode('name', 'a')]);
+        const b = objectNode('obj', [stringNode('name', 'b')]);
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+
+    describe('arrays', () => {
+      it('returns true for arrays with same items', () => {
+        const a = arrayNode('arr', stringNode('item'));
+        const b = arrayNode('arr', stringNode('item'));
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when items differ', () => {
+        const a = arrayNode('arr', stringNode('item'));
+        const b = arrayNode('arr', numberNode('item'));
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+
+    describe('refs', () => {
+      it('returns true for refs with same reference', () => {
+        const a = refNode('field', 'File');
+        const b = refNode('field', 'File');
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when ref differs', () => {
+        const a = refNode('field', 'File');
+        const b = refNode('field', 'Image');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+
+    describe('null nodes', () => {
+      it('returns true for two null nodes', () => {
+        const a = nullNode();
+        const b = nullNode();
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+    });
+
+    describe('formulas', () => {
+      it('returns true for same formula expression', () => {
+        const a = stringNodeWithFormula('computed', 'a + b');
+        const b = stringNodeWithFormula('computed', 'a + b');
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when formula expressions differ', () => {
+        const a = stringNodeWithFormula('computed', 'a + b');
+        const b = stringNodeWithFormula('computed', 'a - b');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when one has formula and other does not', () => {
+        const a = stringNodeWithFormula('field', 'a + b');
+        const b = stringNode('field');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+
+      it('returns false when other has formula and first does not', () => {
+        const a = stringNode('field');
+        const b = stringNodeWithFormula('field', 'a + b');
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+
+    describe('nested structures', () => {
+      it('returns true for identical nested structure', () => {
+        const a = objectNode('root', [
+          objectNode('nested', [stringNode('deep')]),
+        ]);
+        const b = objectNode('root', [
+          objectNode('nested', [stringNode('deep')]),
+        ]);
+
+        expect(areNodesEqual(a, b)).toBe(true);
+      });
+
+      it('returns false when deep child differs', () => {
+        const a = objectNode('root', [
+          objectNode('nested', [stringNode('deep', 'a')]),
+        ]);
+        const b = objectNode('root', [
+          objectNode('nested', [stringNode('deep', 'b')]),
+        ]);
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/core/schema-diff/__tests__/SchemaDiff.spec.ts
+++ b/src/core/schema-diff/__tests__/SchemaDiff.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from '@jest/globals';
+import { SchemaDiff } from '../SchemaDiff.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import {
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+} from '../../schema-node/index.js';
+
+describe('SchemaDiff', () => {
+  describe('isDirty', () => {
+    it('returns false when no changes', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+      const diff = new SchemaDiff(tree);
+
+      expect(diff.isDirty()).toBe(false);
+    });
+
+    it('returns false when trees are clones', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+        createNumberNode('age', 'age'),
+      ]);
+      const tree = createSchemaTree(root);
+      const diff = new SchemaDiff(tree);
+
+      expect(diff.isDirty()).toBe(false);
+    });
+  });
+
+  describe('markAsSaved', () => {
+    it('clears dirty state', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+      const diff = new SchemaDiff(tree);
+
+      expect(diff.isDirty()).toBe(false);
+
+      diff.markAsSaved();
+
+      expect(diff.isDirty()).toBe(false);
+    });
+  });
+
+  describe('collectChanges', () => {
+    it('returns all raw changes', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+        createStringNode('age', 'age'),
+      ]);
+      const baseTree = createSchemaTree(baseRoot);
+      const diff = new SchemaDiff(baseTree);
+
+      const changes = diff.collectChanges();
+      expect(changes).toHaveLength(0);
+    });
+  });
+
+  describe('coalesceChanges', () => {
+    it('returns coalesced changes grouped by type', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const baseTree = createSchemaTree(baseRoot);
+      const diff = new SchemaDiff(baseTree);
+
+      const coalesced = diff.coalesceChanges();
+
+      expect(coalesced.added).toHaveLength(0);
+      expect(coalesced.removed).toHaveLength(0);
+      expect(coalesced.moved).toHaveLength(0);
+      expect(coalesced.modified).toHaveLength(0);
+    });
+  });
+
+  describe('trackReplacement', () => {
+    it('tracks type changes via replacement', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('old-id', 'field'),
+      ]);
+      const baseTree = createSchemaTree(baseRoot);
+      const diff = new SchemaDiff(baseTree);
+
+      diff.trackReplacement('old-id', 'new-id');
+
+      expect(diff.index.getReplacementNodeId('old-id')).toBe('new-id');
+    });
+  });
+
+  describe('baseTree and currentTree', () => {
+    it('provides access to both trees', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+      const diff = new SchemaDiff(tree);
+
+      expect(diff.baseTree).not.toBe(diff.currentTree);
+      expect(diff.baseTree.root().id()).toBe('root');
+      expect(diff.currentTree.root().id()).toBe('root');
+    });
+
+    it('baseTree is independent clone of currentTree', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+      const diff = new SchemaDiff(tree);
+
+      expect(diff.baseTree.root()).not.toBe(diff.currentTree.root());
+    });
+  });
+});

--- a/src/core/schema-diff/__tests__/test-helpers.ts
+++ b/src/core/schema-diff/__tests__/test-helpers.ts
@@ -1,0 +1,94 @@
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+  createRefNode,
+  NULL_NODE,
+} from '../../schema-node/index.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import type { SchemaTree } from '../../schema-tree/index.js';
+import type { SchemaNode, NodeMetadata, Formula } from '../../schema-node/index.js';
+import { SchemaDiff } from '../SchemaDiff.js';
+
+let idCounter = 0;
+
+export function resetIdCounter(): void {
+  idCounter = 0;
+}
+
+function nextId(): string {
+  return `node-${++idCounter}`;
+}
+
+export function stringNode(
+  name: string,
+  defaultValue = '',
+  metadata: NodeMetadata = {},
+): SchemaNode {
+  return createStringNode(nextId(), name, { defaultValue, metadata });
+}
+
+export function numberNode(
+  name: string,
+  defaultValue = 0,
+  metadata: NodeMetadata = {},
+): SchemaNode {
+  return createNumberNode(nextId(), name, { defaultValue, metadata });
+}
+
+export function booleanNode(
+  name: string,
+  defaultValue = false,
+  metadata: NodeMetadata = {},
+): SchemaNode {
+  return createBooleanNode(nextId(), name, { defaultValue, metadata });
+}
+
+export function objectNode(
+  name: string,
+  children: SchemaNode[] = [],
+  metadata: NodeMetadata = {},
+): SchemaNode {
+  return createObjectNode(nextId(), name, children, metadata);
+}
+
+export function arrayNode(
+  name: string,
+  items: SchemaNode,
+  metadata: NodeMetadata = {},
+): SchemaNode {
+  return createArrayNode(nextId(), name, items, metadata);
+}
+
+export function refNode(name: string, ref: string): SchemaNode {
+  return createRefNode(nextId(), name, ref);
+}
+
+export function nullNode(): SchemaNode {
+  return NULL_NODE;
+}
+
+export function stringNodeWithFormula(
+  name: string,
+  expression: string,
+  defaultValue = '',
+): SchemaNode {
+  const formula: Formula = { version: 1, expression };
+  return createStringNode(nextId(), name, { defaultValue, formula });
+}
+
+export function createTree(children: SchemaNode[]): SchemaTree {
+  const root = createObjectNode(nextId(), 'root', children);
+  return createSchemaTree(root);
+}
+
+export function createTreeAndDiff(children: SchemaNode[]): {
+  tree: SchemaTree;
+  diff: SchemaDiff;
+} {
+  const tree = createTree(children);
+  const diff = new SchemaDiff(tree);
+  return { tree, diff };
+}

--- a/src/core/schema-diff/index.ts
+++ b/src/core/schema-diff/index.ts
@@ -1,0 +1,6 @@
+export type { RawChange, CoalescedChanges, ChangeType } from './types.js';
+export { SchemaDiff } from './SchemaDiff.js';
+export { NodePathIndex } from './NodePathIndex.js';
+export { ChangeCollector, collectChanges } from './ChangeCollector.js';
+export { ChangeCoalescer, coalesceChanges } from './ChangeCoalescer.js';
+export { areNodesEqual } from './SchemaComparator.js';

--- a/src/core/schema-diff/types.ts
+++ b/src/core/schema-diff/types.ts
@@ -1,0 +1,16 @@
+import type { SchemaNode } from '../schema-node/index.js';
+
+export type ChangeType = 'added' | 'removed' | 'moved' | 'modified';
+
+export interface RawChange {
+  readonly type: ChangeType;
+  readonly baseNode: SchemaNode | null;
+  readonly currentNode: SchemaNode | null;
+}
+
+export interface CoalescedChanges {
+  readonly moved: readonly RawChange[];
+  readonly added: readonly RawChange[];
+  readonly removed: readonly RawChange[];
+  readonly modified: readonly RawChange[];
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a schema-diff module to compare schema trees and report added, removed, moved, and modified node changes, with a simple API to coalesce nested changes. Also exposes the new APIs via core exports and updates docs.

- **New Features**
  - SchemaDiff facade to check dirty state, collect/coalesce changes, track replacements, and mark saves.
  - ChangeCollector gathers raw changes between base and current trees.
  - ChangeCoalescer filters nested changes to top-level and groups by type.
  - NodePathIndex stores base paths and replacement mappings for type changes.
  - SchemaComparator provides deep node equality.
  - Core README and index updated to export schema-diff types and utilities.

<sup>Written for commit 5a7f7ef23d9a8e4853c228c096b785f93122133e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

