### PR TITLE
feat: schema-patch

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.coverage.exclusions=**/__tests__**,**/__mocks__**,**/*.spec.ts
 # ====================
 # Issue Ignore Rules
 # ====================
-sonar.issue.ignore.multicriteria=tech1,tech2,fp1
+sonar.issue.ignore.multicriteria=tech1,tech2,fp1,fp2,fp3
 
 # ====================
 # Technical Debt Exclusions
@@ -37,6 +37,14 @@ sonar.issue.ignore.multicriteria.tech2.resourceKey=**src/lib/*
 # FP: JSON Schema if/then is valid schema syntax, not Promise-related
 sonar.issue.ignore.multicriteria.fp1.ruleKey=typescript:S7739
 sonar.issue.ignore.multicriteria.fp1.resourceKey=**/meta-schema.ts
+
+# FP: SchemaNode.removeChild is not DOM API, it's our custom method
+sonar.issue.ignore.multicriteria.fp2.ruleKey=typescript:S6788
+sonar.issue.ignore.multicriteria.fp2.resourceKey=**/schema-tree/**
+
+# FP: ObjectNode._children is mutated via push/splice, cannot be readonly
+sonar.issue.ignore.multicriteria.fp3.ruleKey=typescript:S4165
+sonar.issue.ignore.multicriteria.fp3.resourceKey=**/ObjectNode.ts
 
 # ====================
 # Duplicate Code Exclusions

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,3 +7,4 @@ export * from './schema-tree/index.js';
 export * from './value-diff/index.js';
 export * from './schema-diff/index.js';
 export * from './schema-serializer/index.js';
+export * from './schema-patch/index.js';

--- a/src/core/schema-diff/ChangeCoalescer.ts
+++ b/src/core/schema-diff/ChangeCoalescer.ts
@@ -1,6 +1,13 @@
 import type { SchemaTree } from '../schema-tree/index.js';
 import type { Path } from '../path/index.js';
