### PR TITLE
feat: schema-serializer

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -13,6 +13,7 @@ Foundation layer for unified-toolkit. Contains base abstractions used by all oth
 | `schema-node` | Immutable schema node wrappers |
 | `schema-tree` | Tree structure with indexing |
 | `schema-diff` | Tree comparison, change collection |
+| `schema-serializer` | SchemaNode → JsonSchema serialization |
 | `value-diff` | Field-level value comparison |
 
 ## Exports
@@ -45,6 +46,10 @@ export type { SchemaTree } from '@revisium/schema-toolkit/core';
 export { SchemaDiff, ChangeCollector, ChangeCoalescer, NodePathIndex, areNodesEqual } from '@revisium/schema-toolkit/core';
 export type { RawChange, CoalescedChanges, ChangeType } from '@revisium/schema-toolkit/core';
 
+// schema-serializer
+export { SchemaSerializer } from '@revisium/schema-toolkit/core';
+export type { SerializeOptions } from '@revisium/schema-toolkit/core';
+
 // value-diff
 export { computeValueDiff, FieldChangeType } from '@revisium/schema-toolkit/core';
 export type { FieldChange } from '@revisium/schema-toolkit/core';
@@ -54,14 +59,15 @@ export type { FieldChange } from '@revisium/schema-toolkit/core';
 
 ```text
 core/
-├── types/        # No dependencies
-├── reactivity/   # Depends on types
-├── path/         # No dependencies
-├── validation/   # Depends on types
-├── schema-node/  # Depends on path
-├── schema-tree/  # Depends on schema-node, path
-├── schema-diff/  # Depends on schema-tree, schema-node, path
-└── value-diff/   # No dependencies
+├── types/             # No dependencies
+├── reactivity/        # Depends on types
+├── path/              # No dependencies
+├── validation/        # Depends on types
+├── schema-node/       # Depends on path
+├── schema-tree/       # Depends on schema-node, path
+├── schema-diff/       # Depends on schema-tree, schema-node, path
+├── schema-serializer/ # Depends on schema-node, schema-tree, types
+└── value-diff/        # No dependencies
 ```
 
 All other unified-toolkit modules depend on core.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,3 +6,4 @@ export * from './schema-node/index.js';
 export * from './schema-tree/index.js';
 export * from './value-diff/index.js';
 export * from './schema-diff/index.js';
+export * from './schema-serializer/index.js';

--- a/src/core/schema-serializer/README.md
+++ b/src/core/schema-serializer/README.md
@@ -1,0 +1,249 @@
+# schema-serializer
+
+Serializes `SchemaNode` trees into JSON Schema format.
+
+## Responsibility
+
+- Converts `SchemaNode` → `JsonSchema`
+- Handles metadata (title, description, deprecated)
+- Serializes formulas to `x-formula`
+- Serializes foreign keys
+- Handles `$ref` for RefNode
+- Does NOT compare schemas (see `schema-diff`)
+
+## API
+
+```typescript
+interface SerializeOptions {
+  excludeNodeIds?: Set<string>;
+}
+
+class SchemaSerializer {
+  serializeNode(
+    node: SchemaNode,
+    tree: SchemaTree,
+    options?: SerializeOptions
+  ): JsonSchema;
+
+  serializeTree(tree: SchemaTree): JsonObjectSchema;
+}
+```
+
+## Usage
+
+### Basic Serialization
+
+```typescript
+import { SchemaSerializer } from '@revisium/schema-toolkit';
+import { createSchemaTree, createObjectNode, createStringNode } from '@revisium/schema-toolkit';
+
+const root = createObjectNode('root', 'root', [
+  createStringNode('name-id', 'name', { defaultValue: 'John' }),
+]);
+const tree = createSchemaTree(root);
+
+const serializer = new SchemaSerializer();
+const jsonSchema = serializer.serializeTree(tree);
+
+// Result:
+// {
+//   type: 'object',
+//   properties: {
+//     name: { type: 'string', default: 'John' }
+//   },
+//   additionalProperties: false,
+//   required: ['name']
+// }
+```
+
+### With Metadata
+
+```typescript
+const root = createObjectNode('root', 'root', [
+  createStringNode('name-id', 'name', {
+    defaultValue: '',
+    metadata: {
+      title: 'User Name',
+      description: 'The full name of the user',
+      deprecated: false,
+    },
+  }),
+]);
+const tree = createSchemaTree(root);
+
+const result = serializer.serializeTree(tree);
+
+// Result:
+// {
+//   type: 'object',
+//   properties: {
+//     name: {
+//       type: 'string',
+//       default: '',
+//       title: 'User Name',
+//       description: 'The full name of the user'
+//     }
+//   },
+//   ...
+// }
+```
+
+### With Formulas
+
+```typescript
+const root = createObjectNode('root', 'root', [
+  createNumberNode('price-id', 'price', { defaultValue: 0 }),
+  createNumberNode('qty-id', 'quantity', { defaultValue: 0 }),
+  createNumberNode('total-id', 'total', {
+    defaultValue: 0,
+    formula: { version: 1, expression: 'price * quantity' },
+  }),
+]);
+const tree = createSchemaTree(root);
+
+const result = serializer.serializeTree(tree);
+
+// Result includes:
+// {
+//   ...
+//   properties: {
+//     total: {
+//       type: 'number',
+//       default: 0,
+//       readOnly: true,
+//       'x-formula': {
+//         version: 1,
+//         expression: 'price * quantity'
+//       }
+//     }
+//   }
+// }
+```
+
+### With Foreign Keys
+
+```typescript
+const root = createObjectNode('root', 'root', [
+  createStringNode('user-id', 'userId', {
+    defaultValue: '',
+    foreignKey: 'users',
+  }),
+]);
+const tree = createSchemaTree(root);
+
+const result = serializer.serializeTree(tree);
+
+// Result:
+// {
+//   type: 'object',
+//   properties: {
+//     userId: {
+//       type: 'string',
+//       default: '',
+//       foreignKey: 'users'
+//     }
+//   },
+//   ...
+// }
+```
+
+### Excluding Nodes
+
+```typescript
+const root = createObjectNode('root', 'root', [
+  createStringNode('name-id', 'name', { defaultValue: '' }),
+  createStringNode('secret-id', 'secret', { defaultValue: '' }),
+]);
+const tree = createSchemaTree(root);
+
+const result = serializer.serializeNode(tree.root(), tree, {
+  excludeNodeIds: new Set(['secret-id']),
+});
+
+// Result excludes 'secret' field:
+// {
+//   type: 'object',
+//   properties: {
+//     name: { type: 'string', default: '' }
+//   },
+//   additionalProperties: false,
+//   required: ['name']
+// }
+```
+
+### Arrays and Nested Objects
+
+```typescript
+const root = createObjectNode('root', 'root', [
+  createArrayNode(
+    'items-id',
+    'items',
+    createObjectNode('item-id', '[*]', [
+      createStringNode('name-id', 'name', { defaultValue: '' }),
+      createNumberNode('price-id', 'price', { defaultValue: 0 }),
+    ]),
+  ),
+]);
+const tree = createSchemaTree(root);
+
+const result = serializer.serializeTree(tree);
+
+// Result:
+// {
+//   type: 'object',
+//   properties: {
+//     items: {
+//       type: 'array',
+//       items: {
+//         type: 'object',
+//         properties: {
+//           name: { type: 'string', default: '' },
+//           price: { type: 'number', default: 0 }
+//         },
+//         additionalProperties: false,
+//         required: ['name', 'price']
+//       }
+//     }
+//   },
+//   additionalProperties: false,
+//   required: ['items']
+// }
+```
+
+### Ref Fields
+
+```typescript
+const root = createObjectNode('root', 'root', [
+  createRefNode('file-id', 'avatar', 'File'),
+]);
+const tree = createSchemaTree(root);
+
+const result = serializer.serializeTree(tree);
+
+// Result:
+// {
+//   type: 'object',
+//   properties: {
+//     avatar: { $ref: 'File' }
+//   },
+//   additionalProperties: false,
+//   required: ['avatar']
+// }
+```
+
+## Output Types
+
+| Input Node | Output Schema |
+|------------|---------------|
+| ObjectNode | JsonObjectSchema |
+| ArrayNode | JsonArraySchema |
+| StringNode | JsonStringSchema |
+| NumberNode | JsonNumberSchema |
+| BooleanNode | JsonBooleanSchema |
+| RefNode | JsonRefSchema |
+
+## Dependencies
+
+- `schema-node` - Input node types
+- `schema-tree` - Tree structure for context
+- `types` - JSON Schema output types