-import type { RawChange, CoalescedChanges } from './types.js';
+import type {
+  RawChange,
+  CoalescedChanges,
+  MovedChange,
+  AddedChange,
+  RemovedChange,
+  ModifiedChange,
+} from './types.js';
 import { NodePathIndex } from './NodePathIndex.js';
 
 export class ChangeCoalescer {
@@ -10,10 +17,10 @@ export class ChangeCoalescer {
   ) {}
 
   coalesce(changes: readonly RawChange[]): CoalescedChanges {
-    const moved: RawChange[] = [];
-    const added: RawChange[] = [];
-    const removed: RawChange[] = [];
-    const modified: RawChange[] = [];
+    const moved: MovedChange[] = [];
+    const added: AddedChange[] = [];
+    const removed: RemovedChange[] = [];
+    const modified: ModifiedChange[] = [];
 
     const movedPaths = this.getMovedPaths(changes);
 
@@ -45,7 +52,7 @@ export class ChangeCoalescer {
     const paths = new Set<string>();
 
     for (const change of changes) {
-      if (change.type === 'moved' && change.baseNode) {
+      if (change.type === 'moved') {
         const basePath = this.index.getBasePath(change.baseNode.id());
         if (basePath) {
           paths.add(basePath.asJsonPointer());
@@ -61,11 +68,7 @@ export class ChangeCoalescer {
     allChanges: readonly RawChange[],
     movedPaths: Set<string>,
   ): boolean {
-    const node = change.currentNode ?? change.baseNode;
-    if (!node) return false;
-
     const path = this.getChangePath(change);
-    if (!path) return false;
 
     if (this.hasParentChange(change, allChanges, path)) {
       return true;
@@ -78,16 +81,11 @@ export class ChangeCoalescer {
     return false;
   }
 
-  private getChangePath(change: RawChange): Path | null {
-    if (change.type === 'removed' && change.baseNode) {
-      return this.index.getBasePath(change.baseNode.id()) ?? null;
+  private getChangePath(change: RawChange): Path {
+    if (change.type === 'removed') {
+      return this.index.getBasePath(change.baseNode.id())!;
     }
-
-    if (change.currentNode) {
-      return this.currentTree.pathOf(change.currentNode.id());
-    }
-
-    return null;
+    return this.currentTree.pathOf(change.currentNode.id());
   }
 
   private hasParentChange(
@@ -97,10 +95,14 @@ export class ChangeCoalescer {
   ): boolean {
     for (const other of allChanges) {
       if (other === change) continue;
-      if (other.type === 'modified') continue;
+
+      if (other.type === 'modified') {
+        if (!this.isTypeChangeReplacement(other)) {
+          continue;
+        }
+      }
 
       const otherPath = this.getChangePath(other);
-      if (!otherPath) continue;
 
       if (path.isChildOf(otherPath)) {
         return true;
@@ -110,25 +112,29 @@ export class ChangeCoalescer {
     return false;
   }
 
+  private isTypeChangeReplacement(change: ModifiedChange): boolean {
+    return change.baseNode.nodeType() !== change.currentNode.nodeType();
+  }
+
   private isAffectedByMove(
     change: RawChange,
     movedPaths: Set<string>,
   ): boolean {
-    if (change.type === 'moved') {
+    if (change.type !== 'modified') {
       return false;
     }
 
-    if (change.type === 'modified' && change.baseNode) {
-      const basePath = this.index.getBasePath(change.baseNode.id());
-      if (basePath) {
-        for (const movedPath of movedPaths) {
-          if (
-            basePath.asJsonPointer().startsWith(movedPath + '/') &&
-            basePath.asJsonPointer() !== movedPath
-          ) {
-            return true;
-          }
-        }
+    const basePath = this.index.getBasePath(change.baseNode.id());
+    if (!basePath) {
+      return false;
+    }
+
+    for (const movedPath of movedPaths) {
+      if (
+        basePath.asJsonPointer().startsWith(movedPath + '/') &&
+        basePath.asJsonPointer() !== movedPath
+      ) {
+        return true;
       }
     }
 

--- a/src/core/schema-diff/ChangeCoalescer.ts
+++ b/src/core/schema-diff/ChangeCoalescer.ts
@@ -83,7 +83,13 @@ export class ChangeCoalescer {
 
   private getChangePath(change: RawChange): Path {
     if (change.type === 'removed') {
-      return this.index.getBasePath(change.baseNode.id())!;
+      const basePath = this.index.getBasePath(change.baseNode.id());
+      if (!basePath) {
+        throw new Error(
+          `Base path not found for removed node: ${change.baseNode.id()}`,
+        );
+      }
+      return basePath;
     }
     return this.currentTree.pathOf(change.currentNode.id());
   }

--- a/src/core/schema-diff/README.md
+++ b/src/core/schema-diff/README.md
@@ -38,7 +38,7 @@ class SchemaDiff {
 ## Usage
 
 ```typescript
-import { SchemaDiff } from '@revisium/schema-toolkit/core';
+import { SchemaDiff, createSchemaTree } from '@revisium/schema-toolkit/core';
 
 const tree = createSchemaTree(rootNode);
 const diff = new SchemaDiff(tree);

--- a/src/core/schema-diff/SchemaComparator.ts
+++ b/src/core/schema-diff/SchemaComparator.ts
@@ -32,6 +32,34 @@ export function areNodesEqual(a: SchemaNode, b: SchemaNode): boolean {
   return a.isNull() && b.isNull();
 }
 
+export function areNodesContentEqual(a: SchemaNode, b: SchemaNode): boolean {
+  if (a.nodeType() !== b.nodeType()) {
+    return false;
+  }
+
+  if (!areMetadataEqual(a, b)) {
+    return false;
+  }
+
+  if (a.isPrimitive()) {
+    return arePrimitivesEqual(a, b);
+  }
+
+  if (a.isObject()) {
+    return areObjectsEqual(a, b);
+  }
+
+  if (a.isArray()) {
+    return areArraysEqual(a, b);
+  }
+
+  if (a.isRef()) {
+    return a.ref() === b.ref();
+  }
+
+  return a.isNull() && b.isNull();
+}
+
 function areMetadataEqual(a: SchemaNode, b: SchemaNode): boolean {
   const metaA = a.metadata();
   const metaB = b.metadata();
@@ -60,6 +88,7 @@ function arePrimitivesEqual(a: SchemaNode, b: SchemaNode): boolean {
   }
 
   return (
+    formulaA.version === formulaB.version &&
     formulaA.expression === formulaB.expression &&
     a.foreignKey() === b.foreignKey()
   );
@@ -84,5 +113,8 @@ function areObjectsEqual(a: SchemaNode, b: SchemaNode): boolean {
 }
 
 function areArraysEqual(a: SchemaNode, b: SchemaNode): boolean {
+  if (a.defaultValue() !== b.defaultValue()) {
+    return false;
+  }
   return areNodesEqual(a.items(), b.items());
 }

--- a/src/core/schema-diff/__tests__/ChangeCoalescer.spec.ts
+++ b/src/core/schema-diff/__tests__/ChangeCoalescer.spec.ts
@@ -137,4 +137,65 @@ describe('ChangeCoalescer', () => {
       expect(coalesced.modified).toHaveLength(0);
     });
   });
+
+  describe('move affected changes', () => {
+    it('filters out modified changes that are children of moved nodes', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createObjectNode('parent', 'parent', [
+          createStringNode('child', 'child', { defaultValue: 'old' }),
+        ]),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createObjectNode('parent', 'renamedParent', [
+          createStringNode('child', 'child', { defaultValue: 'new' }),
+        ]),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      expect(coalesced.moved).toHaveLength(1);
+      expect(coalesced.moved[0]?.currentNode?.name()).toBe('renamedParent');
+      const childModified = coalesced.modified.find(
+        (c) => c.currentNode?.name() === 'child',
+      );
+      expect(childModified).toBeUndefined();
+    });
+
+    it('filters out deeply nested modified changes under moved parent', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createObjectNode('parent', 'parent', [
+          createObjectNode('nested', 'nested', [
+            createStringNode('deep', 'deep', { defaultValue: 'old' }),
+          ]),
+        ]),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createObjectNode('parent', 'renamedParent', [
+          createObjectNode('nested', 'nested', [
+            createStringNode('deep', 'deep', { defaultValue: 'new' }),
+          ]),
+        ]),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const rawChanges = collectChanges(baseTree, currentTree, index);
+      const coalescer = new ChangeCoalescer(currentTree, index);
+      const coalesced = coalescer.coalesce(rawChanges);
+
+      expect(coalesced.moved).toHaveLength(1);
+      const deepModified = coalesced.modified.find(
+        (c) => c.currentNode?.name() === 'deep',
+      );
+      expect(deepModified).toBeUndefined();
+    });
+  });
 });

--- a/src/core/schema-diff/__tests__/ChangeCoalescer.spec.ts
+++ b/src/core/schema-diff/__tests__/ChangeCoalescer.spec.ts
@@ -33,7 +33,7 @@ describe('ChangeCoalescer', () => {
       const coalesced = coalescer.coalesce(rawChanges);
 
       expect(coalesced.added).toHaveLength(1);
-      expect(coalesced.added[0].currentNode?.name()).toBe('parent');
+      expect(coalesced.added[0]?.currentNode?.name()).toBe('parent');
     });
 
     it('returns single remove for parent when removing nested structure', () => {
@@ -56,7 +56,7 @@ describe('ChangeCoalescer', () => {
       const coalesced = coalescer.coalesce(rawChanges);
 
       expect(coalesced.removed).toHaveLength(1);
-      expect(coalesced.removed[0].baseNode?.name()).toBe('parent');
+      expect(coalesced.removed[0]?.baseNode?.name()).toBe('parent');
     });
   });
 
@@ -84,7 +84,7 @@ describe('ChangeCoalescer', () => {
       const coalesced = coalescer.coalesce(rawChanges);
 
       expect(coalesced.moved).toHaveLength(1);
-      expect(coalesced.moved[0].currentNode?.name()).toBe('newParent');
+      expect(coalesced.moved[0]?.currentNode?.name()).toBe('newParent');
     });
   });
 

--- a/src/core/schema-diff/__tests__/ChangeCollector.spec.ts
+++ b/src/core/schema-diff/__tests__/ChangeCollector.spec.ts
@@ -45,8 +45,8 @@ describe('ChangeCollector', () => {
 
       const addedChanges = changes.filter((c) => c.type === 'added');
       expect(addedChanges).toHaveLength(1);
-      expect(addedChanges[0].currentNode?.name()).toBe('newField');
-      expect(addedChanges[0].baseNode).toBeNull();
+      expect(addedChanges[0]?.currentNode?.name()).toBe('newField');
+      expect(addedChanges[0]?.baseNode).toBeNull();
     });
 
     it('detects added nested field with parent modified', () => {
@@ -68,7 +68,7 @@ describe('ChangeCollector', () => {
 
       const addedChanges = changes.filter((c) => c.type === 'added');
       expect(addedChanges).toHaveLength(1);
-      expect(addedChanges[0].currentNode?.name()).toBe('newField');
+      expect(addedChanges[0]?.currentNode?.name()).toBe('newField');
     });
   });
 
@@ -91,8 +91,8 @@ describe('ChangeCollector', () => {
 
       const removedChanges = changes.filter((c) => c.type === 'removed');
       expect(removedChanges).toHaveLength(1);
-      expect(removedChanges[0].baseNode?.name()).toBe('age');
-      expect(removedChanges[0].currentNode).toBeNull();
+      expect(removedChanges[0]?.baseNode?.name()).toBe('age');
+      expect(removedChanges[0]?.currentNode).toBeNull();
     });
 
     it('detects removed nested field with parent modified', () => {
@@ -114,7 +114,7 @@ describe('ChangeCollector', () => {
 
       const removedChanges = changes.filter((c) => c.type === 'removed');
       expect(removedChanges).toHaveLength(1);
-      expect(removedChanges[0].baseNode?.name()).toBe('field');
+      expect(removedChanges[0]?.baseNode?.name()).toBe('field');
     });
   });
 
@@ -184,8 +184,8 @@ describe('ChangeCollector', () => {
 
       const movedChanges = changes.filter((c) => c.type === 'moved');
       expect(movedChanges).toHaveLength(1);
-      expect(movedChanges[0].baseNode?.name()).toBe('oldName');
-      expect(movedChanges[0].currentNode?.name()).toBe('newName');
+      expect(movedChanges[0]?.baseNode?.name()).toBe('oldName');
+      expect(movedChanges[0]?.currentNode?.name()).toBe('newName');
 
       const modifiedChanges = changes.filter(
         (c) => c.type === 'modified' && c.currentNode?.name() === 'newName',

--- a/src/core/schema-diff/__tests__/SchemaComparator.spec.ts
+++ b/src/core/schema-diff/__tests__/SchemaComparator.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import { areNodesEqual } from '../SchemaComparator.js';
+import { areNodesEqual, areNodesContentEqual } from '../SchemaComparator.js';
 import {
   stringNode,
   numberNode,
@@ -121,6 +121,15 @@ describe('SchemaComparator', () => {
 
         expect(areNodesEqual(a, b)).toBe(false);
       });
+
+      it('returns false when array metadata differs', () => {
+        const a = arrayNode('arr', stringNode('item'), {});
+        const b = arrayNode('arr', stringNode('item'), {
+          description: 'New description',
+        });
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
     });
 
     describe('refs', () => {
@@ -176,6 +185,13 @@ describe('SchemaComparator', () => {
 
         expect(areNodesEqual(a, b)).toBe(false);
       });
+
+      it('returns false when formula versions differ', () => {
+        const a = stringNodeWithFormula('computed', 'a + b', '', 1);
+        const b = stringNodeWithFormula('computed', 'a + b', '', 2);
+
+        expect(areNodesEqual(a, b)).toBe(false);
+      });
     });
 
     describe('nested structures', () => {
@@ -200,6 +216,64 @@ describe('SchemaComparator', () => {
 
         expect(areNodesEqual(a, b)).toBe(false);
       });
+    });
+  });
+
+  describe('areNodesContentEqual', () => {
+    it('returns true for identical nodes ignoring name', () => {
+      const a = stringNode('name', 'default');
+      const b = stringNode('differentName', 'default');
+
+      expect(areNodesContentEqual(a, b)).toBe(true);
+    });
+
+    it('returns false when types differ', () => {
+      const a = stringNode('field');
+      const b = numberNode('field');
+
+      expect(areNodesContentEqual(a, b)).toBe(false);
+    });
+
+    it('returns false when metadata differs', () => {
+      const a = stringNode('name', '', { description: 'old' });
+      const b = stringNode('name', '', { description: 'new' });
+
+      expect(areNodesContentEqual(a, b)).toBe(false);
+    });
+
+    it('returns true for objects with same children', () => {
+      const a = objectNode('objA', [stringNode('field')]);
+      const b = objectNode('objB', [stringNode('field')]);
+
+      expect(areNodesContentEqual(a, b)).toBe(true);
+    });
+
+    it('returns true for arrays with same items', () => {
+      const a = arrayNode('arrA', stringNode('item'));
+      const b = arrayNode('arrB', stringNode('item'));
+
+      expect(areNodesContentEqual(a, b)).toBe(true);
+    });
+
+    it('returns true for refs with same reference', () => {
+      const a = refNode('refA', 'File');
+      const b = refNode('refB', 'File');
+
+      expect(areNodesContentEqual(a, b)).toBe(true);
+    });
+
+    it('returns false for refs with different reference', () => {
+      const a = refNode('ref', 'File');
+      const b = refNode('ref', 'Image');
+
+      expect(areNodesContentEqual(a, b)).toBe(false);
+    });
+
+    it('returns true for two null nodes', () => {
+      const a = nullNode();
+      const b = nullNode();
+
+      expect(areNodesContentEqual(a, b)).toBe(true);
     });
   });
 });

--- a/src/core/schema-diff/__tests__/test-helpers.ts
+++ b/src/core/schema-diff/__tests__/test-helpers.ts
@@ -74,8 +74,9 @@ export function stringNodeWithFormula(
   name: string,
   expression: string,
   defaultValue = '',
+  version = 1,
 ): SchemaNode {
-  const formula: Formula = { version: 1, expression };
+  const formula: Formula = { version, expression };
   return createStringNode(nextId(), name, { defaultValue, formula });
 }
 

--- a/src/core/schema-diff/index.ts
+++ b/src/core/schema-diff/index.ts
@@ -1,6 +1,14 @@
-export type { RawChange, CoalescedChanges, ChangeType } from './types.js';
+export type {
+  RawChange,
+  AddedChange,
+  RemovedChange,
+  MovedChange,
+  ModifiedChange,
+  CoalescedChanges,
+  ChangeType,
+} from './types.js';
 export { SchemaDiff } from './SchemaDiff.js';
 export { NodePathIndex } from './NodePathIndex.js';
 export { ChangeCollector, collectChanges } from './ChangeCollector.js';
 export { ChangeCoalescer, coalesceChanges } from './ChangeCoalescer.js';
-export { areNodesEqual } from './SchemaComparator.js';
+export { areNodesEqual, areNodesContentEqual } from './SchemaComparator.js';

--- a/src/core/schema-diff/types.ts
+++ b/src/core/schema-diff/types.ts
@@ -2,15 +2,35 @@ import type { SchemaNode } from '../schema-node/index.js';
 
 export type ChangeType = 'added' | 'removed' | 'moved' | 'modified';
 
-export interface RawChange {
-  readonly type: ChangeType;
-  readonly baseNode: SchemaNode | null;
-  readonly currentNode: SchemaNode | null;
+export interface AddedChange {
+  readonly type: 'added';
+  readonly baseNode: null;
+  readonly currentNode: SchemaNode;
 }
 
+export interface RemovedChange {
+  readonly type: 'removed';
+  readonly baseNode: SchemaNode;
+  readonly currentNode: null;
+}
+
+export interface MovedChange {
+  readonly type: 'moved';
+  readonly baseNode: SchemaNode;
+  readonly currentNode: SchemaNode;
+}
+
+export interface ModifiedChange {
+  readonly type: 'modified';
+  readonly baseNode: SchemaNode;
+  readonly currentNode: SchemaNode;
+}
+
+export type RawChange = AddedChange | RemovedChange | MovedChange | ModifiedChange;
+
 export interface CoalescedChanges {
-  readonly moved: readonly RawChange[];
-  readonly added: readonly RawChange[];
-  readonly removed: readonly RawChange[];
-  readonly modified: readonly RawChange[];
+  readonly moved: readonly MovedChange[];
+  readonly added: readonly AddedChange[];
+  readonly removed: readonly RemovedChange[];
+  readonly modified: readonly ModifiedChange[];
 }

--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -1,53 +1,26 @@
-import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import type { SchemaNode, NodeType, NodeMetadata } from './types.js';
 import { EMPTY_METADATA } from './types.js';
-import { NULL_NODE } from './NullNode.js';
+import { BaseNode } from './BaseNode.js';
 
-export class ArrayNode implements SchemaNode {
+export class ArrayNode extends BaseNode {
+  private _items: SchemaNode;
+
   constructor(
-    private readonly _id: string,
-    private readonly _name: string,
-    private readonly _items: SchemaNode,
-    private readonly _metadata: NodeMetadata = EMPTY_METADATA,
-  ) {}
-
-  id(): string {
-    return this._id;
-  }
-
-  name(): string {
-    return this._name;
+    id: string,
+    name: string,
+    items: SchemaNode,
+    metadata: NodeMetadata = EMPTY_METADATA,
+  ) {
+    super(id, name, metadata);
+    this._items = items;
   }
 
   nodeType(): NodeType {
     return 'array';
   }
 
-  metadata(): NodeMetadata {
-    return this._metadata;
-  }
-
-  isObject(): boolean {
-    return false;
-  }
-
   isArray(): boolean {
     return true;
-  }
-
-  isPrimitive(): boolean {
-    return false;
-  }
-
-  isRef(): boolean {
-    return false;
-  }
-
-  isNull(): boolean {
-    return false;
-  }
-
-  property(): SchemaNode {
-    return NULL_NODE;
   }
 
   properties(): readonly SchemaNode[] {
@@ -58,33 +31,17 @@ export class ArrayNode implements SchemaNode {
     return this._items;
   }
 
-  ref(): string | undefined {
-    return undefined;
-  }
-
-  formula(): Formula | undefined {
-    return undefined;
-  }
-
-  hasFormula(): boolean {
-    return false;
-  }
-
-  defaultValue(): unknown {
-    return undefined;
-  }
-
-  foreignKey(): string | undefined {
-    return undefined;
-  }
-
   clone(): SchemaNode {
     return new ArrayNode(
-      this._id,
-      this._name,
+      this.id(),
+      this.name(),
       this._items.clone(),
-      this._metadata,
+      this.metadata(),
     );
+  }
+
+  setItems(node: SchemaNode): void {
+    this._items = node;
   }
 }
 

--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -1,0 +1,117 @@
+import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import { EMPTY_METADATA } from './types.js';
+import { NULL_NODE } from './NullNode.js';
+
+export abstract class BaseNode implements SchemaNode {
+  protected _name: string;
+  protected _metadata: NodeMetadata;
+
+  constructor(
+    private readonly _id: string,
+    name: string,
+    metadata: NodeMetadata = EMPTY_METADATA,
+  ) {
+    this._name = name;
+    this._metadata = metadata;
+  }
+
+  id(): string {
+    return this._id;
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  abstract nodeType(): NodeType;
+
+  metadata(): NodeMetadata {
+    return this._metadata;
+  }
+
+  isObject(): boolean {
+    return false;
+  }
+
+  isArray(): boolean {
+    return false;
+  }
+
+  isPrimitive(): boolean {
+    return false;
+  }
+
+  isRef(): boolean {
+    return false;
+  }
+
+  isNull(): boolean {
+    return false;
+  }
+
+  property(_name: string): SchemaNode {
+    return NULL_NODE;
+  }
+
+  properties(): readonly SchemaNode[] {
+    return [];
+  }
+
+  items(): SchemaNode {
+    return NULL_NODE;
+  }
+
+  ref(): string | undefined {
+    return undefined;
+  }
+
+  formula(): Formula | undefined {
+    return undefined;
+  }
+
+  hasFormula(): boolean {
+    return false;
+  }
+
+  defaultValue(): unknown {
+    return undefined;
+  }
+
+  foreignKey(): string | undefined {
+    return undefined;
+  }
+
+  abstract clone(): SchemaNode;
+
+  setName(name: string): void {
+    this._name = name;
+  }
+
+  setMetadata(metadata: NodeMetadata): void {
+    this._metadata = metadata;
+  }
+
+  addChild(_node: SchemaNode): void {
+    // No-op by default
+  }
+
+  removeChild(_name: string): boolean {
+    return false;
+  }
+
+  setItems(_node: SchemaNode): void {
+    // No-op by default
+  }
+
+  setDefaultValue(_value: unknown): void {
+    // No-op by default
+  }
+
+  setFormula(_formula: Formula | undefined): void {
+    // No-op by default
+  }
+
+  setForeignKey(_key: string | undefined): void {
+    // No-op by default
+  }
+}

--- a/src/core/schema-node/BooleanNode.ts
+++ b/src/core/schema-node/BooleanNode.ts
@@ -21,7 +21,15 @@ export class BooleanNode extends PrimitiveNode {
   }
 
   clone(): SchemaNode {
-    return new BooleanNode(this.id(), this.name(), this._options as BooleanNodeOptions);
+    return new BooleanNode(this.id(), this.name(), this.cloneOptions());
+  }
+
+  private cloneOptions(): BooleanNodeOptions {
+    return {
+      defaultValue: this._defaultValue as boolean | undefined,
+      formula: this._formula,
+      metadata: this._metadata,
+    };
   }
 }
 

--- a/src/core/schema-node/NullNode.ts
+++ b/src/core/schema-node/NullNode.ts
@@ -73,6 +73,38 @@ class NullNodeImpl implements SchemaNode {
   clone(): SchemaNode {
     return this;
   }
+
+  setName(_name: string): void {
+    // No-op for null
+  }
+
+  setMetadata(_metadata: NodeMetadata): void {
+    // No-op for null
+  }
+
+  addChild(_node: SchemaNode): void {
+    // No-op for null
+  }
+
+  removeChild(_name: string): boolean {
+    return false;
+  }
+
+  setItems(_node: SchemaNode): void {
+    // No-op for null
+  }
+
+  setDefaultValue(_value: unknown): void {
+    // No-op for null
+  }
+
+  setFormula(_formula: Formula | undefined): void {
+    // No-op for null
+  }
+
+  setForeignKey(_key: string | undefined): void {
+    // No-op for null
+  }
 }
 
 export const NULL_NODE: SchemaNode = new NullNodeImpl();

--- a/src/core/schema-node/NumberNode.ts
+++ b/src/core/schema-node/NumberNode.ts
@@ -21,7 +21,15 @@ export class NumberNode extends PrimitiveNode {
   }
 
   clone(): SchemaNode {
-    return new NumberNode(this.id(), this.name(), this._options as NumberNodeOptions);
+    return new NumberNode(this.id(), this.name(), this.cloneOptions());
+  }
+
+  private cloneOptions(): NumberNodeOptions {
+    return {
+      defaultValue: this._defaultValue as number | undefined,
+      formula: this._formula,
+      metadata: this._metadata,
+    };
   }
 }
 

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -1,49 +1,27 @@
-import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import type { SchemaNode, NodeType, NodeMetadata } from './types.js';
 import { EMPTY_METADATA } from './types.js';
+import { BaseNode } from './BaseNode.js';
 import { NULL_NODE } from './NullNode.js';
 
-export class ObjectNode implements SchemaNode {
+export class ObjectNode extends BaseNode {
+  private _children: SchemaNode[];
+
   constructor(
-    private readonly _id: string,
-    private readonly _name: string,
-    private readonly _children: readonly SchemaNode[] = [],
-    private readonly _metadata: NodeMetadata = EMPTY_METADATA,
-  ) {}
-
-  id(): string {
-    return this._id;
-  }
-
-  name(): string {
-    return this._name;
+    id: string,
+    name: string,
+    children: readonly SchemaNode[] = [],
+    metadata: NodeMetadata = EMPTY_METADATA,
+  ) {
+    super(id, name, metadata);
+    this._children = [...children];
   }
 
   nodeType(): NodeType {
     return 'object';
   }
 
-  metadata(): NodeMetadata {
-    return this._metadata;
-  }
-
   isObject(): boolean {
     return true;
-  }
-
-  isArray(): boolean {
-    return false;
-  }
-
-  isPrimitive(): boolean {
-    return false;
-  }
-
-  isRef(): boolean {
-    return false;
-  }
-
-  isNull(): boolean {
-    return false;
   }
 
   property(name: string): SchemaNode {
@@ -54,37 +32,26 @@ export class ObjectNode implements SchemaNode {
     return this._children;
   }
 
-  items(): SchemaNode {
-    return NULL_NODE;
-  }
-
-  ref(): string | undefined {
-    return undefined;
-  }
-
-  formula(): Formula | undefined {
-    return undefined;
-  }
-
-  hasFormula(): boolean {
-    return false;
-  }
-
-  defaultValue(): unknown {
-    return undefined;
-  }
-
-  foreignKey(): string | undefined {
-    return undefined;
-  }
-
   clone(): SchemaNode {
     return new ObjectNode(
-      this._id,
-      this._name,
+      this.id(),
+      this.name(),
       this._children.map((child) => child.clone()),
-      this._metadata,
+      this.metadata(),
     );
+  }
+
+  addChild(node: SchemaNode): void {
+    this._children.push(node);
+  }
+
+  removeChild(name: string): boolean {
+    const index = this._children.findIndex((child) => child.name() === name);
+    if (index === -1) {
+      return false;
+    }
+    this._children.splice(index, 1);
+    return true;
   }
 }
 

--- a/src/core/schema-node/PrimitiveNode.ts
+++ b/src/core/schema-node/PrimitiveNode.ts
@@ -1,6 +1,6 @@
 import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
 import { EMPTY_METADATA } from './types.js';
-import { NULL_NODE } from './NullNode.js';
+import { BaseNode } from './BaseNode.js';
 
 export interface PrimitiveNodeOptions {
   readonly defaultValue?: unknown;
@@ -9,78 +9,55 @@ export interface PrimitiveNodeOptions {
   readonly metadata?: NodeMetadata;
 }
 
-export abstract class PrimitiveNode implements SchemaNode {
+export abstract class PrimitiveNode extends BaseNode {
+  protected _defaultValue: unknown;
+  protected _foreignKey: string | undefined;
+  protected _formula: Formula | undefined;
+
   constructor(
-    private readonly _id: string,
-    private readonly _name: string,
-    protected readonly _options: PrimitiveNodeOptions = {},
-  ) {}
-
-  id(): string {
-    return this._id;
-  }
-
-  name(): string {
-    return this._name;
+    id: string,
+    name: string,
+    options: PrimitiveNodeOptions = {},
+  ) {
+    super(id, name, options.metadata ?? EMPTY_METADATA);
+    this._defaultValue = options.defaultValue;
+    this._foreignKey = options.foreignKey;
+    this._formula = options.formula;
   }
 
   abstract nodeType(): NodeType;
-
-  metadata(): NodeMetadata {
-    return this._options.metadata ?? EMPTY_METADATA;
-  }
-
-  isObject(): boolean {
-    return false;
-  }
-
-  isArray(): boolean {
-    return false;
-  }
 
   isPrimitive(): boolean {
     return true;
   }
 
-  isRef(): boolean {
-    return false;
-  }
-
-  isNull(): boolean {
-    return false;
-  }
-
-  property(): SchemaNode {
-    return NULL_NODE;
-  }
-
-  properties(): readonly SchemaNode[] {
-    return [];
-  }
-
-  items(): SchemaNode {
-    return NULL_NODE;
-  }
-
-  ref(): string | undefined {
-    return undefined;
-  }
-
   formula(): Formula | undefined {
-    return this._options.formula;
+    return this._formula;
   }
 
   hasFormula(): boolean {
-    return this._options.formula !== undefined;
+    return this._formula !== undefined;
   }
 
   defaultValue(): unknown {
-    return this._options.defaultValue;
+    return this._defaultValue;
   }
 
   foreignKey(): string | undefined {
-    return this._options.foreignKey;
+    return this._foreignKey;
   }
 
   abstract clone(): SchemaNode;
+
+  setDefaultValue(value: unknown): void {
+    this._defaultValue = value;
+  }
+
+  setFormula(formula: Formula | undefined): void {
+    this._formula = formula;
+  }
+
+  setForeignKey(key: string | undefined): void {
+    this._foreignKey = key;
+  }
 }

--- a/src/core/schema-node/RefNode.ts
+++ b/src/core/schema-node/RefNode.ts
@@ -3,7 +3,7 @@ import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
 
 export class RefNode extends BaseNode {
-  private _ref: string;
+  private readonly _ref: string;
 
   constructor(
     id: string,

--- a/src/core/schema-node/RefNode.ts
+++ b/src/core/schema-node/RefNode.ts
@@ -1,89 +1,37 @@
-import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import type { SchemaNode, NodeType, NodeMetadata } from './types.js';
 import { EMPTY_METADATA } from './types.js';
-import { NULL_NODE } from './NullNode.js';
+import { BaseNode } from './BaseNode.js';
 
-export class RefNode implements SchemaNode {
+export class RefNode extends BaseNode {
+  private _ref: string;
+
   constructor(
-    private readonly _id: string,
-    private readonly _name: string,
-    private readonly _ref: string,
-    private readonly _metadata: NodeMetadata = EMPTY_METADATA,
+    id: string,
+    name: string,
+    ref: string,
+    metadata: NodeMetadata = EMPTY_METADATA,
   ) {
-    if (!_ref) {
+    super(id, name, metadata);
+    if (!ref) {
       throw new Error('RefNode requires a non-empty ref');
     }
-  }
-
-  id(): string {
-    return this._id;
-  }
-
-  name(): string {
-    return this._name;
+    this._ref = ref;
   }
 
   nodeType(): NodeType {
     return 'ref';
   }
 
-  metadata(): NodeMetadata {
-    return this._metadata;
-  }
-
-  isObject(): boolean {
-    return false;
-  }
-
-  isArray(): boolean {
-    return false;
-  }
-
-  isPrimitive(): boolean {
-    return false;
-  }
-
   isRef(): boolean {
     return true;
-  }
-
-  isNull(): boolean {
-    return false;
-  }
-
-  property(): SchemaNode {
-    return NULL_NODE;
-  }
-
-  properties(): readonly SchemaNode[] {
-    return [];
-  }
-
-  items(): SchemaNode {
-    return NULL_NODE;
   }
 
   ref(): string | undefined {
     return this._ref;
   }
 
-  formula(): Formula | undefined {
-    return undefined;
-  }
-
-  hasFormula(): boolean {
-    return false;
-  }
-
-  defaultValue(): unknown {
-    return undefined;
-  }
-
-  foreignKey(): string | undefined {
-    return undefined;
-  }
-
   clone(): SchemaNode {
-    return new RefNode(this._id, this._name, this._ref, this._metadata);
+    return new RefNode(this.id(), this.name(), this._ref, this.metadata());
   }
 }
 

--- a/src/core/schema-node/StringNode.ts
+++ b/src/core/schema-node/StringNode.ts
@@ -22,7 +22,16 @@ export class StringNode extends PrimitiveNode {
   }
 
   clone(): SchemaNode {
-    return new StringNode(this.id(), this.name(), this._options as StringNodeOptions);
+    return new StringNode(this.id(), this.name(), this.cloneOptions());
+  }
+
+  private cloneOptions(): StringNodeOptions {
+    return {
+      defaultValue: this._defaultValue as string | undefined,
+      foreignKey: this._foreignKey,
+      formula: this._formula,
+      metadata: this._metadata,
+    };
   }
 }
 

--- a/src/core/schema-node/__tests__/ArrayNode.spec.ts
+++ b/src/core/schema-node/__tests__/ArrayNode.spec.ts
@@ -95,4 +95,81 @@ describe('ArrayNode', () => {
 
     expect(node.metadata()).toBe(EMPTY_METADATA);
   });
+
+  describe('mutations', () => {
+    it('setName changes the name', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'oldName', items);
+
+      node.setName('newName');
+
+      expect(node.name()).toBe('newName');
+    });
+
+    it('setMetadata changes metadata', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+
+      node.setMetadata({ description: 'Updated' });
+
+      expect(node.metadata().description).toBe('Updated');
+    });
+
+    it('setItems changes the items schema', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+      const newItems = createStringNode('str-2', 'newItem');
+
+      node.setItems(newItems);
+
+      expect(node.items()).toBe(newItems);
+    });
+
+    it('addChild is no-op for array', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+      const child = createStringNode('str-2', 'extra');
+
+      node.addChild(child);
+
+      expect(node.properties()).toHaveLength(1);
+      expect(node.properties()[0]).toBe(items);
+    });
+
+    it('removeChild returns false for array', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+
+      const result = node.removeChild('item');
+
+      expect(result).toBe(false);
+    });
+
+    it('setDefaultValue is no-op for array', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+
+      node.setDefaultValue([]);
+
+      expect(node.defaultValue()).toBeUndefined();
+    });
+
+    it('setFormula is no-op for array', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+
+      node.setFormula({ version: 1, expression: 'test' });
+
+      expect(node.formula()).toBeUndefined();
+    });
+
+    it('setForeignKey is no-op for array', () => {
+      const items = createStringNode('str-1', 'item');
+      const node = createArrayNode('arr-1', 'tags', items);
+
+      node.setForeignKey('users');
+
+      expect(node.foreignKey()).toBeUndefined();
+    });
+  });
 });

--- a/src/core/schema-node/__tests__/NullNode.spec.ts
+++ b/src/core/schema-node/__tests__/NullNode.spec.ts
@@ -49,4 +49,45 @@ describe('NULL_NODE', () => {
   it('returns EMPTY_METADATA', () => {
     expect(NULL_NODE.metadata()).toBe(EMPTY_METADATA);
   });
+
+  describe('mutations are no-ops', () => {
+    it('setName does nothing', () => {
+      NULL_NODE.setName('test');
+      expect(NULL_NODE.name()).toBe('');
+    });
+
+    it('setMetadata does nothing', () => {
+      NULL_NODE.setMetadata({ description: 'test' });
+      expect(NULL_NODE.metadata()).toBe(EMPTY_METADATA);
+    });
+
+    it('addChild does nothing', () => {
+      NULL_NODE.addChild(NULL_NODE);
+      expect(NULL_NODE.properties()).toHaveLength(0);
+    });
+
+    it('removeChild returns false', () => {
+      expect(NULL_NODE.removeChild('any')).toBe(false);
+    });
+
+    it('setItems does nothing', () => {
+      NULL_NODE.setItems(NULL_NODE);
+      expect(NULL_NODE.items()).toBe(NULL_NODE);
+    });
+
+    it('setDefaultValue does nothing', () => {
+      NULL_NODE.setDefaultValue('test');
+      expect(NULL_NODE.defaultValue()).toBeUndefined();
+    });
+
+    it('setFormula does nothing', () => {
+      NULL_NODE.setFormula({ version: 1, expression: 'test' });
+      expect(NULL_NODE.formula()).toBeUndefined();
+    });
+
+    it('setForeignKey does nothing', () => {
+      NULL_NODE.setForeignKey('users');
+      expect(NULL_NODE.foreignKey()).toBeUndefined();
+    });
+  });
 });

--- a/src/core/schema-node/__tests__/ObjectNode.spec.ts
+++ b/src/core/schema-node/__tests__/ObjectNode.spec.ts
@@ -107,4 +107,83 @@ describe('ObjectNode', () => {
 
     expect(node.metadata()).toBe(EMPTY_METADATA);
   });
+
+  describe('mutations', () => {
+    it('setName changes the name', () => {
+      const node = createObjectNode('obj-1', 'oldName');
+
+      node.setName('newName');
+
+      expect(node.name()).toBe('newName');
+    });
+
+    it('setMetadata changes metadata', () => {
+      const node = createObjectNode('obj-1', 'user');
+
+      node.setMetadata({ description: 'Updated' });
+
+      expect(node.metadata().description).toBe('Updated');
+    });
+
+    it('addChild adds a child node', () => {
+      const node = createObjectNode('obj-1', 'user');
+      const child = createStringNode('str-1', 'name');
+
+      node.addChild(child);
+
+      expect(node.properties()).toHaveLength(1);
+      expect(node.property('name')).toBe(child);
+    });
+
+    it('removeChild removes existing child', () => {
+      const child = createStringNode('str-1', 'name');
+      const node = createObjectNode('obj-1', 'user', [child]);
+
+      const result = node.removeChild('name');
+
+      expect(result).toBe(true);
+      expect(node.properties()).toHaveLength(0);
+    });
+
+    it('removeChild returns false for non-existent child', () => {
+      const node = createObjectNode('obj-1', 'user');
+
+      const result = node.removeChild('missing');
+
+      expect(result).toBe(false);
+    });
+
+    it('setItems is no-op for object', () => {
+      const node = createObjectNode('obj-1', 'user');
+      const items = createStringNode('str-1', '');
+
+      node.setItems(items);
+
+      expect(node.items()).toBe(NULL_NODE);
+    });
+
+    it('setDefaultValue is no-op for object', () => {
+      const node = createObjectNode('obj-1', 'user');
+
+      node.setDefaultValue('test');
+
+      expect(node.defaultValue()).toBeUndefined();
+    });
+
+    it('setFormula is no-op for object', () => {
+      const node = createObjectNode('obj-1', 'user');
+
+      node.setFormula({ version: 1, expression: 'test' });
+
+      expect(node.formula()).toBeUndefined();
+    });
+
+    it('setForeignKey is no-op for object', () => {
+      const node = createObjectNode('obj-1', 'user');
+
+      node.setForeignKey('users');
+
+      expect(node.foreignKey()).toBeUndefined();
+    });
+  });
 });

--- a/src/core/schema-node/__tests__/PrimitiveNodes.spec.ts
+++ b/src/core/schema-node/__tests__/PrimitiveNodes.spec.ts
@@ -302,3 +302,91 @@ describe('BooleanNode', () => {
     expect(node.formula()).toBeUndefined();
   });
 });
+
+describe('PrimitiveNode mutations', () => {
+  it('setName changes the name', () => {
+    const node = createStringNode('str-1', 'oldName');
+
+    node.setName('newName');
+
+    expect(node.name()).toBe('newName');
+  });
+
+  it('setMetadata changes metadata', () => {
+    const node = createStringNode('str-1', 'name');
+
+    node.setMetadata({ description: 'Updated' });
+
+    expect(node.metadata().description).toBe('Updated');
+  });
+
+  it('setDefaultValue changes default value', () => {
+    const node = createStringNode('str-1', 'name', { defaultValue: 'old' });
+
+    node.setDefaultValue('new');
+
+    expect(node.defaultValue()).toBe('new');
+  });
+
+  it('setFormula changes formula', () => {
+    const node = createStringNode('str-1', 'name');
+
+    node.setFormula({ version: 1, expression: 'a + b' });
+
+    expect(node.formula()).toEqual({ version: 1, expression: 'a + b' });
+    expect(node.hasFormula()).toBe(true);
+  });
+
+  it('setFormula with undefined removes formula', () => {
+    const node = createStringNode('str-1', 'name', {
+      formula: { version: 1, expression: 'a + b' },
+    });
+
+    node.setFormula(undefined);
+
+    expect(node.formula()).toBeUndefined();
+    expect(node.hasFormula()).toBe(false);
+  });
+
+  it('setForeignKey changes foreign key', () => {
+    const node = createStringNode('str-1', 'userId');
+
+    node.setForeignKey('users');
+
+    expect(node.foreignKey()).toBe('users');
+  });
+
+  it('setForeignKey with undefined removes foreign key', () => {
+    const node = createStringNode('str-1', 'userId', { foreignKey: 'users' });
+
+    node.setForeignKey(undefined);
+
+    expect(node.foreignKey()).toBeUndefined();
+  });
+
+  it('addChild is no-op for primitive', () => {
+    const node = createStringNode('str-1', 'name');
+    const child = createStringNode('str-2', 'child');
+
+    node.addChild(child);
+
+    expect(node.properties()).toHaveLength(0);
+  });
+
+  it('removeChild returns false for primitive', () => {
+    const node = createStringNode('str-1', 'name');
+
+    const result = node.removeChild('any');
+
+    expect(result).toBe(false);
+  });
+
+  it('setItems is no-op for primitive', () => {
+    const node = createStringNode('str-1', 'name');
+    const items = createStringNode('str-2', '');
+
+    node.setItems(items);
+
+    expect(node.items()).toBe(NULL_NODE);
+  });
+});

--- a/src/core/schema-node/__tests__/RefNode.spec.ts
+++ b/src/core/schema-node/__tests__/RefNode.spec.ts
@@ -87,4 +87,70 @@ describe('RefNode', () => {
 
     expect(node.metadata()).toBe(EMPTY_METADATA);
   });
+
+  describe('mutations', () => {
+    it('setName changes the name', () => {
+      const node = createRefNode('ref-1', 'oldName', 'File');
+
+      node.setName('newName');
+
+      expect(node.name()).toBe('newName');
+    });
+
+    it('setMetadata changes metadata', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      node.setMetadata({ description: 'Updated' });
+
+      expect(node.metadata().description).toBe('Updated');
+    });
+
+    it('addChild is no-op for ref', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      node.addChild(createRefNode('ref-2', 'child', 'File'));
+
+      expect(node.properties()).toHaveLength(0);
+    });
+
+    it('removeChild returns false for ref', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      const result = node.removeChild('any');
+
+      expect(result).toBe(false);
+    });
+
+    it('setItems is no-op for ref', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      node.setItems(createRefNode('ref-2', '', 'File'));
+
+      expect(node.items()).toBe(NULL_NODE);
+    });
+
+    it('setDefaultValue is no-op for ref', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      node.setDefaultValue('test');
+
+      expect(node.defaultValue()).toBeUndefined();
+    });
+
+    it('setFormula is no-op for ref', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      node.setFormula({ version: 1, expression: 'test' });
+
+      expect(node.formula()).toBeUndefined();
+    });
+
+    it('setForeignKey is no-op for ref', () => {
+      const node = createRefNode('ref-1', 'avatar', 'File');
+
+      node.setForeignKey('users');
+
+      expect(node.foreignKey()).toBeUndefined();
+    });
+  });
 });

--- a/src/core/schema-node/types.ts
+++ b/src/core/schema-node/types.ts
@@ -43,4 +43,13 @@ export interface SchemaNode {
   foreignKey(): string | undefined;
 
   clone(): SchemaNode;
+
+  setName(name: string): void;
+  setMetadata(metadata: NodeMetadata): void;
+  addChild(node: SchemaNode): void;
+  removeChild(name: string): boolean;
+  setItems(node: SchemaNode): void;
+  setDefaultValue(value: unknown): void;
+  setFormula(formula: Formula | undefined): void;
+  setForeignKey(key: string | undefined): void;
 }

--- a/src/core/schema-patch/PatchBuilder.ts
+++ b/src/core/schema-patch/PatchBuilder.ts
@@ -1,0 +1,31 @@
+import type { SchemaTree } from '../schema-tree/index.js';
+import {
+  NodePathIndex,
+  collectChanges,
+  coalesceChanges,
+} from '../schema-diff/index.js';
+import { PatchGenerator } from './PatchGenerator.js';
+import { PatchEnricher } from './PatchEnricher.js';
+import type { SchemaPatch } from './types.js';
+
+export class PatchBuilder {
+  build(currentTree: SchemaTree, baseTree: SchemaTree): SchemaPatch[] {
+    const index = new NodePathIndex(baseTree);
+    this.syncReplacements(currentTree, index);
+
+    const rawChanges = collectChanges(baseTree, currentTree, index);
+    const coalesced = coalesceChanges(rawChanges, currentTree, index);
+
+    const generator = new PatchGenerator(currentTree, baseTree);
+    const patches = generator.generate(coalesced);
+
+    const enricher = new PatchEnricher(currentTree, baseTree);
+    return patches.map((patch) => enricher.enrich(patch));
+  }
+
+  private syncReplacements(tree: SchemaTree, index: NodePathIndex): void {
+    for (const [oldId, newId] of tree.replacements()) {
+      index.trackReplacement(oldId, newId);
+    }
+  }
+}

--- a/src/core/schema-patch/PatchEnricher.ts
+++ b/src/core/schema-patch/PatchEnricher.ts
@@ -1,0 +1,273 @@
+import type { SchemaNode } from '../schema-node/index.js';
+import type { SchemaTree } from '../schema-tree/index.js';
+import { jsonPointerToPath } from '../path/index.js';
+import type { JsonPatch, SchemaPatch } from './types.js';
+
+export class PatchEnricher {
+  constructor(
+    private readonly currentTree: SchemaTree,
+    private readonly baseTree: SchemaTree,
+  ) {}
+
+  enrich(patch: JsonPatch): SchemaPatch {
+    const fieldName = this.getFieldNameFromPath(patch.path);
+
+    if (patch.op === 'add') {
+      return this.enrichAddPatch(patch, fieldName);
+    }
+
+    if (patch.op === 'remove') {
+      return this.enrichRemovePatch(patch, fieldName);
+    }
+
+    if (patch.op === 'move') {
+      return this.enrichMovePatch(patch, fieldName);
+    }
+
+    return this.enrichReplacePatch(patch, fieldName);
+  }
+
+  private enrichAddPatch(patch: JsonPatch, fieldName: string): SchemaPatch {
+    const currentNode = this.getNodeAtPath(this.currentTree, patch.path);
+
+    if (!currentNode) {
+      return { patch, fieldName };
+    }
+
+    return {
+      patch,
+      fieldName,
+      ...this.computeAddMetadata(currentNode),
+    };
+  }
+
+  private enrichRemovePatch(patch: JsonPatch, fieldName: string): SchemaPatch {
+    return { patch, fieldName };
+  }
+
+  private enrichMovePatch(patch: JsonPatch, fieldName: string): SchemaPatch {
+    const fromPath = patch.from || '';
+    const isRename = this.isRenameMove(fromPath, patch.path);
+
+    const baseNode = this.getNodeAtPath(this.baseTree, fromPath);
+    const currentNode = this.getNodeAtPath(this.currentTree, patch.path);
+
+    const formulaChange = this.computeFormulaChange(baseNode, currentNode);
+
+    return {
+      patch,
+      fieldName,
+      isRename: isRename || undefined,
+      formulaChange,
+    };
+  }
+
+  private enrichReplacePatch(patch: JsonPatch, fieldName: string): SchemaPatch {
+    const baseNode = this.getNodeAtPath(this.baseTree, patch.path);
+    const currentNode = this.getNodeAtPath(this.currentTree, patch.path);
+
+    const isArrayMetadataPatch = baseNode?.isArray() && currentNode?.isArray();
+
+    return {
+      patch,
+      fieldName,
+      typeChange: this.computeTypeChange(baseNode, currentNode, isArrayMetadataPatch),
+      formulaChange: this.computeFormulaChange(baseNode, currentNode),
+      defaultChange: isArrayMetadataPatch
+        ? undefined
+        : this.computeDefaultChange(baseNode, currentNode),
+      descriptionChange: this.computeDescriptionChange(baseNode, currentNode),
+      deprecatedChange: this.computeDeprecatedChange(baseNode, currentNode),
+      foreignKeyChange: this.computeForeignKeyChange(baseNode, currentNode),
+    };
+  }
+
+  private computeAddMetadata(
+    node: SchemaNode,
+  ): Partial<SchemaPatch> {
+    const result: Partial<SchemaPatch> = {};
+
+    const formula = node.formula();
+    if (formula) {
+      result.formulaChange = {
+        fromFormula: undefined,
+        toFormula: formula.expression,
+      };
+    }
+
+    const defaultValue = node.defaultValue();
+    if (defaultValue !== undefined && defaultValue !== '' && defaultValue !== 0 && defaultValue !== false) {
+      result.defaultChange = {
+        fromDefault: undefined,
+        toDefault: defaultValue as string | number | boolean,
+      };
+    }
+
+    const meta = node.metadata();
+    if (meta.description) {
+      result.descriptionChange = {
+        fromDescription: undefined,
+        toDescription: meta.description,
+      };
+    }
+
+    if (meta.deprecated) {
+      result.deprecatedChange = {
+        fromDeprecated: undefined,
+        toDeprecated: meta.deprecated,
+      };
+    }
+
+    const foreignKey = node.foreignKey();
+    if (foreignKey) {
+      result.foreignKeyChange = {
+        fromForeignKey: undefined,
+        toForeignKey: foreignKey,
+      };
+    }
+
+    return result;
+  }
+
+  private computeTypeChange(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+    ignoreItems?: boolean,
+  ): SchemaPatch['typeChange'] {
+    if (!baseNode || !currentNode) {
+      return undefined;
+    }
+
+    const baseType = this.getNodeType(baseNode);
+    const currentType = this.getNodeType(currentNode);
+
+    if (ignoreItems) {
+      const baseBaseType = baseNode.nodeType();
+      const currentBaseType = currentNode.nodeType();
+      if (baseBaseType === currentBaseType) {
+        return undefined;
+      }
+    }
+
+    if (baseType !== currentType) {
+      return { fromType: baseType, toType: currentType };
+    }
+
+    return undefined;
+  }
+
+  private computeFormulaChange(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+  ): SchemaPatch['formulaChange'] {
+    const baseFormula = baseNode?.formula();
+    const currentFormula = currentNode?.formula();
+
+    const baseExpr = baseFormula?.expression;
+    const currentExpr = currentFormula?.expression;
+
+    if (baseExpr !== currentExpr) {
+      return { fromFormula: baseExpr, toFormula: currentExpr };
+    }
+
+    return undefined;
+  }
+
+  private computeDefaultChange(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+  ): SchemaPatch['defaultChange'] {
+    const baseDefault = baseNode?.defaultValue();
+    const currentDefault = currentNode?.defaultValue();
+
+    if (baseDefault !== currentDefault) {
+      return {
+        fromDefault: baseDefault as string | number | boolean | undefined,
+        toDefault: currentDefault as string | number | boolean | undefined,
+      };
+    }
+
+    return undefined;
+  }
+
+  private computeDescriptionChange(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+  ): SchemaPatch['descriptionChange'] {
+    const baseDesc = baseNode?.metadata().description;
+    const currentDesc = currentNode?.metadata().description;
+
+    if (baseDesc !== currentDesc) {
+      return { fromDescription: baseDesc, toDescription: currentDesc };
+    }
+
+    return undefined;
+  }
+
+  private computeDeprecatedChange(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+  ): SchemaPatch['deprecatedChange'] {
+    const baseDeprecated = baseNode?.metadata().deprecated;
+    const currentDeprecated = currentNode?.metadata().deprecated;
+
+    if (baseDeprecated !== currentDeprecated) {
+      return { fromDeprecated: baseDeprecated, toDeprecated: currentDeprecated };
+    }
+
+    return undefined;
+  }
+
+  private computeForeignKeyChange(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+  ): SchemaPatch['foreignKeyChange'] {
+    const baseFk = baseNode?.foreignKey();
+    const currentFk = currentNode?.foreignKey();
+
+    if (baseFk !== currentFk) {
+      return { fromForeignKey: baseFk, toForeignKey: currentFk };
+    }
+
+    return undefined;
+  }
+
+  private getNodeType(node: SchemaNode): string {
+    if (node.isArray()) {
+      const items = node.items();
+      return `array<${this.getNodeType(items)}>`;
+    }
+    return node.nodeType();
+  }
+
+  private getFieldNameFromPath(jsonPointer: string): string {
+    try {
+      return jsonPointerToPath(jsonPointer).asSimple();
+    } catch {
+      return '';
+    }
+  }
+
+  private isRenameMove(fromPointer: string, toPointer: string): boolean {
+    try {
+      const fromParent = jsonPointerToPath(fromPointer).parent();
+      const toParent = jsonPointerToPath(toPointer).parent();
+      return fromParent.equals(toParent);
+    } catch {
+      return false;
+    }
+  }
+
+  private getNodeAtPath(
+    tree: SchemaTree,
+    jsonPointer: string,
+  ): SchemaNode | null {
+    try {
+      const path = jsonPointerToPath(jsonPointer);
+      const node = tree.nodeAt(path);
+      return node.isNull() ? null : node;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/core/schema-patch/PatchGenerator.ts
+++ b/src/core/schema-patch/PatchGenerator.ts
@@ -1,0 +1,383 @@
+import type { SchemaNode } from '../schema-node/index.js';
+import type { SchemaTree } from '../schema-tree/index.js';
+import type { Path } from '../path/index.js';
+import { jsonPointerToPath } from '../path/index.js';
+import { SchemaSerializer } from '../schema-serializer/index.js';
+import { areNodesContentEqual } from '../schema-diff/index.js';
+import type {
+  CoalescedChanges,
+  MovedChange,
+  AddedChange,
+  RemovedChange,
+  ModifiedChange,
+} from '../schema-diff/index.js';
+import type { JsonPatch } from './types.js';
+
+export class PatchGenerator {
+  private readonly serializer = new SchemaSerializer();
+
+  constructor(
+    private readonly currentTree: SchemaTree,
+    private readonly baseTree: SchemaTree,
+  ) {}
+
+  generate(coalesced: CoalescedChanges): JsonPatch[] {
+    const movedNodeIds = this.collectMovedNodeIds(coalesced.moved);
+    const movePatches = this.generateMovePatches(coalesced.moved);
+    const addPatches = this.generateAddPatches(coalesced.added, movedNodeIds);
+    const removePatches = this.generateRemovePatches(coalesced.removed);
+
+    const { prerequisiteAdds, regularAdds } = this.partitionAddPatches(
+      addPatches,
+      movePatches,
+    );
+
+    const childChangePaths = new Set([
+      ...addPatches.map((p) => p.path),
+      ...removePatches.map((p) => p.path),
+      ...movePatches.flatMap((p) => [p.path, p.from ?? '']).filter(Boolean),
+    ]);
+
+    const replacePatches = this.generateReplacePatches(
+      coalesced.modified,
+      childChangePaths,
+      movedNodeIds,
+    );
+
+    return [
+      ...prerequisiteAdds,
+      ...movePatches,
+      ...replacePatches,
+      ...regularAdds,
+      ...removePatches,
+    ];
+  }
+
+  private collectMovedNodeIds(moved: readonly MovedChange[]): Set<string> {
+    const nodeIds = new Set<string>();
+    for (const change of moved) {
+      nodeIds.add(change.currentNode.id());
+    }
+    return nodeIds;
+  }
+
+  private partitionAddPatches(
+    addPatches: JsonPatch[],
+    movePatches: JsonPatch[],
+  ): { prerequisiteAdds: JsonPatch[]; regularAdds: JsonPatch[] } {
+    const moveDestinations = movePatches.map((p) => jsonPointerToPath(p.path));
+
+    const prerequisiteAdds: JsonPatch[] = [];
+    const regularAdds: JsonPatch[] = [];
+
+    for (const addPatch of addPatches) {
+      const addPath = jsonPointerToPath(addPatch.path);
+      const isPrerequisite = moveDestinations.some((moveDest) =>
+        moveDest.isChildOf(addPath),
+      );
+
+      if (isPrerequisite) {
+        prerequisiteAdds.push(addPatch);
+      } else {
+        regularAdds.push(addPatch);
+      }
+    }
+
+    return { prerequisiteAdds, regularAdds };
+  }
+
+  private generateMovePatches(moved: readonly MovedChange[]): JsonPatch[] {
+    const patches: JsonPatch[] = [];
+
+    for (const change of moved) {
+      const basePath = this.baseTree.pathOf(change.baseNode.id());
+      const currentPath = this.currentTree.pathOf(change.currentNode.id());
+
+      patches.push({
+        op: 'move',
+        from: basePath.asJsonPointer(),
+        path: currentPath.asJsonPointer(),
+      });
+
+      const modifyPatch = this.generateModifyAfterMove(
+        change.baseNode,
+        change.currentNode,
+        currentPath.asJsonPointer(),
+      );
+      if (modifyPatch) {
+        patches.push(modifyPatch);
+      }
+    }
+
+    return patches;
+  }
+
+  private generateModifyAfterMove(
+    baseNode: SchemaNode,
+    currentNode: SchemaNode,
+    currentPath: string,
+  ): JsonPatch | null {
+    if (areNodesContentEqual(currentNode, baseNode)) {
+      return null;
+    }
+
+    const currentSchema = this.serializer.serializeNode(
+      currentNode,
+      this.currentTree,
+    );
+
+    return {
+      op: 'replace',
+      path: currentPath,
+      value: currentSchema,
+    };
+  }
+
+  private generateAddPatches(
+    added: readonly AddedChange[],
+    movedNodeIds: Set<string>,
+  ): JsonPatch[] {
+    const patches: JsonPatch[] = [];
+
+    for (const change of added) {
+      const currentPath = this.currentTree.pathOf(change.currentNode.id());
+      const schema = this.serializer.serializeNode(
+        change.currentNode,
+        this.currentTree,
+        { excludeNodeIds: movedNodeIds },
+      );
+      patches.push({
+        op: 'add',
+        path: currentPath.asJsonPointer(),
+        value: schema,
+      });
+    }
+
+    return patches;
+  }
+
+  private generateRemovePatches(removed: readonly RemovedChange[]): JsonPatch[] {
+    const patches: JsonPatch[] = [];
+
+    for (const change of removed) {
+      const basePath = this.baseTree.pathOf(change.baseNode.id());
+      patches.push({
+        op: 'remove',
+        path: basePath.asJsonPointer(),
+      });
+    }
+
+    return patches;
+  }
+
+  private generateReplacePatches(
+    modified: readonly ModifiedChange[],
+    childChangePaths: Set<string>,
+    movedNodeIds: Set<string>,
+  ): JsonPatch[] {
+    const patches: JsonPatch[] = [];
+    const replacedPaths: Path[] = [];
+    const childChangePathObjects = [...childChangePaths].map(jsonPointerToPath);
+
+    for (const change of modified) {
+      if (movedNodeIds.has(change.currentNode.id())) {
+        continue;
+      }
+
+      const currentPath = this.currentTree.pathOf(change.currentNode.id());
+
+      if (this.isChildOfAny(currentPath, replacedPaths)) {
+        continue;
+      }
+
+      if (this.hasChildIn(currentPath, childChangePathObjects)) {
+        continue;
+      }
+
+      if (!this.isActuallyModified(change)) {
+        continue;
+      }
+
+      if (change.currentNode.isArray()) {
+        const arrayPatches = this.generateArrayReplacePatches(
+          change.currentNode,
+          change.baseNode,
+          currentPath,
+        );
+        patches.push(...arrayPatches);
+        replacedPaths.push(currentPath);
+        continue;
+      }
+
+      const schema = this.serializer.serializeNode(
+        change.currentNode,
+        this.currentTree,
+      );
+      patches.push({
+        op: 'replace',
+        path: currentPath.asJsonPointer(),
+        value: schema,
+      });
+      replacedPaths.push(currentPath);
+    }
+
+    return patches;
+  }
+
+  private generateArrayReplacePatches(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+    currentPath: Path,
+  ): JsonPatch[] {
+    if (!baseNode.isArray()) {
+      const schema = this.serializer.serializeNode(
+        currentNode,
+        this.currentTree,
+      );
+      return [
+        {
+          op: 'replace',
+          path: currentPath.asJsonPointer(),
+          value: schema,
+        },
+      ];
+    }
+
+    const patches: JsonPatch[] = [];
+    const metadataChanged = this.hasMetadataChanged(currentNode, baseNode);
+    const itemsChanged = this.hasItemsChanged(currentNode, baseNode);
+
+    if (metadataChanged) {
+      const schema = this.serializer.serializeNode(
+        currentNode,
+        this.currentTree,
+      );
+      patches.push({
+        op: 'replace',
+        path: currentPath.asJsonPointer(),
+        value: schema,
+      });
+    }
+
+    if (itemsChanged) {
+      const items = currentNode.items();
+      const itemsPath = currentPath.childItems();
+      const itemsSchema = this.serializer.serializeNode(
+        items,
+        this.currentTree,
+      );
+      patches.push({
+        op: 'replace',
+        path: itemsPath.asJsonPointer(),
+        value: itemsSchema,
+      });
+    }
+
+    return patches;
+  }
+
+  private hasItemsChanged(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+  ): boolean {
+    const items = currentNode.items();
+    const baseItems = baseNode.items();
+
+    const currentItemsSchema = this.serializer.serializeNode(
+      items,
+      this.currentTree,
+    );
+    const baseItemsSchema = this.serializer.serializeNode(
+      baseItems,
+      this.baseTree,
+    );
+
+    return JSON.stringify(currentItemsSchema) !== JSON.stringify(baseItemsSchema);
+  }
+
+  private isChildOfAny(path: Path, parents: Path[]): boolean {
+    return parents.some((parent) => path.isChildOf(parent));
+  }
+
+  private hasChildIn(path: Path, candidates: Path[]): boolean {
+    return candidates.some((candidate) => candidate.isChildOf(path));
+  }
+
+  private isActuallyModified(change: ModifiedChange): boolean {
+    const currentSchema = this.serializer.serializeNode(
+      change.currentNode,
+      this.currentTree,
+    );
+    const baseSchema = this.serializer.serializeNode(
+      change.baseNode,
+      this.baseTree,
+    );
+
+    if (JSON.stringify(currentSchema) === JSON.stringify(baseSchema)) {
+      return false;
+    }
+
+    if (
+      change.currentNode.isObject() &&
+      this.hasOnlyChildChanges(change.currentNode, change.baseNode)
+    ) {
+      return false;
+    }
+
+    if (
+      change.currentNode.isArray() &&
+      this.hasOnlyItemsChanges(change.currentNode, change.baseNode)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private hasOnlyChildChanges(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+  ): boolean {
+    if (!baseNode.isObject()) {
+      return false;
+    }
+
+    if (this.hasMetadataChanged(currentNode, baseNode)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private hasMetadataChanged(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+  ): boolean {
+    const currentMeta = currentNode.metadata();
+    const baseMeta = baseNode.metadata();
+
+    return (
+      currentMeta.title !== baseMeta.title ||
+      currentMeta.description !== baseMeta.description ||
+      currentMeta.deprecated !== baseMeta.deprecated
+    );
+  }
+
+  private hasOnlyItemsChanges(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+  ): boolean {
+    if (!baseNode.isArray()) {
+      return false;
+    }
+
+    if (this.hasMetadataChanged(currentNode, baseNode)) {
+      return false;
+    }
+
+    const items = currentNode.items();
+    const baseItems = baseNode.items();
+
+    return items.id() === baseItems.id();
+  }
+}

--- a/src/core/schema-patch/README.md
+++ b/src/core/schema-patch/README.md
@@ -1,0 +1,160 @@
+# schema-patch
+
+Generates JSON Patch operations from schema tree changes with rich metadata for UI display.
+
+## Overview
+
+The schema-patch module provides a pipeline for converting schema tree differences into JSON Patch operations (RFC 6902) with additional metadata like type changes, formula changes, and more.
+
+## Components
+
+### PatchBuilder
+
+Main entry point that orchestrates the entire pipeline:
+
+```typescript
+import { PatchBuilder } from '@revisium/schema-toolkit/core';
+
+const builder = new PatchBuilder();
+const patches = builder.build(currentTree, baseTree);
+```
+
+### PatchGenerator
+
+Converts coalesced changes into JSON Patch operations:
+
+```typescript
+import { PatchGenerator } from '@revisium/schema-toolkit/core';
+
+const generator = new PatchGenerator(currentTree, baseTree);
+const jsonPatches = generator.generate(coalescedChanges);
+```
+
+### PatchEnricher
+
+Adds metadata to JSON Patches for UI display:
+
+```typescript
+import { PatchEnricher } from '@revisium/schema-toolkit/core';
+
+const enricher = new PatchEnricher(currentTree, baseTree);
+const schemaPatch = enricher.enrich(jsonPatch);
+```
+
+## Types
+
+### JsonPatch
+
+Standard JSON Patch operation:
+
+```typescript
+interface JsonPatch {
+  op: 'add' | 'remove' | 'replace' | 'move';
+  path: string;
+  from?: string;
+  value?: JsonSchema;
+}
+```
+
+### SchemaPatch
+
+Enriched patch with metadata:
+
+```typescript
+interface SchemaPatch {
+  patch: JsonPatch;
+  fieldName: string;
+  typeChange?: { fromType: string; toType: string };
+  formulaChange?: { fromFormula: string | undefined; toFormula: string | undefined };
+  defaultChange?: { fromDefault: DefaultValueType; toDefault: DefaultValueType };
+  descriptionChange?: { fromDescription: string | undefined; toDescription: string | undefined };
+  deprecatedChange?: { fromDeprecated: boolean | undefined; toDeprecated: boolean | undefined };
+  foreignKeyChange?: { fromForeignKey: string | undefined; toForeignKey: string | undefined };
+  isRename?: boolean;
+}
+```
+
+## Pipeline
+
+```
+SchemaTree (current) + SchemaTree (base)
+    ↓
+ChangeCollector → RawChange[]
+    ↓
+ChangeCoalescer → CoalescedChanges
+    ↓
+PatchGenerator → JsonPatch[]
+    ↓
+PatchEnricher → SchemaPatch[]
+```
+
+## Patch Ordering
+
+Patches are ordered for safe sequential application:
+
+1. **Prerequisite Adds** - Parent containers needed for moves
+2. **Moves** - Rename/relocate operations
+3. **Replaces** - Modification patches
+4. **Regular Adds** - New field additions
+5. **Removes** - Field deletions
+
+## Examples
+
+### Detect field rename
+
+```typescript
+const baseRoot = createObjectNode('root', 'root', [
+  createStringNode('field-id', 'oldName'),
+]);
+const currentRoot = createObjectNode('root', 'root', [
+  createStringNode('field-id', 'newName'),
+]);
+
+const baseTree = createSchemaTree(baseRoot);
+const currentTree = createSchemaTree(currentRoot);
+
+const builder = new PatchBuilder();
+const patches = builder.build(currentTree, baseTree);
+
+// patches[0]:
+// {
+//   patch: { op: 'move', from: '/properties/oldName', path: '/properties/newName' },
+//   fieldName: 'newName',
+//   isRename: true
+// }
+```
+
+### Detect type change
+
+```typescript
+const baseRoot = createObjectNode('root', 'root', [
+  createStringNode('old-id', 'field'),
+]);
+const currentRoot = createObjectNode('root', 'root', [
+  createNumberNode('new-id', 'field'),
+]);
+
+const baseTree = createSchemaTree(baseRoot);
+const currentTree = createSchemaTree(currentRoot);
+
+currentTree.trackReplacement('old-id', 'new-id');
+
+const patches = builder.build(currentTree, baseTree);
+
+// patches[0].typeChange:
+// { fromType: 'string', toType: 'number' }
+```
+
+### Array items changes
+
+```typescript
+// Field name for array items uses [*] notation:
+// - 'items[*].name' for field inside array items
+// - 'items[*]' for the array items type itself
+```
+
+## Dependencies
+
+- schema-diff: Change collection and coalescing
+- schema-serializer: Node to JSON Schema conversion
+- path: JSON Pointer handling

--- a/src/core/schema-patch/__tests__/PatchBuilder.arrays.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.arrays.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  obj,
+  arr,
+  str,
+  num,
+} from './test-helpers.js';
+
+describe('PatchBuilder array operations', () => {
+  it('generates add patch for field inside array items', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', obj('', [str('existingField')], { id: 'items-id' }))]),
+      objRoot([arr('items', obj('', [str('existingField'), str('newField')], { id: 'items-id' }))]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates remove patch for field inside array items', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', obj('', [str('fieldA'), str('fieldB')], { id: 'items-id' }))]),
+      objRoot([arr('items', obj('', [str('fieldB')], { id: 'items-id' }))]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates replace patch for field inside array items', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', obj('', [str('name', { default: 'initial' })], { id: 'items-id' }))]),
+      objRoot([arr('items', obj('', [str('name', { default: 'modified' })], { id: 'items-id' }))]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates move patch for renamed field inside array items', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', obj('', [str('oldName', { id: 'field-id' })], { id: 'items-id' }))]),
+      objRoot([arr('items', obj('', [str('newName', { id: 'field-id' })], { id: 'items-id' }))]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates replace patch for items when array items type changes', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', str('', { id: 'items-id' }))]),
+      objRoot([arr('items', num('', { id: 'new-items-id' }))]),
+    );
+
+    current.trackReplacement('items-id', 'new-items-id');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates replace patch for array when only array metadata changes', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', str('', { id: 'items-id' }))]),
+      objRoot([arr('items', str('', { id: 'items-id' }), { description: 'New description' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates two patches when both array metadata and items type change', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', str('', { id: 'items-id' }))]),
+      objRoot([arr('items', num('', { id: 'new-items-id' }), { description: 'New description' })]),
+    );
+
+    current.trackReplacement('items-id', 'new-items-id');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchBuilder.basic.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.basic.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  obj,
+  str,
+  num,
+} from './test-helpers.js';
+
+describe('PatchBuilder basic operations', () => {
+  describe('no changes', () => {
+    it('returns empty array when trees are identical', () => {
+      const { base, current } = treePair(
+        objRoot([str('name', { default: 'test' })]),
+        objRoot([str('name', { default: 'test' })]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('adding top-level field', () => {
+    it('generates add patch for new top-level field', () => {
+      const { base, current } = treePair(
+        objRoot([str('existing')]),
+        objRoot([str('existing'), str('newField')]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('adding nested field', () => {
+    it('generates add patch for new nested field', () => {
+      const { base, current } = treePair(
+        objRoot([obj('nested', [str('te')])]),
+        objRoot([obj('nested', [str('te'), str('new')])]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('modifying field', () => {
+    it('generates replace patch when default value changes', () => {
+      const { base, current } = treePair(
+        objRoot([str('name', { default: 'initial' })]),
+        objRoot([str('name', { default: 'modified' })]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('removing field', () => {
+    it('generates remove patch when top-level field is deleted', () => {
+      const { base, current } = treePair(
+        objRoot([str('name'), num('age')]),
+        objRoot([num('age')]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates remove patch when nested field is deleted', () => {
+      const { base, current } = treePair(
+        objRoot([obj('nested', [str('fieldA'), str('fieldB')])]),
+        objRoot([obj('nested', [str('fieldB')])]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('renaming field', () => {
+    it('generates move patch when field is renamed', () => {
+      const { base, current } = treePair(
+        objRoot([str('oldName', { id: 'field-id' })]),
+        objRoot([str('newName', { id: 'field-id' })]),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchBuilder.edgeCases.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.edgeCases.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  obj,
+  arr,
+  str,
+} from './test-helpers.js';
+
+describe('PatchBuilder edge cases', () => {
+  it('removes parent with children - single remove patch for parent', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj('parent', [
+          str('child1'),
+          str('child2'),
+          obj('nested', [str('grandchild')]),
+        ]),
+      ]),
+      objRoot([]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('renames parent - children move together, single move patch', () => {
+    const { base, current } = treePair(
+      objRoot([obj('oldParent', [str('child1'), str('child2')], { id: 'parent-id' })]),
+      objRoot([obj('newParent', [str('child1'), str('child2')], { id: 'parent-id' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('rename + modify generates move then replace', () => {
+    const { base, current } = treePair(
+      objRoot([str('oldName', { id: 'field-id', default: 'initial' })]),
+      objRoot([str('newName', { id: 'field-id', default: 'modified' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});
+
+describe('PatchBuilder patch ordering', () => {
+  it('move patches come before add/remove', () => {
+    const { base, current } = treePair(
+      objRoot([str('fieldA', { id: 'fieldA-id' }), str('fieldB')]),
+      objRoot([str('renamedA', { id: 'fieldA-id' }), str('newField')]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('add then remove same path in sequence - net effect is no change', () => {
+    const { base, current } = treePair(
+      objRoot([str('existing')]),
+      objRoot([str('existing')]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('multiple renames in sequence', () => {
+    const { base, current } = treePair(
+      objRoot([
+        str('a', { id: 'a-id' }),
+        str('b', { id: 'b-id' }),
+        str('c', { id: 'c-id' }),
+      ]),
+      objRoot([
+        str('x', { id: 'a-id' }),
+        str('y', { id: 'b-id' }),
+        str('z', { id: 'c-id' }),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('array items rename with nested modifications', () => {
+    const { base, current } = treePair(
+      objRoot([
+        arr('items', obj('', [str('oldField', { id: 'field-id', default: 'original' })], { id: 'items-id' })),
+      ]),
+      objRoot([
+        arr('items', obj('', [str('newField', { id: 'field-id', default: 'modified' })], { id: 'items-id' })),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchBuilder.metadata.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.metadata.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  str,
+  num,
+} from './test-helpers.js';
+
+describe('PatchBuilder SchemaPatch metadata', () => {
+  it('detects type change from string to number', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { id: 'old-field' })]),
+      objRoot([num('field', { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects formula addition', () => {
+    const { base, current } = treePair(
+      objRoot([num('field')]),
+      objRoot([num('field', { formula: { version: 1, expression: 'value * 2' } })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects formula removal', () => {
+    const { base, current } = treePair(
+      objRoot([num('computed', { formula: { version: 1, expression: 'value * 2' } })]),
+      objRoot([num('computed')]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects default value change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { default: 'initial' })]),
+      objRoot([str('field', { default: 'modified' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects description change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { description: 'old description' })]),
+      objRoot([str('field', { description: 'new description' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects deprecated change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field')]),
+      objRoot([str('field', { deprecated: true })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects foreignKey addition', () => {
+    const { base, current } = treePair(
+      objRoot([str('field')]),
+      objRoot([str('field', { foreignKey: 'users' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects foreignKey change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { foreignKey: 'users' })]),
+      objRoot([str('field', { foreignKey: 'categories' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('detects foreignKey removal', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { foreignKey: 'users' })]),
+      objRoot([str('field')]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('marks move as rename when parent is same', () => {
+    const { base, current } = treePair(
+      objRoot([str('oldName', { id: 'field-id' })]),
+      objRoot([str('newName', { id: 'field-id' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});
+
+describe('PatchBuilder add patch metadata', () => {
+  it('includes formula in add patch when field has formula', () => {
+    const { base, current } = treePair(
+      objRoot([num('value')]),
+      objRoot([num('value'), num('computed', { formula: { version: 1, expression: 'value * 2' } })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('includes description in add patch when field has description', () => {
+    const { base, current } = treePair(
+      objRoot([]),
+      objRoot([str('field', { description: 'My description' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('includes deprecated in add patch when field is deprecated', () => {
+    const { base, current } = treePair(
+      objRoot([]),
+      objRoot([str('field', { deprecated: true })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('includes default value in add patch when not standard', () => {
+    const { base, current } = treePair(
+      objRoot([]),
+      objRoot([str('field', { default: 'my default' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('includes foreignKey in add patch when field has foreignKey', () => {
+    const { base, current } = treePair(
+      objRoot([]),
+      objRoot([str('categoryId', { foreignKey: 'categories' })]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchBuilder.nested.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.nested.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  obj,
+  str,
+  num,
+} from './test-helpers.js';
+
+describe('PatchBuilder nested operations', () => {
+  it('generates replace patch for nested field modification', () => {
+    const { base, current } = treePair(
+      objRoot([obj('nested', [num('value', { default: 10 })])]),
+      objRoot([obj('nested', [num('value', { default: 20 })])]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates move patch for renamed nested field', () => {
+    const { base, current } = treePair(
+      objRoot([obj('nested', [str('oldName', { id: 'field-id' })])]),
+      objRoot([obj('nested', [str('newName', { id: 'field-id' })])]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates multiple patches for multiple changes in one object', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj('nested', [
+          str('fieldA', { default: 'a' }),
+          str('fieldB', { default: 'b' }),
+          str('fieldC', { default: 'c' }),
+        ]),
+      ]),
+      objRoot([
+        obj('nested', [
+          str('fieldA', { default: 'modified' }),
+          str('fieldC', { default: 'c' }),
+          str('fieldD'),
+        ]),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchBuilder.rootChanges.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.rootChanges.spec.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  arrRoot,
+  strRoot,
+  numRoot,
+  boolRoot,
+  obj,
+  arr,
+  str,
+} from './test-helpers.js';
+
+describe('PatchBuilder root changes', () => {
+  describe('object root', () => {
+    it('generates replace patch when root description changes', () => {
+      const { base, current } = treePair(
+        objRoot([str('name')]),
+        objRoot([str('name')], { description: 'New root description' }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates replace patch when root deprecated changes', () => {
+      const { base, current } = treePair(
+        objRoot([str('name')]),
+        objRoot([str('name')], { deprecated: true }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('primitive root', () => {
+    it('string root - no changes', () => {
+      const { base, current } = treePair(
+        strRoot({ default: 'hello' }),
+        strRoot({ default: 'hello' }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('string root - description change', () => {
+      const { base, current } = treePair(
+        strRoot({ default: 'hello' }),
+        strRoot({ default: 'hello', description: 'A string value' }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('string root - default value change', () => {
+      const { base, current } = treePair(
+        strRoot({ default: 'old' }),
+        strRoot({ default: 'new' }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('number root - default value change', () => {
+      const { base, current } = treePair(
+        numRoot({ default: 0 }),
+        numRoot({ default: 42 }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('boolean root - deprecated change', () => {
+      const { base, current } = treePair(
+        boolRoot({ default: false }),
+        boolRoot({ default: false, deprecated: true }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('array root', () => {
+    it('array root with primitive items - no changes', () => {
+      const { base, current } = treePair(
+        arrRoot(str('', { id: 'items' })),
+        arrRoot(str('', { id: 'items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array root - description change on root', () => {
+      const { base, current } = treePair(
+        arrRoot(str('', { id: 'items' })),
+        arrRoot(str('', { id: 'items' }), { description: 'Array of strings' }),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array root - items default value change', () => {
+      const { base, current } = treePair(
+        arrRoot(str('', { id: 'items', default: 'old' })),
+        arrRoot(str('', { id: 'items', default: 'new' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array root with object items - add field to items', () => {
+      const { base, current } = treePair(
+        arrRoot(obj('', [str('existing')], { id: 'items' })),
+        arrRoot(obj('', [str('existing'), str('new')], { id: 'items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array root with object items - remove field from items', () => {
+      const { base, current } = treePair(
+        arrRoot(obj('', [str('fieldA'), str('fieldB')], { id: 'items' })),
+        arrRoot(obj('', [str('fieldB')], { id: 'items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array root with object items - rename field in items', () => {
+      const { base, current } = treePair(
+        arrRoot(obj('', [str('oldName', { id: 'field-id' })], { id: 'items' })),
+        arrRoot(obj('', [str('newName', { id: 'field-id' })], { id: 'items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('nested arrays', () => {
+    it('array of arrays - no changes', () => {
+      const { base, current } = treePair(
+        arrRoot(arr('', str('', { id: 'inner-items' }), { id: 'outer-items' })),
+        arrRoot(arr('', str('', { id: 'inner-items' }), { id: 'outer-items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array of arrays - inner items change', () => {
+      const { base, current } = treePair(
+        arrRoot(arr('', str('', { id: 'inner-items', default: 'old' }), { id: 'outer-items' })),
+        arrRoot(arr('', str('', { id: 'inner-items', default: 'new' }), { id: 'outer-items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array of arrays of objects - add field to innermost object', () => {
+      const { base, current } = treePair(
+        arrRoot(arr('', obj('', [str('existing')], { id: 'inner-obj' }), { id: 'outer-items' })),
+        arrRoot(arr('', obj('', [str('existing'), str('new')], { id: 'inner-obj' }), { id: 'outer-items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array of arrays of objects - remove field from innermost object', () => {
+      const { base, current } = treePair(
+        arrRoot(arr('', obj('', [str('fieldA'), str('fieldB')], { id: 'inner-obj' }), { id: 'outer-items' })),
+        arrRoot(arr('', obj('', [str('fieldB')], { id: 'inner-obj' }), { id: 'outer-items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('array of arrays of objects - rename field in innermost object', () => {
+      const { base, current } = treePair(
+        arrRoot(arr('', obj('', [str('oldName', { id: 'field-id' })], { id: 'inner-obj' }), { id: 'outer-items' })),
+        arrRoot(arr('', obj('', [str('newName', { id: 'field-id' })], { id: 'inner-obj' }), { id: 'outer-items' })),
+      );
+
+      const patches = builder.build(current, base);
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchBuilder.typeChanges.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.typeChanges.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  builder,
+  treePair,
+  objRoot,
+  obj,
+  arr,
+  str,
+} from './test-helpers.js';
+
+describe('PatchBuilder type changes', () => {
+  it('primitive to object', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { id: 'old-field' })]),
+      objRoot([obj('field', [str('nested')], { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('primitive to array', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { id: 'old-field' })]),
+      objRoot([arr('field', str('', { id: 'items-id' }), { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('object to primitive', () => {
+    const { base, current } = treePair(
+      objRoot([obj('field', [str('nested')], { id: 'old-field' })]),
+      objRoot([str('field', { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('object to array', () => {
+    const { base, current } = treePair(
+      objRoot([obj('field', [str('nested')], { id: 'old-field' })]),
+      objRoot([arr('field', str('', { id: 'items-id' }), { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const patches = builder.build(current, base);
+
+    expect(patches).toMatchSnapshot();
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchEnricher.edgeCases.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.edgeCases.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from '@jest/globals';
+import { PatchEnricher } from '../PatchEnricher.js';
+import {
+  treePair,
+  objRoot,
+  str,
+} from './test-helpers.js';
+import type { JsonPatch } from '../types.js';
+
+describe('PatchEnricher edge cases', () => {
+  describe('invalid paths', () => {
+    it('handles invalid json pointer in path', () => {
+      const { current, base } = treePair(
+        objRoot([str('field')]),
+        objRoot([str('field')]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: 'invalid-no-slash' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('handles invalid json pointer in move from path', () => {
+      const { current, base } = treePair(
+        objRoot([str('field')]),
+        objRoot([str('field')]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'move',
+        from: 'invalid-no-slash',
+        path: '/properties/field',
+      };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('handles path to non-existent node', () => {
+      const { current, base } = treePair(
+        objRoot([str('field')]),
+        objRoot([str('field')]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'add',
+        path: '/properties/nonexistent/properties/deep',
+      };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchEnricher.replace.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.replace.spec.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from '@jest/globals';
+import { PatchEnricher } from '../PatchEnricher.js';
+import {
+  treePair,
+  objRoot,
+  obj,
+  arr,
+  str,
+  num,
+} from './test-helpers.js';
+import type { JsonPatch } from '../types.js';
+
+describe('PatchEnricher replace patch enrichment', () => {
+  it('detects type change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { id: 'old-field' })]),
+      objRoot([num('field', { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects array type with items', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { id: 'old-field' })]),
+      objRoot([arr('field', num('', { id: 'items' }), { id: 'new-field' })]),
+    );
+
+    current.trackReplacement('old-field', 'new-field');
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects formula addition', () => {
+    const { base, current } = treePair(
+      objRoot([num('field')]),
+      objRoot([num('field', { formula: { version: 1, expression: 'value * 2' } })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects formula removal', () => {
+    const { base, current } = treePair(
+      objRoot([num('field', { formula: { version: 1, expression: 'value * 2' } })]),
+      objRoot([num('field')]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects formula change', () => {
+    const { base, current } = treePair(
+      objRoot([num('field', { formula: { version: 1, expression: 'value * 2' } })]),
+      objRoot([num('field', { formula: { version: 1, expression: 'value * 3' } })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects default value change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { default: 'old' })]),
+      objRoot([str('field', { default: 'new' })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects description change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { description: 'old' })]),
+      objRoot([str('field', { description: 'new' })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects deprecated change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field')]),
+      objRoot([str('field', { deprecated: true })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects foreignKey change', () => {
+    const { base, current } = treePair(
+      objRoot([str('field', { foreignKey: 'users' })]),
+      objRoot([str('field', { foreignKey: 'categories' })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('skips defaultChange for array replace when only metadata changes', () => {
+    const { base, current } = treePair(
+      objRoot([arr('items', str('', { id: 'item' }))]),
+      objRoot([arr('items', str('', { id: 'item' }), { description: 'Updated' })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = { op: 'replace', path: '/properties/items' };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+});
+
+describe('PatchEnricher move patch enrichment', () => {
+  it('marks as rename when parent is same', () => {
+    const { base, current } = treePair(
+      objRoot([str('oldName', { id: 'field-id' })]),
+      objRoot([str('newName', { id: 'field-id' })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = {
+      op: 'move',
+      from: '/properties/oldName',
+      path: '/properties/newName',
+    };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('does not mark as rename when parent differs', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj('source', [str('field', { id: 'field-id' })]),
+        obj('target', []),
+      ]),
+      objRoot([
+        obj('source', []),
+        obj('target', [str('field', { id: 'field-id' })]),
+      ]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = {
+      op: 'move',
+      from: '/properties/source/properties/field',
+      path: '/properties/target/properties/field',
+    };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+
+  it('detects formula change on move', () => {
+    const { base, current } = treePair(
+      objRoot([num('oldName', { id: 'field-id', formula: { version: 1, expression: 'value * 2' } })]),
+      objRoot([num('newName', { id: 'field-id', formula: { version: 1, expression: 'value * 3' } })]),
+    );
+
+    const enricher = new PatchEnricher(current, base);
+    const patch: JsonPatch = {
+      op: 'move',
+      from: '/properties/oldName',
+      path: '/properties/newName',
+    };
+
+    expect(enricher.enrich(patch)).toMatchSnapshot();
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchEnricher.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from '@jest/globals';
+import { PatchEnricher } from '../PatchEnricher.js';
+import {
+  treePair,
+  objRoot,
+  strRoot,
+  obj,
+  arr,
+  str,
+  num,
+} from './test-helpers.js';
+import type { JsonPatch } from '../types.js';
+
+describe('PatchEnricher', () => {
+  describe('fieldName extraction', () => {
+    it('extracts simple field name', () => {
+      const { current } = treePair(
+        objRoot([str('name')]),
+        objRoot([str('name')]),
+      );
+
+      const enricher = new PatchEnricher(current, current);
+      const patch: JsonPatch = { op: 'replace', path: '/properties/name' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('extracts nested field name', () => {
+      const { current } = treePair(
+        objRoot([obj('nested', [str('field')])]),
+        objRoot([obj('nested', [str('field')])]),
+      );
+
+      const enricher = new PatchEnricher(current, current);
+      const patch: JsonPatch = { op: 'replace', path: '/properties/nested/properties/field' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('extracts array items field name', () => {
+      const { current } = treePair(
+        objRoot([arr('items', obj('', [str('name')], { id: 'itemsNode' }))]),
+        objRoot([arr('items', obj('', [str('name')], { id: 'itemsNode' }))]),
+      );
+
+      const enricher = new PatchEnricher(current, current);
+      const patch: JsonPatch = { op: 'replace', path: '/properties/items/items/properties/name' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+
+  describe('add patch enrichment', () => {
+    it('includes formula in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([num('computed', { formula: { version: 1, expression: 'value * 2' } })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: '/properties/computed' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('includes description in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([str('field', { description: 'My description' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('includes deprecated in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([str('field', { deprecated: true })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('includes non-standard default value in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([str('field', { default: 'my default' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('includes foreignKey in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([str('categoryId', { foreignKey: 'categories' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: '/properties/categoryId' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('skips standard default values in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([str('field', { default: '' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+
+  describe('remove patch enrichment', () => {
+    it('returns patch with fieldName only', () => {
+      const { current } = treePair(
+        objRoot([str('field')]),
+        objRoot([str('field')]),
+      );
+
+      const enricher = new PatchEnricher(current, current);
+      const patch: JsonPatch = { op: 'remove', path: '/properties/field' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+
+  describe('root node patches', () => {
+    it('enriches root description change', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([], { description: 'Root description' }),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'replace', path: '' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('enriches primitive root default change', () => {
+      const { base, current } = treePair(
+        strRoot({ default: 'old' }),
+        strRoot({ default: 'new' }),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = { op: 'replace', path: '' };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/schema-patch/__tests__/PatchGenerator.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchGenerator.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from '@jest/globals';
+import { PatchGenerator } from '../PatchGenerator.js';
+import {
+  treePair,
+  objRoot,
+  obj,
+  arr,
+  str,
+  num,
+  changes,
+} from './test-helpers.js';
+
+describe('PatchGenerator', () => {
+  describe('generate add patches', () => {
+    it('generates add patch for new field', () => {
+      const { base, current } = treePair(
+        objRoot([str('existing')]),
+        objRoot([str('existing'), str('newField')]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({ added: [current.root().properties()[1]] }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates add patch for nested field', () => {
+      const { base, current } = treePair(
+        objRoot([obj('nested', [])]),
+        objRoot([obj('nested', [str('newField')])]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({ added: [current.root().properties()[0]?.properties()[0]] }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('generate remove patches', () => {
+    it('generates remove patch for deleted field', () => {
+      const { base, current } = treePair(
+        objRoot([str('name'), num('age')]),
+        objRoot([str('name')]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({ removed: [base.root().properties()[1]] }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('generate move patches', () => {
+    it('generates move patch for renamed field', () => {
+      const { base, current } = treePair(
+        objRoot([str('oldName', { id: 'field-id' })]),
+        objRoot([str('newName', { id: 'field-id' })]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          moved: [[base.root().properties()[0], current.root().properties()[0]]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates move then replace for rename with modification', () => {
+      const { base, current } = treePair(
+        objRoot([str('oldName', { id: 'field-id', default: 'old' })]),
+        objRoot([str('newName', { id: 'field-id', default: 'new' })]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          moved: [[base.root().properties()[0], current.root().properties()[0]]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('generate replace patches', () => {
+    it('generates replace patch for modified field', () => {
+      const { base, current } = treePair(
+        objRoot([str('name', { default: 'old' })]),
+        objRoot([str('name', { default: 'new' })]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          modified: [[base.root().properties()[0], current.root().properties()[0]]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('skips replace when only children changed', () => {
+      const { base, current } = treePair(
+        objRoot([obj('nested', [str('child', { default: 'old' })])]),
+        objRoot([obj('nested', [str('child', { default: 'new' })])]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          modified: [
+            [base.root().properties()[0], current.root().properties()[0]],
+            [
+              base.root().properties()[0]?.properties()[0],
+              current.root().properties()[0]?.properties()[0],
+            ],
+          ],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('patch ordering', () => {
+    it('orders patches: prerequisite adds -> moves -> replaces -> regular adds -> removes', () => {
+      const { base, current } = treePair(
+        objRoot([str('fieldA', { id: 'fieldA-id' }), str('toRemove')]),
+        objRoot([str('renamedA', { id: 'fieldA-id' }), obj('target', []), str('newField')]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          moved: [[base.root().properties()[0], current.root().properties()[0]]],
+          added: [current.root().properties()[1], current.root().properties()[2]],
+          removed: [base.root().properties()[1]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('array patches', () => {
+    it('generates add patch for field in array items', () => {
+      const { base, current } = treePair(
+        objRoot([arr('items', obj('', [str('existing')], { id: 'items-id' }))]),
+        objRoot([arr('items', obj('', [str('existing'), str('newField')], { id: 'items-id' }))]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          added: [current.root().properties()[0]?.items().properties()[1]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates replace patch when array items type changes', () => {
+      const { base, current } = treePair(
+        objRoot([arr('items', str('', { id: 'old-items' }))]),
+        objRoot([arr('items', num('', { id: 'new-items' }))]),
+      );
+
+      current.trackReplacement('old-items', 'new-items');
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          modified: [
+            [base.root().properties()[0]?.items(), current.root().properties()[0]?.items()],
+          ],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates separate patches for array metadata and items changes', () => {
+      const { base, current } = treePair(
+        objRoot([arr('items', str('', { id: 'old-items' }))]),
+        objRoot([arr('items', num('', { id: 'new-items' }), { description: 'Updated' })]),
+      );
+
+      current.trackReplacement('old-items', 'new-items');
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          modified: [
+            [base.root().properties()[0], current.root().properties()[0]],
+            [base.root().properties()[0]?.items(), current.root().properties()[0]?.items()],
+          ],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+
+  describe('prerequisite adds', () => {
+    it('orders add before move when adding parent of move destination', () => {
+      const { base, current } = treePair(
+        objRoot([str('field', { id: 'field-id' })]),
+        objRoot([obj('target', [str('field', { id: 'field-id' })])]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          moved: [[base.root().properties()[0], current.root().properties()[0]?.properties()[0]]],
+          added: [current.root().properties()[0]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.arrays.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.arrays.spec.ts.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder array operations generates add patch for field inside array items 1`] = `
+[
+  {
+    "fieldName": "items[*].newField",
+    "patch": {
+      "op": "add",
+      "path": "/properties/items/items/properties/newField",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder array operations generates move patch for renamed field inside array items 1`] = `
+[
+  {
+    "fieldName": "items[*].newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/items/items/properties/oldName",
+      "op": "move",
+      "path": "/properties/items/items/properties/newName",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder array operations generates remove patch for field inside array items 1`] = `
+[
+  {
+    "fieldName": "items[*].fieldA",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/items/items/properties/fieldA",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder array operations generates replace patch for array when only array metadata changes 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": {
+      "fromDescription": undefined,
+      "toDescription": "New description",
+    },
+    "fieldName": "items",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items",
+      "value": {
+        "description": "New description",
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder array operations generates replace patch for field inside array items 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "initial",
+      "toDefault": "modified",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "items[*].name",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items/items/properties/name",
+      "value": {
+        "default": "modified",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder array operations generates replace patch for items when array items type changes 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "items[*]",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items/items",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "number",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder array operations generates two patches when both array metadata and items type change 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": {
+      "fromDescription": undefined,
+      "toDescription": "New description",
+    },
+    "fieldName": "items",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items",
+      "value": {
+        "description": "New description",
+        "items": {
+          "default": 0,
+          "type": "number",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": undefined,
+  },
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "items[*]",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items/items",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "number",
+    },
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.basic.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.basic.spec.ts.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder basic operations adding nested field generates add patch for new nested field 1`] = `
+[
+  {
+    "fieldName": "nested.new",
+    "patch": {
+      "op": "add",
+      "path": "/properties/nested/properties/new",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder basic operations adding top-level field generates add patch for new top-level field 1`] = `
+[
+  {
+    "fieldName": "newField",
+    "patch": {
+      "op": "add",
+      "path": "/properties/newField",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder basic operations modifying field generates replace patch when default value changes 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "initial",
+      "toDefault": "modified",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "name",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/name",
+      "value": {
+        "default": "modified",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder basic operations no changes returns empty array when trees are identical 1`] = `[]`;
+
+exports[`PatchBuilder basic operations removing field generates remove patch when nested field is deleted 1`] = `
+[
+  {
+    "fieldName": "nested.fieldA",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/nested/properties/fieldA",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder basic operations removing field generates remove patch when top-level field is deleted 1`] = `
+[
+  {
+    "fieldName": "name",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/name",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder basic operations renaming field generates move patch when field is renamed 1`] = `
+[
+  {
+    "fieldName": "newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/oldName",
+      "op": "move",
+      "path": "/properties/newName",
+    },
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.edgeCases.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.edgeCases.spec.ts.snap
@@ -1,0 +1,168 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder edge cases removes parent with children - single remove patch for parent 1`] = `
+[
+  {
+    "fieldName": "parent",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/parent",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder edge cases rename + modify generates move then replace 1`] = `
+[
+  {
+    "fieldName": "newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/oldName",
+      "op": "move",
+      "path": "/properties/newName",
+    },
+  },
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "modified",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "newName",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/newName",
+      "value": {
+        "default": "modified",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder edge cases renames parent - children move together, single move patch 1`] = `
+[
+  {
+    "fieldName": "newParent",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/oldParent",
+      "op": "move",
+      "path": "/properties/newParent",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder patch ordering add then remove same path in sequence - net effect is no change 1`] = `[]`;
+
+exports[`PatchBuilder patch ordering array items rename with nested modifications 1`] = `
+[
+  {
+    "fieldName": "items[*].newField",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/items/items/properties/oldField",
+      "op": "move",
+      "path": "/properties/items/items/properties/newField",
+    },
+  },
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "modified",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "items[*].newField",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items/items/properties/newField",
+      "value": {
+        "default": "modified",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder patch ordering move patches come before add/remove 1`] = `
+[
+  {
+    "fieldName": "renamedA",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/fieldA",
+      "op": "move",
+      "path": "/properties/renamedA",
+    },
+  },
+  {
+    "fieldName": "newField",
+    "patch": {
+      "op": "add",
+      "path": "/properties/newField",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+  {
+    "fieldName": "fieldB",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/fieldB",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder patch ordering multiple renames in sequence 1`] = `
+[
+  {
+    "fieldName": "x",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/a",
+      "op": "move",
+      "path": "/properties/x",
+    },
+  },
+  {
+    "fieldName": "y",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/b",
+      "op": "move",
+      "path": "/properties/y",
+    },
+  },
+  {
+    "fieldName": "z",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/c",
+      "op": "move",
+      "path": "/properties/z",
+    },
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
@@ -1,0 +1,358 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "initial",
+      "toDefault": "modified",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "modified",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": {
+      "fromDeprecated": undefined,
+      "toDeprecated": true,
+    },
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "deprecated": true,
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": {
+      "fromDescription": "old description",
+      "toDescription": "new description",
+    },
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "description": "new description",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": {
+      "fromForeignKey": undefined,
+      "toForeignKey": "users",
+    },
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "foreignKey": "users",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": {
+      "fromForeignKey": "users",
+      "toForeignKey": "categories",
+    },
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "foreignKey": "categories",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": {
+      "fromForeignKey": "users",
+      "toForeignKey": undefined,
+    },
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": {
+      "fromFormula": undefined,
+      "toFormula": "value * 2",
+    },
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": 0,
+        "readOnly": true,
+        "type": "number",
+        "x-formula": {
+          "expression": "value * 2",
+          "version": 1,
+        },
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "computed",
+    "foreignKeyChange": undefined,
+    "formulaChange": {
+      "fromFormula": "value * 2",
+      "toFormula": undefined,
+    },
+    "patch": {
+      "op": "replace",
+      "path": "/properties/computed",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata detects type change from string to number 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "number",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder SchemaPatch metadata marks move as rename when parent is same 1`] = `
+[
+  {
+    "fieldName": "newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/oldName",
+      "op": "move",
+      "path": "/properties/newName",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder add patch metadata includes default value in add patch when not standard 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "my default",
+    },
+    "fieldName": "field",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field",
+      "value": {
+        "default": "my default",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder add patch metadata includes deprecated in add patch when field is deprecated 1`] = `
+[
+  {
+    "deprecatedChange": {
+      "fromDeprecated": undefined,
+      "toDeprecated": true,
+    },
+    "fieldName": "field",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "deprecated": true,
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder add patch metadata includes description in add patch when field has description 1`] = `
+[
+  {
+    "descriptionChange": {
+      "fromDescription": undefined,
+      "toDescription": "My description",
+    },
+    "fieldName": "field",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "description": "My description",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder add patch metadata includes foreignKey in add patch when field has foreignKey 1`] = `
+[
+  {
+    "fieldName": "categoryId",
+    "foreignKeyChange": {
+      "fromForeignKey": undefined,
+      "toForeignKey": "categories",
+    },
+    "patch": {
+      "op": "add",
+      "path": "/properties/categoryId",
+      "value": {
+        "default": "",
+        "foreignKey": "categories",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder add patch metadata includes formula in add patch when field has formula 1`] = `
+[
+  {
+    "fieldName": "computed",
+    "formulaChange": {
+      "fromFormula": undefined,
+      "toFormula": "value * 2",
+    },
+    "patch": {
+      "op": "add",
+      "path": "/properties/computed",
+      "value": {
+        "default": 0,
+        "readOnly": true,
+        "type": "number",
+        "x-formula": {
+          "expression": "value * 2",
+          "version": 1,
+        },
+      },
+    },
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
@@ -164,7 +164,9 @@ exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
     "foreignKeyChange": undefined,
     "formulaChange": {
       "fromFormula": undefined,
+      "fromVersion": undefined,
       "toFormula": "value * 2",
+      "toVersion": 1,
     },
     "patch": {
       "op": "replace",
@@ -194,7 +196,9 @@ exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
     "foreignKeyChange": undefined,
     "formulaChange": {
       "fromFormula": "value * 2",
+      "fromVersion": 1,
       "toFormula": undefined,
+      "toVersion": undefined,
     },
     "patch": {
       "op": "replace",
@@ -338,7 +342,9 @@ exports[`PatchBuilder add patch metadata includes formula in add patch when fiel
     "fieldName": "computed",
     "formulaChange": {
       "fromFormula": undefined,
+      "fromVersion": undefined,
       "toFormula": "value * 2",
+      "toVersion": 1,
     },
     "patch": {
       "op": "add",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder nested operations generates move patch for renamed nested field 1`] = `
+[
+  {
+    "fieldName": "nested.newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/nested/properties/oldName",
+      "op": "move",
+      "path": "/properties/nested/properties/newName",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder nested operations generates multiple patches for multiple changes in one object 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "a",
+      "toDefault": "modified",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "nested.fieldA",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/nested/properties/fieldA",
+      "value": {
+        "default": "modified",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+  {
+    "fieldName": "nested.fieldD",
+    "patch": {
+      "op": "add",
+      "path": "/properties/nested/properties/fieldD",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+  {
+    "fieldName": "nested.fieldB",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/nested/properties/fieldB",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder nested operations generates replace patch for nested field modification 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": 10,
+      "toDefault": 20,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "nested.value",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/nested/properties/value",
+      "value": {
+        "default": 20,
+        "type": "number",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.rootChanges.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.rootChanges.spec.ts.snap
@@ -1,0 +1,344 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder root changes array root array root - description change on root 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": {
+      "fromDescription": undefined,
+      "toDescription": "Array of strings",
+    },
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "description": "Array of strings",
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes array root array root - items default value change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "old",
+      "toDefault": "new",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "[*]",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/items",
+      "value": {
+        "default": "new",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes array root array root with object items - add field to items 1`] = `
+[
+  {
+    "fieldName": "[*].new",
+    "patch": {
+      "op": "add",
+      "path": "/items/properties/new",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder root changes array root array root with object items - remove field from items 1`] = `
+[
+  {
+    "fieldName": "[*].fieldA",
+    "patch": {
+      "op": "remove",
+      "path": "/items/properties/fieldA",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder root changes array root array root with object items - rename field in items 1`] = `
+[
+  {
+    "fieldName": "[*].newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/items/properties/oldName",
+      "op": "move",
+      "path": "/items/properties/newName",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder root changes array root array root with primitive items - no changes 1`] = `[]`;
+
+exports[`PatchBuilder root changes nested arrays array of arrays - inner items change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "old",
+      "toDefault": "new",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "[*][*]",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/items/items",
+      "value": {
+        "default": "new",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes nested arrays array of arrays - no changes 1`] = `[]`;
+
+exports[`PatchBuilder root changes nested arrays array of arrays of objects - add field to innermost object 1`] = `
+[
+  {
+    "fieldName": "[*][*].new",
+    "patch": {
+      "op": "add",
+      "path": "/items/items/properties/new",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder root changes nested arrays array of arrays of objects - remove field from innermost object 1`] = `
+[
+  {
+    "fieldName": "[*][*].fieldA",
+    "patch": {
+      "op": "remove",
+      "path": "/items/items/properties/fieldA",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder root changes nested arrays array of arrays of objects - rename field in innermost object 1`] = `
+[
+  {
+    "fieldName": "[*][*].newName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/items/items/properties/oldName",
+      "op": "move",
+      "path": "/items/items/properties/newName",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder root changes object root generates replace patch when root deprecated changes 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": {
+      "fromDeprecated": undefined,
+      "toDeprecated": true,
+    },
+    "descriptionChange": undefined,
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "additionalProperties": false,
+        "deprecated": true,
+        "properties": {
+          "name": {
+            "default": "",
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes object root generates replace patch when root description changes 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": {
+      "fromDescription": undefined,
+      "toDescription": "New root description",
+    },
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "additionalProperties": false,
+        "description": "New root description",
+        "properties": {
+          "name": {
+            "default": "",
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes primitive root boolean root - deprecated change 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": {
+      "fromDeprecated": undefined,
+      "toDeprecated": true,
+    },
+    "descriptionChange": undefined,
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "default": false,
+        "deprecated": true,
+        "type": "boolean",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes primitive root number root - default value change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": 0,
+      "toDefault": 42,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "default": 42,
+        "type": "number",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes primitive root string root - default value change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "old",
+      "toDefault": "new",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "default": "new",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes primitive root string root - description change 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": {
+      "fromDescription": undefined,
+      "toDescription": "A string value",
+    },
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "default": "hello",
+        "description": "A string value",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder root changes primitive root string root - no changes 1`] = `[]`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.typeChanges.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.typeChanges.spec.ts.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchBuilder type changes object to array 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": {
+      "fromType": "object",
+      "toType": "array<string>",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder type changes object to primitive 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+    "typeChange": {
+      "fromType": "object",
+      "toType": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder type changes primitive to array 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "array<string>",
+    },
+  },
+]
+`;
+
+exports[`PatchBuilder type changes primitive to object 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "additionalProperties": false,
+        "properties": {
+          "nested": {
+            "default": "",
+            "type": "string",
+          },
+        },
+        "required": [
+          "nested",
+        ],
+        "type": "object",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "object",
+    },
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.edgeCases.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.edgeCases.spec.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in move from path 1`] = `
+{
+  "fieldName": "field",
+  "formulaChange": undefined,
+  "isRename": undefined,
+  "patch": {
+    "from": "invalid-no-slash",
+    "op": "move",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in path 1`] = `
+{
+  "fieldName": "",
+  "patch": {
+    "op": "add",
+    "path": "invalid-no-slash",
+  },
+}
+`;
+
+exports[`PatchEnricher edge cases invalid paths handles path to non-existent node 1`] = `
+{
+  "fieldName": "nonexistent.deep",
+  "patch": {
+    "op": "add",
+    "path": "/properties/nonexistent/properties/deep",
+  },
+}
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
@@ -5,7 +5,9 @@ exports[`PatchEnricher move patch enrichment detects formula change on move 1`] 
   "fieldName": "newName",
   "formulaChange": {
     "fromFormula": "value * 2",
+    "fromVersion": 1,
     "toFormula": "value * 3",
+    "toVersion": 1,
   },
   "isRename": true,
   "patch": {
@@ -146,7 +148,9 @@ exports[`PatchEnricher replace patch enrichment detects formula addition 1`] = `
   "foreignKeyChange": undefined,
   "formulaChange": {
     "fromFormula": undefined,
+    "fromVersion": undefined,
     "toFormula": "value * 2",
+    "toVersion": 1,
   },
   "patch": {
     "op": "replace",
@@ -165,7 +169,9 @@ exports[`PatchEnricher replace patch enrichment detects formula change 1`] = `
   "foreignKeyChange": undefined,
   "formulaChange": {
     "fromFormula": "value * 2",
+    "fromVersion": 1,
     "toFormula": "value * 3",
+    "toVersion": 1,
   },
   "patch": {
     "op": "replace",
@@ -184,7 +190,9 @@ exports[`PatchEnricher replace patch enrichment detects formula removal 1`] = `
   "foreignKeyChange": undefined,
   "formulaChange": {
     "fromFormula": "value * 2",
+    "fromVersion": 1,
     "toFormula": undefined,
+    "toVersion": undefined,
   },
   "patch": {
     "op": "replace",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchEnricher move patch enrichment detects formula change on move 1`] = `
+{
+  "fieldName": "newName",
+  "formulaChange": {
+    "fromFormula": "value * 2",
+    "toFormula": "value * 3",
+  },
+  "isRename": true,
+  "patch": {
+    "from": "/properties/oldName",
+    "op": "move",
+    "path": "/properties/newName",
+  },
+}
+`;
+
+exports[`PatchEnricher move patch enrichment does not mark as rename when parent differs 1`] = `
+{
+  "fieldName": "target.field",
+  "formulaChange": undefined,
+  "isRename": undefined,
+  "patch": {
+    "from": "/properties/source/properties/field",
+    "op": "move",
+    "path": "/properties/target/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher move patch enrichment marks as rename when parent is same 1`] = `
+{
+  "fieldName": "newName",
+  "formulaChange": undefined,
+  "isRename": true,
+  "patch": {
+    "from": "/properties/oldName",
+    "op": "move",
+    "path": "/properties/newName",
+  },
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects array type with items 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": {
+    "fromType": "string",
+    "toType": "array<number>",
+  },
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects default value change 1`] = `
+{
+  "defaultChange": {
+    "fromDefault": "old",
+    "toDefault": "new",
+  },
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects deprecated change 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": {
+    "fromDeprecated": undefined,
+    "toDeprecated": true,
+  },
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects description change 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": {
+    "fromDescription": "old",
+    "toDescription": "new",
+  },
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects foreignKey change 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": {
+    "fromForeignKey": "users",
+    "toForeignKey": "categories",
+  },
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects formula addition 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": {
+    "fromFormula": undefined,
+    "toFormula": "value * 2",
+  },
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects formula change 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": {
+    "fromFormula": "value * 2",
+    "toFormula": "value * 3",
+  },
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects formula removal 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": {
+    "fromFormula": "value * 2",
+    "toFormula": undefined,
+  },
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects type change 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "field",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "typeChange": {
+    "fromType": "string",
+    "toType": "number",
+  },
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment skips defaultChange for array replace when only metadata changes 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": {
+    "fromDescription": undefined,
+    "toDescription": "Updated",
+  },
+  "fieldName": "items",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/items",
+  },
+  "typeChange": undefined,
+}
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
@@ -47,7 +47,9 @@ exports[`PatchEnricher add patch enrichment includes formula in add patch metada
   "fieldName": "computed",
   "formulaChange": {
     "fromFormula": undefined,
+    "fromVersion": undefined,
     "toFormula": "value * 2",
+    "toVersion": 1,
   },
   "patch": {
     "op": "add",
@@ -72,6 +74,10 @@ exports[`PatchEnricher add patch enrichment includes non-standard default value 
 
 exports[`PatchEnricher add patch enrichment skips standard default values in add patch metadata 1`] = `
 {
+  "defaultChange": {
+    "fromDefault": undefined,
+    "toDefault": "",
+  },
   "fieldName": "field",
   "patch": {
     "op": "add",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchEnricher add patch enrichment includes deprecated in add patch metadata 1`] = `
+{
+  "deprecatedChange": {
+    "fromDeprecated": undefined,
+    "toDeprecated": true,
+  },
+  "fieldName": "field",
+  "patch": {
+    "op": "add",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher add patch enrichment includes description in add patch metadata 1`] = `
+{
+  "descriptionChange": {
+    "fromDescription": undefined,
+    "toDescription": "My description",
+  },
+  "fieldName": "field",
+  "patch": {
+    "op": "add",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher add patch enrichment includes foreignKey in add patch metadata 1`] = `
+{
+  "fieldName": "categoryId",
+  "foreignKeyChange": {
+    "fromForeignKey": undefined,
+    "toForeignKey": "categories",
+  },
+  "patch": {
+    "op": "add",
+    "path": "/properties/categoryId",
+  },
+}
+`;
+
+exports[`PatchEnricher add patch enrichment includes formula in add patch metadata 1`] = `
+{
+  "fieldName": "computed",
+  "formulaChange": {
+    "fromFormula": undefined,
+    "toFormula": "value * 2",
+  },
+  "patch": {
+    "op": "add",
+    "path": "/properties/computed",
+  },
+}
+`;
+
+exports[`PatchEnricher add patch enrichment includes non-standard default value in add patch metadata 1`] = `
+{
+  "defaultChange": {
+    "fromDefault": undefined,
+    "toDefault": "my default",
+  },
+  "fieldName": "field",
+  "patch": {
+    "op": "add",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher add patch enrichment skips standard default values in add patch metadata 1`] = `
+{
+  "fieldName": "field",
+  "patch": {
+    "op": "add",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher fieldName extraction extracts array items field name 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "items[*].name",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/items/items/properties/name",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher fieldName extraction extracts nested field name 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "nested.field",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/nested/properties/field",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher fieldName extraction extracts simple field name 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "name",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "/properties/name",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher remove patch enrichment returns patch with fieldName only 1`] = `
+{
+  "fieldName": "field",
+  "patch": {
+    "op": "remove",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher root node patches enriches primitive root default change 1`] = `
+{
+  "defaultChange": {
+    "fromDefault": "old",
+    "toDefault": "new",
+  },
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher root node patches enriches root description change 1`] = `
+{
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": {
+    "fromDescription": undefined,
+    "toDescription": "Root description",
+  },
+  "fieldName": "",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "patch": {
+    "op": "replace",
+    "path": "",
+  },
+  "typeChange": undefined,
+}
+`;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchGenerator.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchGenerator.spec.ts.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PatchGenerator array patches generates add patch for field in array items 1`] = `
+[
+  {
+    "op": "add",
+    "path": "/properties/items/items/properties/newField",
+    "value": {
+      "default": "",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator array patches generates replace patch when array items type changes 1`] = `
+[
+  {
+    "op": "replace",
+    "path": "/properties/items/items",
+    "value": {
+      "default": 0,
+      "type": "number",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator array patches generates separate patches for array metadata and items changes 1`] = `
+[
+  {
+    "op": "replace",
+    "path": "/properties/items",
+    "value": {
+      "description": "Updated",
+      "items": {
+        "default": 0,
+        "type": "number",
+      },
+      "type": "array",
+    },
+  },
+  {
+    "op": "replace",
+    "path": "/properties/items/items",
+    "value": {
+      "default": 0,
+      "type": "number",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator generate add patches generates add patch for nested field 1`] = `
+[
+  {
+    "op": "add",
+    "path": "/properties/nested/properties/newField",
+    "value": {
+      "default": "",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator generate add patches generates add patch for new field 1`] = `
+[
+  {
+    "op": "add",
+    "path": "/properties/newField",
+    "value": {
+      "default": "",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator generate move patches generates move patch for renamed field 1`] = `
+[
+  {
+    "from": "/properties/oldName",
+    "op": "move",
+    "path": "/properties/newName",
+  },
+]
+`;
+
+exports[`PatchGenerator generate move patches generates move then replace for rename with modification 1`] = `
+[
+  {
+    "from": "/properties/oldName",
+    "op": "move",
+    "path": "/properties/newName",
+  },
+  {
+    "op": "replace",
+    "path": "/properties/newName",
+    "value": {
+      "default": "new",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator generate remove patches generates remove patch for deleted field 1`] = `
+[
+  {
+    "op": "remove",
+    "path": "/properties/age",
+  },
+]
+`;
+
+exports[`PatchGenerator generate replace patches generates replace patch for modified field 1`] = `
+[
+  {
+    "op": "replace",
+    "path": "/properties/name",
+    "value": {
+      "default": "new",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator generate replace patches skips replace when only children changed 1`] = `
+[
+  {
+    "op": "replace",
+    "path": "/properties/nested/properties/child",
+    "value": {
+      "default": "new",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator patch ordering orders patches: prerequisite adds -> moves -> replaces -> regular adds -> removes 1`] = `
+[
+  {
+    "from": "/properties/fieldA",
+    "op": "move",
+    "path": "/properties/renamedA",
+  },
+  {
+    "op": "add",
+    "path": "/properties/target",
+    "value": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object",
+    },
+  },
+  {
+    "op": "add",
+    "path": "/properties/newField",
+    "value": {
+      "default": "",
+      "type": "string",
+    },
+  },
+  {
+    "op": "remove",
+    "path": "/properties/toRemove",
+  },
+]
+`;
+
+exports[`PatchGenerator prerequisite adds orders add before move when adding parent of move destination 1`] = `
+[
+  {
+    "op": "add",
+    "path": "/properties/target",
+    "value": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object",
+    },
+  },
+  {
+    "from": "/properties/field",
+    "op": "move",
+    "path": "/properties/target/properties/field",
+  },
+]
+`;

--- a/src/core/schema-patch/__tests__/test-helpers.ts
+++ b/src/core/schema-patch/__tests__/test-helpers.ts
@@ -1,0 +1,225 @@
+import { PatchBuilder } from '../PatchBuilder.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import type { SchemaTree } from '../../schema-tree/index.js';
+import type { SchemaNode, Formula, NodeMetadata } from '../../schema-node/index.js';
+import {
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+  createArrayNode,
+  createBooleanNode,
+} from '../../schema-node/index.js';
+import type {
+  CoalescedChanges,
+  AddedChange,
+  RemovedChange,
+  MovedChange,
+  ModifiedChange,
+} from '../../schema-diff/index.js';
+
+export const builder = new PatchBuilder();
+
+export {
+  createSchemaTree,
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+  createArrayNode,
+  createBooleanNode,
+};
+
+export type { SchemaTree, SchemaNode };
+
+interface PrimitiveNodeOptions {
+  id?: string;
+  default?: string | number | boolean;
+  formula?: Formula;
+  foreignKey?: string;
+  description?: string;
+  deprecated?: boolean;
+}
+
+interface ObjectNodeOptions {
+  id?: string;
+  description?: string;
+  deprecated?: boolean;
+}
+
+interface ArrayNodeOptions {
+  id?: string;
+  description?: string;
+  deprecated?: boolean;
+}
+
+const buildMetadata = (opts?: {
+  description?: string;
+  deprecated?: boolean;
+}): NodeMetadata | undefined => {
+  if (!opts?.description && !opts?.deprecated) {
+    return undefined;
+  }
+  return { description: opts.description, deprecated: opts.deprecated };
+};
+
+export const str = (
+  name: string,
+  opts?: PrimitiveNodeOptions,
+): SchemaNode => {
+  return createStringNode(opts?.id ?? name, name, {
+    defaultValue: opts?.default as string | undefined,
+    formula: opts?.formula,
+    foreignKey: opts?.foreignKey,
+    metadata: buildMetadata(opts),
+  });
+};
+
+export const num = (
+  name: string,
+  opts?: PrimitiveNodeOptions,
+): SchemaNode => {
+  return createNumberNode(opts?.id ?? name, name, {
+    defaultValue: opts?.default as number | undefined,
+    formula: opts?.formula,
+    metadata: buildMetadata(opts),
+  });
+};
+
+export const bool = (
+  name: string,
+  opts?: PrimitiveNodeOptions,
+): SchemaNode => {
+  return createBooleanNode(opts?.id ?? name, name, {
+    defaultValue: opts?.default as boolean | undefined,
+    metadata: buildMetadata(opts),
+  });
+};
+
+export const obj = (
+  name: string,
+  children: SchemaNode[],
+  opts?: ObjectNodeOptions,
+): SchemaNode => {
+  return createObjectNode(
+    opts?.id ?? name,
+    name,
+    children,
+    buildMetadata(opts),
+  );
+};
+
+export const arr = (
+  name: string,
+  items: SchemaNode,
+  opts?: ArrayNodeOptions,
+): SchemaNode => {
+  return createArrayNode(
+    opts?.id ?? name,
+    name,
+    items,
+    buildMetadata(opts),
+  );
+};
+
+export const objRoot = (
+  children: SchemaNode[],
+  opts?: { description?: string; deprecated?: boolean },
+): SchemaNode => {
+  return createObjectNode('root', 'root', children, buildMetadata(opts));
+};
+
+export const arrRoot = (
+  items: SchemaNode,
+  opts?: { description?: string; deprecated?: boolean },
+): SchemaNode => {
+  return createArrayNode('root', 'root', items, buildMetadata(opts));
+};
+
+export const strRoot = (
+  opts?: PrimitiveNodeOptions,
+): SchemaNode => {
+  return createStringNode('root', 'root', {
+    defaultValue: opts?.default as string | undefined,
+    formula: opts?.formula,
+    foreignKey: opts?.foreignKey,
+    metadata: buildMetadata(opts),
+  });
+};
+
+export const numRoot = (
+  opts?: PrimitiveNodeOptions,
+): SchemaNode => {
+  return createNumberNode('root', 'root', {
+    defaultValue: opts?.default as number | undefined,
+    formula: opts?.formula,
+    metadata: buildMetadata(opts),
+  });
+};
+
+export const boolRoot = (
+  opts?: PrimitiveNodeOptions,
+): SchemaNode => {
+  return createBooleanNode('root', 'root', {
+    defaultValue: opts?.default as boolean | undefined,
+    metadata: buildMetadata(opts),
+  });
+};
+
+export interface TreePair {
+  base: SchemaTree;
+  current: SchemaTree;
+}
+
+export const treePair = (
+  baseRoot: SchemaNode,
+  currentRoot: SchemaNode,
+): TreePair => ({
+  base: createSchemaTree(baseRoot),
+  current: createSchemaTree(currentRoot),
+});
+
+type MaybeNode = SchemaNode | undefined;
+
+interface ChangesInput {
+  added?: MaybeNode[];
+  removed?: MaybeNode[];
+  moved?: Array<[MaybeNode, MaybeNode]>;
+  modified?: Array<[MaybeNode, MaybeNode]>;
+}
+
+export const changes = (input: ChangesInput = {}): CoalescedChanges => {
+  const added: AddedChange[] = (input.added ?? [])
+    .filter((n): n is SchemaNode => n !== undefined)
+    .map((n) => ({
+      type: 'added' as const,
+      baseNode: null,
+      currentNode: n,
+    }));
+
+  const removed: RemovedChange[] = (input.removed ?? [])
+    .filter((n): n is SchemaNode => n !== undefined)
+    .map((n) => ({
+      type: 'removed' as const,
+      baseNode: n,
+      currentNode: null,
+    }));
+
+  const moved: MovedChange[] = (input.moved ?? [])
+    .filter((pair): pair is [SchemaNode, SchemaNode] =>
+      pair[0] !== undefined && pair[1] !== undefined)
+    .map(([b, c]) => ({
+      type: 'moved' as const,
+      baseNode: b,
+      currentNode: c,
+    }));
+
+  const modified: ModifiedChange[] = (input.modified ?? [])
+    .filter((pair): pair is [SchemaNode, SchemaNode] =>
+      pair[0] !== undefined && pair[1] !== undefined)
+    .map(([b, c]) => ({
+      type: 'modified' as const,
+      baseNode: b,
+      currentNode: c,
+    }));
+
+  return { added, removed, moved, modified };
+};

--- a/src/core/schema-patch/index.ts
+++ b/src/core/schema-patch/index.ts
@@ -1,0 +1,4 @@
+export { PatchBuilder } from './PatchBuilder.js';
+export { PatchGenerator } from './PatchGenerator.js';
+export { PatchEnricher } from './PatchEnricher.js';
+export type { JsonPatch, SchemaPatch, DefaultValueType } from './types.js';

--- a/src/core/schema-patch/types.ts
+++ b/src/core/schema-patch/types.ts
@@ -19,6 +19,8 @@ export interface SchemaPatch {
   formulaChange?: {
     fromFormula: string | undefined;
     toFormula: string | undefined;
+    fromVersion: number | undefined;
+    toVersion: number | undefined;
   };
   defaultChange?: {
     fromDefault: DefaultValueType;

--- a/src/core/schema-patch/types.ts
+++ b/src/core/schema-patch/types.ts
@@ -1,0 +1,40 @@
+import type { JsonSchema } from '../../types/index.js';
+
+export interface JsonPatch {
+  op: 'add' | 'remove' | 'replace' | 'move';
+  path: string;
+  from?: string;
+  value?: JsonSchema;
+}
+
+export type DefaultValueType = string | number | boolean | undefined;
+
+export interface SchemaPatch {
+  patch: JsonPatch;
+  fieldName: string;
+  typeChange?: {
+    fromType: string;
+    toType: string;
+  };
+  formulaChange?: {
+    fromFormula: string | undefined;
+    toFormula: string | undefined;
+  };
+  defaultChange?: {
+    fromDefault: DefaultValueType;
+    toDefault: DefaultValueType;
+  };
+  descriptionChange?: {
+    fromDescription: string | undefined;
+    toDescription: string | undefined;
+  };
+  deprecatedChange?: {
+    fromDeprecated: boolean | undefined;
+    toDeprecated: boolean | undefined;
+  };
+  foreignKeyChange?: {
+    fromForeignKey: string | undefined;
+    toForeignKey: string | undefined;
+  };
+  isRename?: boolean;
+}

--- a/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
+++ b/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
@@ -745,7 +745,7 @@ describe('SchemaSerializer', () => {
       );
 
       expect(() => {
-        serializer.serializeNode(mockArrayNode as ReturnType<typeof createObjectNode>, mockTree);
+        serializer.serializeNode(mockArrayNode as unknown as ReturnType<typeof createObjectNode>, mockTree);
       }).toThrow('Array node must have items');
     });
 
@@ -778,7 +778,7 @@ describe('SchemaSerializer', () => {
       );
 
       expect(() => {
-        serializer.serializeNode(mockRefNode as ReturnType<typeof createObjectNode>, mockTree);
+        serializer.serializeNode(mockRefNode as unknown as ReturnType<typeof createObjectNode>, mockTree);
       }).toThrow('Ref node must have a ref value');
     });
 
@@ -786,7 +786,7 @@ describe('SchemaSerializer', () => {
       const mockNode = {
         id: () => 'unknown-id',
         name: () => 'unknown',
-        nodeType: () => 'custom' as ReturnType<typeof createStringNode>['nodeType'],
+        nodeType: () => 'custom' as unknown as ReturnType<typeof createStringNode>['nodeType'],
         metadata: () => ({}),
         isObject: () => false,
         isArray: () => false,
@@ -811,7 +811,7 @@ describe('SchemaSerializer', () => {
       );
 
       expect(() => {
-        serializer.serializeNode(mockNode as ReturnType<typeof createObjectNode>, mockTree);
+        serializer.serializeNode(mockNode as unknown as ReturnType<typeof createObjectNode>, mockTree);
       }).toThrow('Unknown primitive type: custom');
     });
   });

--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -76,6 +76,10 @@ export class SchemaTreeImpl implements SchemaTree {
       return;
     }
 
+    if (parent.isArray()) {
+      throw new Error('Cannot add child to array node. Use setItems instead.');
+    }
+
     parent.addChild(node);
     this.rebuildIndex();
   }
@@ -92,8 +96,7 @@ export class SchemaTreeImpl implements SchemaTree {
       return false;
     }
 
-    const segments = path.segments();
-    const lastSegment = segments[segments.length - 1];
+    const lastSegment = path.segments().at(-1);
 
     if (!lastSegment || lastSegment.isItems()) {
       return false;
@@ -134,8 +137,24 @@ export class SchemaTreeImpl implements SchemaTree {
       return;
     }
 
+    if (currentParent.isArray()) {
+      throw new Error('Cannot move node from array. Array items cannot be moved.');
+    }
+
     const newParent = this.nodeById(newParentId);
     if (newParent.isNull()) {
+      return;
+    }
+
+    if (newParent.isArray()) {
+      throw new Error('Cannot move node into array. Use setItems instead.');
+    }
+
+    const newParentPath = this.pathOf(newParentId);
+    if (
+      newParentPath.equals(currentPath) ||
+      newParentPath.isChildOf(currentPath)
+    ) {
       return;
     }
 
@@ -156,8 +175,7 @@ export class SchemaTreeImpl implements SchemaTree {
       return;
     }
 
-    const segments = path.segments();
-    const lastSegment = segments[segments.length - 1];
+    const lastSegment = path.segments().at(-1);
 
     if (!lastSegment) {
       return;

--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -6,6 +6,7 @@ import { TreeNodeIndex } from './TreeNodeIndex.js';
 
 export class SchemaTreeImpl implements SchemaTree {
   private readonly index = new TreeNodeIndex();
+  private readonly _replacements = new Map<string, string>();
 
   constructor(private readonly rootNode: SchemaNode) {
     this.index.rebuild(rootNode);
@@ -54,7 +55,127 @@ export class SchemaTreeImpl implements SchemaTree {
   }
 
   clone(): SchemaTree {
-    return new SchemaTreeImpl(this.rootNode.clone());
+    const cloned = new SchemaTreeImpl(this.rootNode.clone());
+    for (const [oldId, newId] of this._replacements) {
+      cloned._replacements.set(oldId, newId);
+    }
+    return cloned;
+  }
+
+  trackReplacement(oldNodeId: string, newNodeId: string): void {
+    this._replacements.set(oldNodeId, newNodeId);
+  }
+
+  replacements(): IterableIterator<[string, string]> {
+    return this._replacements.entries();
+  }
+
+  addChildTo(parentId: string, node: SchemaNode): void {
+    const parent = this.nodeById(parentId);
+    if (parent.isNull()) {
+      return;
+    }
+
+    parent.addChild(node);
+    this.rebuildIndex();
+  }
+
+  removeNodeAt(path: Path): boolean {
+    if (path.isEmpty()) {
+      return false;
+    }
+
+    const parentPath = path.parent();
+    const parent = this.nodeAt(parentPath);
+
+    if (parent.isNull()) {
+      return false;
+    }
+
+    const segments = path.segments();
+    const lastSegment = segments[segments.length - 1];
+
+    if (!lastSegment || lastSegment.isItems()) {
+      return false;
+    }
+
+    const removed = parent.removeChild(lastSegment.propertyName());
+    if (removed) {
+      this.rebuildIndex();
+    }
+    return removed;
+  }
+
+  renameNode(nodeId: string, newName: string): void {
+    const node = this.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+
+    node.setName(newName);
+    this.rebuildIndex();
+  }
+
+  moveNode(nodeId: string, newParentId: string): void {
+    const node = this.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+
+    const currentPath = this.pathOf(nodeId);
+    if (currentPath.isEmpty()) {
+      return;
+    }
+
+    const currentParentPath = currentPath.parent();
+    const currentParent = this.nodeAt(currentParentPath);
+
+    if (currentParent.isNull()) {
+      return;
+    }
+
+    const newParent = this.nodeById(newParentId);
+    if (newParent.isNull()) {
+      return;
+    }
+
+    currentParent.removeChild(node.name());
+    newParent.addChild(node);
+    this.rebuildIndex();
+  }
+
+  setNodeAt(path: Path, node: SchemaNode): void {
+    if (path.isEmpty()) {
+      return;
+    }
+
+    const parentPath = path.parent();
+    const parent = this.nodeAt(parentPath);
+
+    if (parent.isNull()) {
+      return;
+    }
+
+    const segments = path.segments();
+    const lastSegment = segments[segments.length - 1];
+
+    if (!lastSegment) {
+      return;
+    }
+
+    if (lastSegment.isItems()) {
+      parent.setItems(node);
+    } else {
+      parent.removeChild(lastSegment.propertyName());
+      node.setName(lastSegment.propertyName());
+      parent.addChild(node);
+    }
+
+    this.rebuildIndex();
+  }
+
+  private rebuildIndex(): void {
+    this.index.rebuild(this.rootNode);
   }
 }
 

--- a/src/core/schema-tree/types.ts
+++ b/src/core/schema-tree/types.ts
@@ -9,4 +9,12 @@ export interface SchemaTree {
   nodeIds(): IterableIterator<string>;
   countNodes(): number;
   clone(): SchemaTree;
+  trackReplacement(oldNodeId: string, newNodeId: string): void;
+  replacements(): IterableIterator<[string, string]>;
+
+  addChildTo(parentId: string, node: SchemaNode): void;
+  removeNodeAt(path: Path): boolean;
+  renameNode(nodeId: string, newName: string): void;
+  moveNode(nodeId: string, newParentId: string): void;
+  setNodeAt(path: Path, node: SchemaNode): void;
 }

--- a/src/lib/__tests__/applyPatches.spec.ts
+++ b/src/lib/__tests__/applyPatches.spec.ts
@@ -2330,7 +2330,7 @@ describe('applyPatches', () => {
             type: 'number',
             default: 0,
             'x-formula': { version: 1, expression: 'price * 2' },
-          },
+          } as JsonSchema,
         }),
       );
     });
@@ -2358,7 +2358,7 @@ describe('applyPatches', () => {
             type: 'boolean',
             default: false,
             'x-formula': { version: 1, expression: 'count > 0' },
-          },
+          } as JsonSchema,
         }),
       );
     });
@@ -2394,7 +2394,7 @@ describe('applyPatches', () => {
               version: 1,
               expression: 'firstName + " " + lastName',
             },
-          },
+          } as JsonSchema,
         }),
       );
     });
@@ -2428,7 +2428,7 @@ describe('applyPatches', () => {
               type: 'number',
               default: 0,
               'x-formula': { version: 1, expression: 'a + b' },
-            },
+            } as JsonSchema,
           }),
         }),
       );

--- a/src/lib/__tests__/createJsonValueStore.spec.ts
+++ b/src/lib/__tests__/createJsonValueStore.spec.ts
@@ -34,13 +34,13 @@ describe('createJsonValueStore', () => {
     const array = root.value['fieldArray'] as JsonArrayValueStore;
     const nested = root.value['nested'] as JsonObjectValueStore;
 
-    expect(root.value['fieldString'].parent).toBe(root);
+    expect(root.value['fieldString']?.parent).toBe(root);
     expect(array.parent).toBe(root);
     for (const arrayValue of array.value) {
       expect(arrayValue.parent).toBe(array);
     }
     expect(nested.parent).toBe(root);
-    expect(nested.value['value'].parent).toBe(nested);
+    expect(nested.value['value']?.parent).toBe(nested);
 
     const expectedValue = root.getPlainValue();
     expect(expectedValue).toStrictEqual(value);
@@ -80,7 +80,7 @@ describe('createJsonValueStore', () => {
     for (const arrayValueObject of array.value) {
       const object = arrayValueObject as JsonObjectValueStore;
       expect(object.parent).toBe(array);
-      expect(object.value['field'].parent).toBe(object);
+      expect(object.value['field']?.parent).toBe(object);
 
       const arrayIds = object.value['ids'] as JsonArrayValueStore;
       expect(arrayIds.parent).toBe(object);

--- a/src/lib/__tests__/formula-array-context.spec.ts
+++ b/src/lib/__tests__/formula-array-context.spec.ts
@@ -26,7 +26,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -87,7 +87,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['orders'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         orders: [
@@ -124,7 +124,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['value', 'doubled'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const nodes = collectFormulaNodes(schema, { value: 10, doubled: 0 });
 
@@ -156,7 +156,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ position: 0 }, { position: 0 }, { position: 0 }],
@@ -192,7 +192,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ position: 0 }, { position: 0 }, { position: 0 }],
@@ -230,7 +230,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ totalCount: 0 }, { totalCount: 0 }, { totalCount: 0 }, { totalCount: 0 }],
@@ -269,7 +269,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ isFirst: false }, { isFirst: false }, { isFirst: false }],
@@ -305,7 +305,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ isLast: false }, { isLast: false }, { isLast: false }],
@@ -344,7 +344,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -385,7 +385,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['measurements'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         measurements: [
@@ -426,7 +426,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -483,7 +483,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['orders'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         orders: [
@@ -535,7 +535,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['groups'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         groups: [
@@ -607,7 +607,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['level1'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         level1: [
@@ -665,7 +665,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -706,7 +706,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -756,7 +756,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['sections'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         sections: [
@@ -795,7 +795,7 @@ describe('array context tokens integration', () => {
             },
           },
         },
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const { values, errors } = evaluateFormulas(schema, { items: [] });
 
@@ -835,7 +835,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ isFirst: false, isLast: false, length: 0 }],
@@ -877,7 +877,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -923,7 +923,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [
@@ -969,7 +969,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items', 'lastItem'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ value: 10 }, { value: 20 }, { value: 30 }],
@@ -1006,7 +1006,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['items', 'secondToLast'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         items: [{ value: 10 }, { value: 20 }, { value: 30 }],
@@ -1037,7 +1037,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['values', 'total'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         values: [10, 20, 30],
@@ -1066,7 +1066,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['values', 'itemCount'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         values: [10, 20, 30, 40, 50],
@@ -1095,7 +1095,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['values', 'average'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         values: [10, 20, 30],
@@ -1129,7 +1129,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['a', 'b', 'c', 'minValue', 'maxValue'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         a: 15,
@@ -1159,7 +1159,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['value', 'clamped'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const { values: v1 } = evaluateFormulas(schema, { value: 10, clamped: 0 });
       expect(v1['clamped']).toBe(10);
@@ -1192,7 +1192,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['values', 'total', 'itemCount'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         values: [],
@@ -1230,7 +1230,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['orders', 'orderCount'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         orders: [{ id: '1' }, { id: '2' }, { id: '3' }],
@@ -1287,7 +1287,7 @@ describe('array context tokens integration', () => {
         },
         additionalProperties: false,
         required: ['level1'],
-      } as JsonSchema;
+      } as unknown as JsonSchema;
 
       const data = {
         level1: [

--- a/src/lib/__tests__/formula.spec.ts
+++ b/src/lib/__tests__/formula.spec.ts
@@ -79,7 +79,7 @@ describe('collectFormulaNodes', () => {
       },
       additionalProperties: false,
       required: ['items'],
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -135,7 +135,7 @@ describe('collectFormulaNodes', () => {
       },
       additionalProperties: false,
       required: ['orders'],
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       orders: [
@@ -169,7 +169,7 @@ describe('collectFormulaNodes', () => {
       },
       additionalProperties: false,
       required: ['data', 'valid'],
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const result = collectFormulaNodes(schema, { data: {}, valid: 0 });
 
@@ -291,7 +291,7 @@ describe('evaluateFormulas', () => {
       },
       additionalProperties: false,
       required: ['items'],
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -352,7 +352,7 @@ describe('evaluateFormulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const { values, errors } = evaluateFormulas(schema, { items: [] });
 
@@ -404,7 +404,7 @@ describe('nested object formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = { rootValue: 50, nested: { computed: 0 } };
     const { values, errors } = evaluateFormulas(schema, data);
@@ -428,7 +428,7 @@ describe('nested object formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = { nested: { sourceValue: 25, computed: 0 } };
     const { values, errors } = evaluateFormulas(schema, data);
@@ -458,7 +458,7 @@ describe('nested object formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = { level1: { level2: { value: 10, result: 0 } } };
     const { values, errors } = evaluateFormulas(schema, data);
@@ -488,7 +488,7 @@ describe('root path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       taxRate: 0.1,
@@ -529,7 +529,7 @@ describe('root path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       config: { multiplier: 3 },
@@ -567,7 +567,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       discount: 0.2,
@@ -604,7 +604,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [{ itemVal: 10, inner: { price: 5, calc: 0 } }],
@@ -640,7 +640,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       rootRate: 2,
@@ -677,7 +677,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       container: {
@@ -716,7 +716,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       rootVal: 3,
@@ -752,7 +752,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       factor: 5,
@@ -791,7 +791,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       multiplier: 3,
@@ -828,7 +828,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       config: { discount: 0.9 },
@@ -875,7 +875,7 @@ describe('relative path formulas', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       settings: { tax: { rate: 0.1 } },
@@ -917,7 +917,7 @@ describe('nested arrays', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -964,7 +964,7 @@ describe('nested arrays', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -1005,7 +1005,7 @@ describe('nested arrays', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       globalRate: 2,
@@ -1052,7 +1052,7 @@ describe('nested arrays', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -1098,7 +1098,7 @@ describe('nested arrays', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -1144,7 +1144,7 @@ describe('nested arrays', () => {
           },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       rootFactor: 3,
@@ -1193,7 +1193,7 @@ describe('wildcard property access', () => {
           'x-formula': { version: 1, expression: 'sum(items[*].price)' },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [
@@ -1228,7 +1228,7 @@ describe('wildcard property access', () => {
           'x-formula': { version: 1, expression: 'count(items) > 0 ? avg(items[*].rating) : 0' },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [{ rating: 10 }, { rating: 20 }, { rating: 30 }],
@@ -1264,7 +1264,7 @@ describe('wildcard property access', () => {
           'x-formula': { version: 1, expression: 'sum(values[*].nested.value)' },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       values: [
@@ -1307,7 +1307,7 @@ describe('wildcard property access', () => {
           'x-formula': { version: 1, expression: 'sum(orders[*].items[*].amount)' },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       orders: [
@@ -1341,7 +1341,7 @@ describe('wildcard property access', () => {
           'x-formula': { version: 1, expression: 'sum(items[*].price)' },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [],
@@ -1372,7 +1372,7 @@ describe('wildcard property access', () => {
           'x-formula': { version: 1, expression: 'count(items[*].active)' },
         },
       },
-    } as JsonSchema;
+    } as unknown as JsonSchema;
 
     const data = {
       items: [{ active: true }, { active: false }, { active: true }],

--- a/src/lib/__tests__/validate-schema-formulas.spec.ts
+++ b/src/lib/__tests__/validate-schema-formulas.spec.ts
@@ -3,12 +3,7 @@ import {
   validateSchemaFormulas,
 } from '../validate-schema-formulas.js';
 
-interface JsonSchema {
-  type?: string;
-  properties?: Record<string, unknown>;
-  items?: unknown;
-  [key: string]: unknown;
-}
+type JsonSchema = Parameters<typeof validateSchemaFormulas>[0];
 
 describe('validateFormulaAgainstSchema', () => {
   const schema: JsonSchema = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new schema-patch module that turns schema diffs into RFC 6902 JSON Patches with rich metadata (type/default/formula/rename) for UI display. Refactors schema node classes to support in-place mutations, enabling accurate patch generation and application.

- **New Features**
  - Added PatchBuilder, PatchGenerator, and PatchEnricher to build JSON Patches (add/remove/replace/move) and enrich them with typeChange, defaultChange, description/deprecated/foreignKey, formulaChange, and isRename.
  - Added areNodesContentEqual for deep content comparison (metadata, items, and formula version) to avoid unnecessary replaces.
  - SchemaTree now tracks replacements and exposes mutation helpers (add/remove/move/rename/set at path) used during patch generation.

- **Refactors**
  - Introduced BaseNode and a mutable API across nodes (setName/setMetadata/addChild/removeChild/setItems/setDefaultValue/setFormula/setForeignKey); updated Object/Array/Primitive/Ref; NULL_NODE is no-op.
  - Tightened schema-diff types to discriminated unions (Added/Removed/Moved/Modified); updated ChangeCoalescer and exports; comparator now checks formula version.
  - Exported schema-patch from core, updated READMEs, and added extensive tests for the patch pipeline and node mutations.

<sup>Written for commit b21666ee582dc9d758d173f00cfdfae7548a61c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