--- a/src/core/schema-serializer/SchemaSerializer.ts
+++ b/src/core/schema-serializer/SchemaSerializer.ts
@@ -1,0 +1,210 @@
+import type { SchemaNode } from '../schema-node/index.js';
+import type { SchemaTree } from '../schema-tree/index.js';
+import type { SerializeOptions } from './types.js';
+import type {
+  JsonSchema,
+  JsonObjectSchema,
+  JsonArraySchema,
+  JsonStringSchema,
+  JsonNumberSchema,
+  JsonBooleanSchema,
+  JsonRefSchema,
+  XFormula,
+} from '../../types/index.js';
+import { JsonSchemaTypeName } from '../../types/index.js';
+
+export class SchemaSerializer {
+  private tree: SchemaTree | null = null;
+  private excludeNodeIds: Set<string> = new Set();
+
+  serializeNode(
+    node: SchemaNode,
+    tree: SchemaTree,
+    options?: SerializeOptions,
+  ): JsonSchema {
+    this.tree = tree;
+    this.excludeNodeIds = options?.excludeNodeIds ?? new Set();
+    try {
+      return this.serialize(node);
+    } finally {
+      this.tree = null;
+      this.excludeNodeIds = new Set();
+    }
+  }
+
+  serializeTree(tree: SchemaTree): JsonObjectSchema {
+    return this.serializeNode(tree.root(), tree) as JsonObjectSchema;
+  }
+
+  private serialize(node: SchemaNode): JsonSchema {
+    if (node.isNull()) {
+      throw new Error('Cannot serialize null node');
+    }
+
+    if (node.isObject()) {
+      return this.serializeObject(node);
+    }
+
+    if (node.isArray()) {
+      return this.serializeArray(node);
+    }
+
+    if (node.isRef()) {
+      return this.serializeRef(node);
+    }
+
+    return this.serializePrimitive(node);
+  }
+
+  private serializeObject(node: SchemaNode): JsonObjectSchema {
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+
+    for (const child of node.properties()) {
+      if (this.shouldExclude(child)) {
+        continue;
+      }
+      properties[child.name()] = this.serialize(child);
+      required.push(child.name());
+    }
+
+    const result: JsonObjectSchema = {
+      type: JsonSchemaTypeName.Object,
+      properties,
+      additionalProperties: false,
+      required,
+    };
+
+    return this.addMetadata(result, node);
+  }
+
+  private serializeArray(node: SchemaNode): JsonArraySchema {
+    const items = node.items();
+    if (items.isNull()) {
+      throw new Error('Array node must have items');
+    }
+
+    const result: JsonArraySchema = {
+      type: JsonSchemaTypeName.Array,
+      items: this.serialize(items),
+    };
+
+    return this.addMetadata(result, node);
+  }
+
+  private serializeRef(node: SchemaNode): JsonRefSchema {
+    const ref = node.ref();
+    if (!ref) {
+      throw new Error('Ref node must have a ref value');
+    }
+
+    const result: JsonRefSchema = {
+      $ref: ref,
+    };
+
+    return this.addMetadata(result, node);
+  }
+
+  private serializePrimitive(node: SchemaNode): JsonSchema {
+    const nodeType = node.nodeType();
+
+    switch (nodeType) {
+      case 'string':
+        return this.serializeString(node);
+      case 'number':
+        return this.serializeNumber(node);
+      case 'boolean':
+        return this.serializeBoolean(node);
+      default:
+        throw new Error(`Unknown primitive type: ${nodeType}`);
+    }
+  }
+
+  private serializeString(node: SchemaNode): JsonStringSchema {
+    const result: JsonStringSchema = {
+      type: JsonSchemaTypeName.String,
+      default: (node.defaultValue() as string) ?? '',
+    };
+
+    const foreignKey = node.foreignKey();
+    if (foreignKey) {
+      result.foreignKey = foreignKey;
+    }
+
+    const formula = node.formula();
+    if (formula) {
+      result.readOnly = true;
+      result['x-formula'] = this.serializeFormula(node, formula);
+    }
+
+    return this.addMetadata(result, node);
+  }
+
+  private serializeNumber(node: SchemaNode): JsonNumberSchema {
+    const result: JsonNumberSchema = {
+      type: JsonSchemaTypeName.Number,
+      default: (node.defaultValue() as number) ?? 0,
+    };
+
+    const formula = node.formula();
+    if (formula) {
+      result.readOnly = true;
+      result['x-formula'] = this.serializeFormula(node, formula);
+    }
+
+    return this.addMetadata(result, node);
+  }
+
+  private serializeBoolean(node: SchemaNode): JsonBooleanSchema {
+    const result: JsonBooleanSchema = {
+      type: JsonSchemaTypeName.Boolean,
+      default: (node.defaultValue() as boolean) ?? false,
+    };
+
+    const formula = node.formula();
+    if (formula) {
+      result.readOnly = true;
+      result['x-formula'] = this.serializeFormula(node, formula);
+    }
+
+    return this.addMetadata(result, node);
+  }
+
+  private serializeFormula(
+    _node: SchemaNode,
+    formula: { version: number; expression: string },
+  ): XFormula {
+    if (!this.tree) {
+      throw new Error(
+        'Cannot serialize formula without tree context. Use serializeNode with tree.',
+      );
+    }
+
+    return {
+      version: 1,
+      expression: formula.expression,
+    };
+  }
+
+  private addMetadata<T extends JsonSchema>(schema: T, node: SchemaNode): T {
+    const meta = node.metadata();
+
+    if (meta.title) {
+      (schema as JsonSchema & { title?: string }).title = meta.title;
+    }
+    if (meta.description) {
+      (schema as JsonSchema & { description?: string }).description =
+        meta.description;
+    }
+    if (meta.deprecated) {
+      (schema as JsonSchema & { deprecated?: boolean }).deprecated =
+        meta.deprecated;
+    }
+
+    return schema;
+  }
+
+  private shouldExclude(node: SchemaNode): boolean {
+    return this.excludeNodeIds.has(node.id());
+  }
+}

--- a/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
+++ b/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
@@ -1,0 +1,873 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { SchemaSerializer } from '../SchemaSerializer.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+  createRefNode,
+} from '../../schema-node/index.js';
+import type { NodeMetadata } from '../../schema-node/index.js';
+import { JsonSchemaTypeName } from '../../../types/index.js';
+
+describe('SchemaSerializer', () => {
+  let serializer: SchemaSerializer;
+
+  beforeEach(() => {
+    serializer = new SchemaSerializer();
+  });
+
+  describe('serializeTree', () => {
+    it('serializes empty object', () => {
+      const root = createObjectNode('root', 'root');
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {},
+        additionalProperties: false,
+        required: [],
+      });
+    });
+
+    it('serializes object with string field', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name-id', 'name', { defaultValue: '' }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: {
+            type: JsonSchemaTypeName.String,
+            default: '',
+          },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      });
+    });
+
+    it('serializes object with multiple fields', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name-id', 'name', { defaultValue: 'test' }),
+        createNumberNode('age-id', 'age', { defaultValue: 25 }),
+        createBooleanNode('active-id', 'active', { defaultValue: true }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: 'test' },
+          age: { type: JsonSchemaTypeName.Number, default: 25 },
+          active: { type: JsonSchemaTypeName.Boolean, default: true },
+        },
+        additionalProperties: false,
+        required: ['name', 'age', 'active'],
+      });
+    });
+  });
+
+  describe('string fields', () => {
+    it('serializes string with default value', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'field', { defaultValue: 'hello' }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.field).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: 'hello',
+      });
+    });
+
+    it('serializes string with empty default', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'field'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.field).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+      });
+    });
+
+    it('serializes string with foreignKey', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'userId', {
+          defaultValue: '',
+          foreignKey: 'users',
+        }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.userId).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        foreignKey: 'users',
+      });
+    });
+
+    it('serializes string with formula', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'computed', {
+          defaultValue: '',
+          formula: { version: 1, expression: 'name + " " + surname' },
+        }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.computed).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        readOnly: true,
+        'x-formula': {
+          version: 1,
+          expression: 'name + " " + surname',
+        },
+      });
+    });
+  });
+
+  describe('number fields', () => {
+    it('serializes number with default value', () => {
+      const root = createObjectNode('root', 'root', [
+        createNumberNode('field-id', 'count', { defaultValue: 42 }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.count).toEqual({
+        type: JsonSchemaTypeName.Number,
+        default: 42,
+      });
+    });
+
+    it('serializes number with zero default', () => {
+      const root = createObjectNode('root', 'root', [
+        createNumberNode('field-id', 'count'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.count).toEqual({
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+      });
+    });
+
+    it('serializes number with formula', () => {
+      const root = createObjectNode('root', 'root', [
+        createNumberNode('field-id', 'total', {
+          defaultValue: 0,
+          formula: { version: 1, expression: 'price * quantity' },
+        }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.total).toEqual({
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+        readOnly: true,
+        'x-formula': {
+          version: 1,
+          expression: 'price * quantity',
+        },
+      });
+    });
+  });
+
+  describe('boolean fields', () => {
+    it('serializes boolean with default value', () => {
+      const root = createObjectNode('root', 'root', [
+        createBooleanNode('field-id', 'enabled', { defaultValue: true }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.enabled).toEqual({
+        type: JsonSchemaTypeName.Boolean,
+        default: true,
+      });
+    });
+
+    it('serializes boolean with false default', () => {
+      const root = createObjectNode('root', 'root', [
+        createBooleanNode('field-id', 'enabled'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.enabled).toEqual({
+        type: JsonSchemaTypeName.Boolean,
+        default: false,
+      });
+    });
+
+    it('serializes boolean with formula', () => {
+      const root = createObjectNode('root', 'root', [
+        createBooleanNode('field-id', 'isValid', {
+          defaultValue: false,
+          formula: { version: 1, expression: 'price > 0' },
+        }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.isValid).toEqual({
+        type: JsonSchemaTypeName.Boolean,
+        default: false,
+        readOnly: true,
+        'x-formula': {
+          version: 1,
+          expression: 'price > 0',
+        },
+      });
+    });
+  });
+
+  describe('array fields', () => {
+    it('serializes array with string items', () => {
+      const root = createObjectNode('root', 'root', [
+        createArrayNode(
+          'arr-id',
+          'tags',
+          createStringNode('items-id', '[*]', { defaultValue: '' }),
+        ),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.tags).toEqual({
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.String,
+          default: '',
+        },
+      });
+    });
+
+    it('serializes array with object items', () => {
+      const root = createObjectNode('root', 'root', [
+        createArrayNode(
+          'arr-id',
+          'items',
+          createObjectNode('items-id', '[*]', [
+            createStringNode('name-id', 'name', { defaultValue: '' }),
+            createNumberNode('qty-id', 'quantity', { defaultValue: 0 }),
+          ]),
+        ),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.items).toEqual({
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Object,
+          properties: {
+            name: { type: JsonSchemaTypeName.String, default: '' },
+            quantity: { type: JsonSchemaTypeName.Number, default: 0 },
+          },
+          additionalProperties: false,
+          required: ['name', 'quantity'],
+        },
+      });
+    });
+
+    it('serializes nested arrays', () => {
+      const root = createObjectNode('root', 'root', [
+        createArrayNode(
+          'outer-id',
+          'matrix',
+          createArrayNode(
+            'inner-id',
+            '[*]',
+            createNumberNode('num-id', '[*]', { defaultValue: 0 }),
+          ),
+        ),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.matrix).toEqual({
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Array,
+          items: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+          },
+        },
+      });
+    });
+  });
+
+  describe('ref fields', () => {
+    it('serializes ref field', () => {
+      const root = createObjectNode('root', 'root', [
+        createRefNode('ref-id', 'file', 'File'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.file).toEqual({
+        $ref: 'File',
+      });
+    });
+
+    it('serializes array of refs', () => {
+      const root = createObjectNode('root', 'root', [
+        createArrayNode(
+          'arr-id',
+          'files',
+          createRefNode('ref-id', '[*]', 'File'),
+        ),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.files).toEqual({
+        type: JsonSchemaTypeName.Array,
+        items: {
+          $ref: 'File',
+        },
+      });
+    });
+  });
+
+  describe('nested objects', () => {
+    it('serializes nested object', () => {
+      const root = createObjectNode('root', 'root', [
+        createObjectNode('address-id', 'address', [
+          createStringNode('street-id', 'street', { defaultValue: '' }),
+          createStringNode('city-id', 'city', { defaultValue: '' }),
+        ]),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.address).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          street: { type: JsonSchemaTypeName.String, default: '' },
+          city: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['street', 'city'],
+      });
+    });
+
+    it('serializes deeply nested structure', () => {
+      const root = createObjectNode('root', 'root', [
+        createObjectNode('level1-id', 'level1', [
+          createObjectNode('level2-id', 'level2', [
+            createStringNode('value-id', 'value', { defaultValue: 'deep' }),
+          ]),
+        ]),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.level1).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          level2: {
+            type: JsonSchemaTypeName.Object,
+            properties: {
+              value: { type: JsonSchemaTypeName.String, default: 'deep' },
+            },
+            additionalProperties: false,
+            required: ['value'],
+          },
+        },
+        additionalProperties: false,
+        required: ['level2'],
+      });
+    });
+  });
+
+  describe('metadata', () => {
+    it('serializes title', () => {
+      const metadata: NodeMetadata = { title: 'User Name' };
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'name', { defaultValue: '', metadata }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.name).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        title: 'User Name',
+      });
+    });
+
+    it('serializes description', () => {
+      const metadata: NodeMetadata = { description: 'The user full name' };
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'name', { defaultValue: '', metadata }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.name).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        description: 'The user full name',
+      });
+    });
+
+    it('serializes deprecated flag', () => {
+      const metadata: NodeMetadata = { deprecated: true };
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'oldField', { defaultValue: '', metadata }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.oldField).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        deprecated: true,
+      });
+    });
+
+    it('serializes all metadata fields', () => {
+      const metadata: NodeMetadata = {
+        title: 'Legacy Field',
+        description: 'This field is deprecated',
+        deprecated: true,
+      };
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'legacy', { defaultValue: '', metadata }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.legacy).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        title: 'Legacy Field',
+        description: 'This field is deprecated',
+        deprecated: true,
+      });
+    });
+
+    it('serializes metadata on root object', () => {
+      const metadata: NodeMetadata = { title: 'User Schema', description: 'User data' };
+      const root = createObjectNode('root', 'root', [], metadata);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {},
+        additionalProperties: false,
+        required: [],
+        title: 'User Schema',
+        description: 'User data',
+      });
+    });
+
+    it('serializes metadata on array field', () => {
+      const metadata: NodeMetadata = { title: 'Tags List' };
+      const root = createObjectNode('root', 'root', [
+        createArrayNode(
+          'arr-id',
+          'tags',
+          createStringNode('items-id', '[*]', { defaultValue: '' }),
+          metadata,
+        ),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.tags).toEqual({
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.String,
+          default: '',
+        },
+        title: 'Tags List',
+      });
+    });
+
+    it('serializes metadata on ref field', () => {
+      const metadata: NodeMetadata = { title: 'Profile Picture' };
+      const root = createObjectNode('root', 'root', [
+        createRefNode('ref-id', 'avatar', 'File', metadata),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.properties.avatar).toEqual({
+        $ref: 'File',
+        title: 'Profile Picture',
+      });
+    });
+
+    it('does not include undefined metadata fields', () => {
+      const metadata: NodeMetadata = { title: 'Name' };
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field-id', 'name', { defaultValue: '', metadata }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+      const nameField = result.properties.name;
+
+      expect(nameField).not.toHaveProperty('description');
+      expect(nameField).not.toHaveProperty('deprecated');
+    });
+  });
+
+  describe('serializeNode with options', () => {
+    it('excludes specified node IDs', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name-id', 'name', { defaultValue: '' }),
+        createStringNode('secret-id', 'secret', { defaultValue: '' }),
+        createNumberNode('age-id', 'age', { defaultValue: 0 }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeNode(tree.root(), tree, {
+        excludeNodeIds: new Set(['secret-id']),
+      });
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+          age: { type: JsonSchemaTypeName.Number, default: 0 },
+        },
+        additionalProperties: false,
+        required: ['name', 'age'],
+      });
+    });
+
+    it('excludes multiple node IDs', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('field1-id', 'field1', { defaultValue: '' }),
+        createStringNode('field2-id', 'field2', { defaultValue: '' }),
+        createStringNode('field3-id', 'field3', { defaultValue: '' }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeNode(tree.root(), tree, {
+        excludeNodeIds: new Set(['field1-id', 'field3-id']),
+      });
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          field2: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['field2'],
+      });
+    });
+
+    it('handles empty excludeNodeIds set', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name-id', 'name', { defaultValue: '' }),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeNode(tree.root(), tree, {
+        excludeNodeIds: new Set(),
+      });
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      });
+    });
+
+    it('excludes nested object properties', () => {
+      const root = createObjectNode('root', 'root', [
+        createObjectNode('obj-id', 'data', [
+          createStringNode('visible-id', 'visible', { defaultValue: '' }),
+          createStringNode('hidden-id', 'hidden', { defaultValue: '' }),
+        ]),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeNode(tree.root(), tree, {
+        excludeNodeIds: new Set(['hidden-id']),
+      });
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          data: {
+            type: JsonSchemaTypeName.Object,
+            properties: {
+              visible: { type: JsonSchemaTypeName.String, default: '' },
+            },
+            additionalProperties: false,
+            required: ['visible'],
+          },
+        },
+        additionalProperties: false,
+        required: ['data'],
+      });
+    });
+
+    it('can exclude entire nested object', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name-id', 'name', { defaultValue: '' }),
+        createObjectNode('obj-id', 'private', [
+          createStringNode('secret-id', 'secret', { defaultValue: '' }),
+        ]),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeNode(tree.root(), tree, {
+        excludeNodeIds: new Set(['obj-id']),
+      });
+
+      expect(result).toEqual({
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on null node', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('name-id', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+      const nullNode = tree.nodeById('non-existent');
+
+      expect(() => {
+        serializer.serializeNode(nullNode, tree);
+      }).toThrow('Cannot serialize null node');
+    });
+
+    it('throws when array has null items', () => {
+      const mockArrayNode = {
+        id: () => 'arr-id',
+        name: () => 'arr',
+        nodeType: () => 'array' as const,
+        metadata: () => ({}),
+        isObject: () => false,
+        isArray: () => true,
+        isPrimitive: () => false,
+        isRef: () => false,
+        isNull: () => false,
+        property: () => ({ isNull: () => true }),
+        properties: () => [],
+        items: () => ({ isNull: () => true }),
+        ref: () => undefined,
+        formula: () => undefined,
+        hasFormula: () => false,
+        defaultValue: () => undefined,
+        foreignKey: () => undefined,
+        clone: () => mockArrayNode,
+      };
+
+      const mockRoot = {
+        id: () => 'root',
+        name: () => 'root',
+        nodeType: () => 'object' as const,
+        metadata: () => ({}),
+        isObject: () => true,
+        isArray: () => false,
+        isPrimitive: () => false,
+        isRef: () => false,
+        isNull: () => false,
+        property: () => mockArrayNode,
+        properties: () => [mockArrayNode],
+        items: () => ({ isNull: () => true }),
+        ref: () => undefined,
+        formula: () => undefined,
+        hasFormula: () => false,
+        defaultValue: () => undefined,
+        foreignKey: () => undefined,
+        clone: () => mockRoot,
+      };
+
+      const mockTree = createSchemaTree(
+        createObjectNode('root', 'root', [
+          createStringNode('dummy', 'dummy'),
+        ]),
+      );
+
+      expect(() => {
+        serializer.serializeNode(mockArrayNode as ReturnType<typeof createObjectNode>, mockTree);
+      }).toThrow('Array node must have items');
+    });
+
+    it('throws when ref has no ref value', () => {
+      const mockRefNode = {
+        id: () => 'ref-id',
+        name: () => 'ref',
+        nodeType: () => 'ref' as const,
+        metadata: () => ({}),
+        isObject: () => false,
+        isArray: () => false,
+        isPrimitive: () => false,
+        isRef: () => true,
+        isNull: () => false,
+        property: () => ({ isNull: () => true }),
+        properties: () => [],
+        items: () => ({ isNull: () => true }),
+        ref: () => undefined,
+        formula: () => undefined,
+        hasFormula: () => false,
+        defaultValue: () => undefined,
+        foreignKey: () => undefined,
+        clone: () => mockRefNode,
+      };
+
+      const mockTree = createSchemaTree(
+        createObjectNode('root', 'root', [
+          createStringNode('dummy', 'dummy'),
+        ]),
+      );
+
+      expect(() => {
+        serializer.serializeNode(mockRefNode as ReturnType<typeof createObjectNode>, mockTree);
+      }).toThrow('Ref node must have a ref value');
+    });
+
+    it('throws for unknown primitive type', () => {
+      const mockNode = {
+        id: () => 'unknown-id',
+        name: () => 'unknown',
+        nodeType: () => 'custom' as ReturnType<typeof createStringNode>['nodeType'],
+        metadata: () => ({}),
+        isObject: () => false,
+        isArray: () => false,
+        isPrimitive: () => true,
+        isRef: () => false,
+        isNull: () => false,
+        property: () => ({ isNull: () => true }),
+        properties: () => [],
+        items: () => ({ isNull: () => true }),
+        ref: () => undefined,
+        formula: () => undefined,
+        hasFormula: () => false,
+        defaultValue: () => 'value',
+        foreignKey: () => undefined,
+        clone: () => mockNode,
+      };
+
+      const mockTree = createSchemaTree(
+        createObjectNode('root', 'root', [
+          createStringNode('dummy', 'dummy'),
+        ]),
+      );
+
+      expect(() => {
+        serializer.serializeNode(mockNode as ReturnType<typeof createObjectNode>, mockTree);
+      }).toThrow('Unknown primitive type: custom');
+    });
+  });
+
+  describe('complex schemas', () => {
+    it('serializes complex e-commerce product schema', () => {
+      const root = createObjectNode('root', 'root', [
+        createStringNode('id-id', 'id', { defaultValue: '' }),
+        createStringNode('name-id', 'name', {
+          defaultValue: '',
+          metadata: { title: 'Product Name' },
+        }),
+        createNumberNode('price-id', 'price', { defaultValue: 0 }),
+        createNumberNode('quantity-id', 'quantity', { defaultValue: 0 }),
+        createNumberNode('total-id', 'total', {
+          defaultValue: 0,
+          formula: { version: 1, expression: 'price * quantity' },
+        }),
+        createObjectNode('category-id', 'category', [
+          createStringNode('cat-id-id', 'id', { defaultValue: '' }),
+          createStringNode('cat-name-id', 'name', { defaultValue: '' }),
+        ]),
+        createArrayNode(
+          'tags-id',
+          'tags',
+          createStringNode('tag-item-id', '[*]', { defaultValue: '' }),
+        ),
+        createRefNode('image-id', 'image', 'File'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const result = serializer.serializeTree(tree);
+
+      expect(result.type).toBe(JsonSchemaTypeName.Object);
+      expect(result.required).toEqual([
+        'id',
+        'name',
+        'price',
+        'quantity',
+        'total',
+        'category',
+        'tags',
+        'image',
+      ]);
+      expect(result.properties.total).toEqual({
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+        readOnly: true,
+        'x-formula': { version: 1, expression: 'price * quantity' },
+      });
+      expect(result.properties.name).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+        title: 'Product Name',
+      });
+      expect(result.properties.image).toEqual({ $ref: 'File' });
+    });
+  });
+});

--- a/src/core/schema-serializer/index.ts
+++ b/src/core/schema-serializer/index.ts
@@ -1,0 +1,2 @@
+export type { SerializeOptions } from './types.js';
+export { SchemaSerializer } from './SchemaSerializer.js';

--- a/src/core/schema-serializer/types.ts
+++ b/src/core/schema-serializer/types.ts
@@ -1,0 +1,3 @@
+export interface SerializeOptions {
+  excludeNodeIds?: Set<string>;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a schema-serializer to convert SchemaNode trees into JSON Schema. Supports metadata, formulas (x-formula), foreign keys, $ref, and excluding fields by node id.

- **New Features**
  - SchemaSerializer with serializeTree and serializeNode(options.excludeNodeIds)
  - Supports object, array, string, number, boolean, and ref nodes
  - Adds title/description/deprecated, formulas (readOnly + x-formula), foreignKey; sets required and additionalProperties: false
  - Exported from core; added README and comprehensive tests

- **Migration**
  - No breaking changes; import from @revisium/schema-toolkit/core

<sup>Written for commit f95aa3e59fa3c6e91fd344ec871a95ea7f522354. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

