### PR TITLE
feat: schema model

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.coverage.exclusions=**/__tests__**,**/__mocks__**,**/*.spec.ts
 # ====================
 # Issue Ignore Rules
 # ====================
-sonar.issue.ignore.multicriteria=tech1,tech2,fp1,fp2,fp3
+sonar.issue.ignore.multicriteria=tech1,tech2,fp1,fp2,fp3,fp4
 
 # ====================
 # Technical Debt Exclusions
@@ -45,6 +45,10 @@ sonar.issue.ignore.multicriteria.fp2.resourceKey=**/schema-tree/**
 # FP: ObjectNode._children is mutated via push/splice, cannot be readonly
 sonar.issue.ignore.multicriteria.fp3.ruleKey=typescript:S4165
 sonar.issue.ignore.multicriteria.fp3.resourceKey=**/ObjectNode.ts
+
+# FP: SchemaNode.removeChild is not DOM API (S7762 variant of S6788)
+sonar.issue.ignore.multicriteria.fp4.ruleKey=typescript:S7762
+sonar.issue.ignore.multicriteria.fp4.resourceKey=**/schema-tree/**
 
 # ====================
 # Duplicate Code Exclusions

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,2 +1,3 @@
 export * from './schema/index.js';
 export * from './value/index.js';
+export * from './schema-model/index.js';

--- a/src/model/schema-model/NodeFactory.ts
+++ b/src/model/schema-model/NodeFactory.ts
@@ -1,0 +1,34 @@
+import { nanoid } from 'nanoid';
+import type { SchemaNode } from '../../core/schema-node/index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+} from '../../core/schema-node/index.js';
+import type { FieldType } from './types.js';
+
+export class NodeFactory {
+  createNode(name: string, type: FieldType): SchemaNode {
+    switch (type) {
+      case 'string':
+        return createStringNode(nanoid(), name, { defaultValue: '' });
+      case 'number':
+        return createNumberNode(nanoid(), name, { defaultValue: 0 });
+      case 'boolean':
+        return createBooleanNode(nanoid(), name, { defaultValue: false });
+      case 'object':
+        return createObjectNode(nanoid(), name, []);
+      case 'array':
+        return this.createArrayNode(name);
+      default:
+        throw new Error(`Unknown field type: ${type}`);
+    }
+  }
+
+  private createArrayNode(name: string): SchemaNode {
+    const items = createStringNode(nanoid(), 'items', { defaultValue: '' });
+    return createArrayNode(nanoid(), name, items);
+  }
+}

--- a/src/model/schema-model/README.md
+++ b/src/model/schema-model/README.md
@@ -1,0 +1,164 @@
+# schema-model
+
+Mutable model for JSON Schema editing with change tracking and patch generation.
+
+## Overview
+
+`SchemaModel` wraps the immutable `SchemaTree` (from Layer 1) and provides:
+- Mutable operations (add, remove, rename, update fields)
+- Optional reactivity through `ReactivityAdapter`
+- Change tracking (base tree vs current tree)
+- Patch generation using `schema-diff` + `schema-patch`
+
+## API
+
+### Creating a Model
+
+```typescript
+import { createSchemaModel } from '@revisium/schema-toolkit';
+import type { JsonObjectSchema } from '@revisium/schema-toolkit';
+
+const schema: JsonObjectSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'age'],
+  properties: {
+    name: { type: 'string', default: '' },
+    age: { type: 'number', default: 0 },
+  },
+};
+
+const model = createSchemaModel(schema);
+```
+
+### Tree Access
+
+```typescript
+// Get root node
+const root = model.root();
+
+// Find node by ID
+const node = model.nodeById('node-id');
+
+// Get path for node
+const path = model.pathOf('node-id');
+```
+
+### Mutations
+
+```typescript
+// Add field
+const newField = model.addField(parentId, 'email', 'string');
+
+// Remove field
+model.removeField(nodeId);
+
+// Rename field
+model.renameField(nodeId, 'newName');
+
+// Change field type
+const newNode = model.changeFieldType(nodeId, 'number');
+
+// Update metadata
+model.updateMetadata(nodeId, {
+  title: 'User Name',
+  description: 'Full name of the user',
+  deprecated: false,
+});
+
+// Update formula
+model.updateFormula(nodeId, 'price * quantity');
+
+// Update foreign key
+model.updateForeignKey(nodeId, 'categories');
+
+// Update default value
+model.updateDefaultValue(nodeId, 'default text');
+```
+
+### State Management
+
+```typescript
+// Check if there are unsaved changes
+if (model.isDirty()) {
+  // Get patches for changes
+  const patches = model.getPatches();
+
+  // Or get plain JSON patches
+  const jsonPatches = model.getJsonPatches();
+
+  // Save current state as base
+  model.markAsSaved();
+}
+
+// Revert all changes since last save
+model.revert();
+
+// Get serialized schema
+const plainSchema = model.getPlainSchema();
+```
+
+### With Reactivity (MobX)
+
+```typescript
+import { createSchemaModel } from '@revisium/schema-toolkit';
+import { mobxAdapter } from '@revisium/schema-toolkit-ui';
+
+const model = createSchemaModel(schema, { reactivity: mobxAdapter });
+
+// Now model properties are observable
+// - root(), isDirty(), getPatches(), etc. will trigger MobX reactions
+```
+
+## Field Types
+
+Supported field types for `addField` and `changeFieldType`:
+- `'string'` - String field with default `''`
+- `'number'` - Number field with default `0`
+- `'boolean'` - Boolean field with default `false`
+- `'object'` - Empty object
+- `'array'` - Array with string items
+
+## Patches
+
+The model generates enriched patches with metadata:
+
+```typescript
+interface SchemaPatch {
+  patch: JsonPatch;           // Standard JSON Patch
+  fieldName: string;          // Human-readable field path
+  typeChange?: {              // Present for type changes
+    fromType: string;
+    toType: string;
+  };
+  formulaChange?: {           // Present for formula changes
+    fromFormula: string | undefined;
+    toFormula: string | undefined;
+  };
+  defaultChange?: {           // Present for default value changes
+    fromDefault: unknown;
+    toDefault: unknown;
+  };
+  isRename?: boolean;         // True for move patches that are renames
+}
+```
+
+## Architecture
+
+```
+SchemaModel
+├── SchemaParser      - Parses JsonObjectSchema → SchemaNode tree
+├── NodeFactory       - Creates new SchemaNode instances
+├── SchemaTree        - Internal mutable tree (from core)
+├── PatchBuilder      - Generates patches (from core)
+└── SchemaSerializer  - Serializes tree to JSON (from core)
+```
+
+## Dependencies
+
+- `core/schema-node` - Immutable node types
+- `core/schema-tree` - Tree structure and navigation
+- `core/schema-diff` - Change detection
+- `core/schema-patch` - Patch generation
+- `core/schema-serializer` - JSON Schema serialization
+- `core/reactivity` - Optional reactivity adapter

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -1,0 +1,183 @@
+import type { SchemaNode, NodeMetadata, Formula } from '../../core/schema-node/index.js';
+import type { SchemaTree } from '../../core/schema-tree/index.js';
+import { createSchemaTree } from '../../core/schema-tree/index.js';
+import type { Path } from '../../core/path/index.js';
+import { PatchBuilder, type SchemaPatch, type JsonPatch } from '../../core/schema-patch/index.js';
+import { SchemaSerializer } from '../../core/schema-serializer/index.js';
+import type { JsonObjectSchema } from '../../types/index.js';
+import type { ReactivityAdapter } from '../../core/reactivity/index.js';
+import type { AnnotationsMap } from '../../core/types/index.js';
+import type { SchemaModel, ReactivityOptions, FieldType } from './types.js';
+import { SchemaParser } from './SchemaParser.js';
+import { NodeFactory } from './NodeFactory.js';
+
+export class SchemaModelImpl implements SchemaModel {
+  private _baseTree: SchemaTree;
+  private _currentTree: SchemaTree;
+  private readonly _reactivity: ReactivityAdapter | undefined;
+  private readonly _patchBuilder = new PatchBuilder();
+  private readonly _serializer = new SchemaSerializer();
+  private readonly _nodeFactory = new NodeFactory();
+
+  constructor(schema: JsonObjectSchema, options?: ReactivityOptions) {
+    const parser = new SchemaParser();
+    const rootNode = parser.parse(schema);
+    this._currentTree = createSchemaTree(rootNode);
+    this._baseTree = this._currentTree.clone();
+    this._reactivity = options?.reactivity;
+
+    if (this._reactivity) {
+      this._reactivity.makeObservable(this, {
+        _currentTree: 'observable.ref',
+        _baseTree: 'observable.ref',
+        root: 'computed',
+        isDirty: 'computed',
+        getPatches: 'computed',
+        getJsonPatches: 'computed',
+        getPlainSchema: 'computed',
+        addField: 'action',
+        removeField: 'action',
+        renameField: 'action',
+        changeFieldType: 'action',
+        updateMetadata: 'action',
+        updateFormula: 'action',
+        updateForeignKey: 'action',
+        updateDefaultValue: 'action',
+        markAsSaved: 'action',
+        revert: 'action',
+      } as AnnotationsMap<this>);
+    }
+  }
+
+  root(): SchemaNode {
+    return this._currentTree.root();
+  }
+
+  nodeById(id: string): SchemaNode {
+    return this._currentTree.nodeById(id);
+  }
+
+  pathOf(id: string): Path {
+    return this._currentTree.pathOf(id);
+  }
+
+  addField(parentId: string, name: string, type: FieldType): SchemaNode {
+    const node = this._nodeFactory.createNode(name, type);
+    this._currentTree.addChildTo(parentId, node);
+    return node;
+  }
+
+  removeField(nodeId: string): boolean {
+    const path = this._currentTree.pathOf(nodeId);
+    if (path.isEmpty()) {
+      return false;
+    }
+    return this._currentTree.removeNodeAt(path);
+  }
+
+  renameField(nodeId: string, newName: string): void {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+    this._currentTree.renameNode(nodeId, newName);
+  }
+
+  changeFieldType(nodeId: string, newType: FieldType): SchemaNode {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return node;
+    }
+
+    const path = this._currentTree.pathOf(nodeId);
+    if (path.isEmpty()) {
+      return node;
+    }
+
+    const newNode = this._nodeFactory.createNode(node.name(), newType);
+    this._currentTree.setNodeAt(path, newNode);
+    this._currentTree.trackReplacement(nodeId, newNode.id());
+
+    return newNode;
+  }
+
+  updateMetadata(nodeId: string, meta: Partial<NodeMetadata>): void {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+
+    const currentMeta = node.metadata();
+    const newMeta: NodeMetadata = {
+      ...currentMeta,
+      ...meta,
+    };
+
+    node.setMetadata(newMeta);
+  }
+
+  updateFormula(nodeId: string, expression: string | undefined): void {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+
+    if (expression === undefined) {
+      node.setFormula(undefined);
+    } else {
+      const formula: Formula = { version: 1, expression };
+      node.setFormula(formula);
+    }
+  }
+
+  updateForeignKey(nodeId: string, foreignKey: string | undefined): void {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+    node.setForeignKey(foreignKey);
+  }
+
+  updateDefaultValue(nodeId: string, value: unknown): void {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return;
+    }
+    node.setDefaultValue(value);
+  }
+
+  isDirty(): boolean {
+    return this.getPatches().length > 0;
+  }
+
+  isValid(): boolean {
+    return this._currentTree.root().isObject();
+  }
+
+  getPatches(): SchemaPatch[] {
+    return this._patchBuilder.build(this._currentTree, this._baseTree);
+  }
+
+  getJsonPatches(): JsonPatch[] {
+    return this.getPatches().map((p) => p.patch);
+  }
+
+  markAsSaved(): void {
+    this._baseTree = this._currentTree.clone();
+  }
+
+  revert(): void {
+    this._currentTree = this._baseTree.clone();
+  }
+
+  getPlainSchema(): JsonObjectSchema {
+    return this._serializer.serializeTree(this._currentTree);
+  }
+}
+
+export function createSchemaModel(
+  schema: JsonObjectSchema,
+  options?: ReactivityOptions,
+): SchemaModel {
+  return new SchemaModelImpl(schema, options);
+}

--- a/src/model/schema-model/SchemaParser.ts
+++ b/src/model/schema-model/SchemaParser.ts
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 import type {
   JsonSchema,
+  JsonSchemaWithoutRef,
   JsonObjectSchema,
   JsonArraySchema,
   JsonStringSchema,
@@ -33,26 +34,27 @@ export class SchemaParser {
       );
     }
 
-    switch (schema.type) {
+    const schemaWithType = schema as JsonSchemaWithoutRef;
+    switch (schemaWithType.type) {
       case JsonSchemaTypeName.Object:
-        return this.parseObject(schema as JsonObjectSchema, name);
+        return this.parseObject(schemaWithType, name);
       case JsonSchemaTypeName.Array:
-        return this.parseArray(schema as JsonArraySchema, name);
+        return this.parseArray(schemaWithType, name);
       case JsonSchemaTypeName.String:
-        return this.parseString(schema as JsonStringSchema, name);
+        return this.parseString(schemaWithType, name);
       case JsonSchemaTypeName.Number:
-        return this.parseNumber(schema as JsonNumberSchema, name);
+        return this.parseNumber(schemaWithType, name);
       case JsonSchemaTypeName.Boolean:
-        return this.parseBoolean(schema as JsonBooleanSchema, name);
+        return this.parseBoolean(schemaWithType, name);
       default:
-        throw new Error(`Unknown schema type: ${(schema as { type: string }).type}`);
+        throw new Error(`Unknown schema type: ${(schemaWithType as { type: string }).type}`);
     }
   }
 
   private parseObject(schema: JsonObjectSchema, name: string): SchemaNode {
     const children: SchemaNode[] = [];
 
-    for (const propName of Object.keys(schema.properties).sort()) {
+    for (const propName of Object.keys(schema.properties).sort((a, b) => a.localeCompare(b))) {
       const propSchema = schema.properties[propName];
       if (propSchema) {
         children.push(this.parseNode(propSchema, propName));

--- a/src/model/schema-model/SchemaParser.ts
+++ b/src/model/schema-model/SchemaParser.ts
@@ -1,0 +1,137 @@
+import { nanoid } from 'nanoid';
+import type {
+  JsonSchema,
+  JsonObjectSchema,
+  JsonArraySchema,
+  JsonStringSchema,
+  JsonNumberSchema,
+  JsonBooleanSchema,
+} from '../../types/index.js';
+import { JsonSchemaTypeName } from '../../types/index.js';
+import type { SchemaNode, NodeMetadata, Formula } from '../../core/schema-node/index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+  createRefNode,
+} from '../../core/schema-node/index.js';
+
+export class SchemaParser {
+  parse(schema: JsonObjectSchema): SchemaNode {
+    return this.parseNode(schema, 'root');
+  }
+
+  private parseNode(schema: JsonSchema, name: string): SchemaNode {
+    if ('$ref' in schema) {
+      return createRefNode(
+        nanoid(),
+        name,
+        schema.$ref,
+        this.extractMetadata(schema),
+      );
+    }
+
+    switch (schema.type) {
+      case JsonSchemaTypeName.Object:
+        return this.parseObject(schema as JsonObjectSchema, name);
+      case JsonSchemaTypeName.Array:
+        return this.parseArray(schema as JsonArraySchema, name);
+      case JsonSchemaTypeName.String:
+        return this.parseString(schema as JsonStringSchema, name);
+      case JsonSchemaTypeName.Number:
+        return this.parseNumber(schema as JsonNumberSchema, name);
+      case JsonSchemaTypeName.Boolean:
+        return this.parseBoolean(schema as JsonBooleanSchema, name);
+      default:
+        throw new Error(`Unknown schema type: ${(schema as { type: string }).type}`);
+    }
+  }
+
+  private parseObject(schema: JsonObjectSchema, name: string): SchemaNode {
+    const children: SchemaNode[] = [];
+
+    for (const propName of Object.keys(schema.properties).sort()) {
+      const propSchema = schema.properties[propName];
+      if (propSchema) {
+        children.push(this.parseNode(propSchema, propName));
+      }
+    }
+
+    return createObjectNode(
+      nanoid(),
+      name,
+      children,
+      this.extractMetadata(schema),
+    );
+  }
+
+  private parseArray(schema: JsonArraySchema, name: string): SchemaNode {
+    const items = this.parseNode(schema.items, 'items');
+    return createArrayNode(
+      nanoid(),
+      name,
+      items,
+      this.extractMetadata(schema),
+    );
+  }
+
+  private parseString(schema: JsonStringSchema, name: string): SchemaNode {
+    return createStringNode(nanoid(), name, {
+      defaultValue: schema.default,
+      foreignKey: schema.foreignKey,
+      formula: this.extractFormula(schema),
+      metadata: this.extractMetadata(schema),
+    });
+  }
+
+  private parseNumber(schema: JsonNumberSchema, name: string): SchemaNode {
+    return createNumberNode(nanoid(), name, {
+      defaultValue: schema.default,
+      formula: this.extractFormula(schema),
+      metadata: this.extractMetadata(schema),
+    });
+  }
+
+  private parseBoolean(schema: JsonBooleanSchema, name: string): SchemaNode {
+    return createBooleanNode(nanoid(), name, {
+      defaultValue: schema.default,
+      formula: this.extractFormula(schema),
+      metadata: this.extractMetadata(schema),
+    });
+  }
+
+  private extractMetadata(schema: JsonSchema): NodeMetadata | undefined {
+    const meta: NodeMetadata = {};
+    let hasValue = false;
+
+    if ('title' in schema && schema.title) {
+      (meta as { title: string }).title = schema.title;
+      hasValue = true;
+    }
+    if ('description' in schema && schema.description) {
+      (meta as { description: string }).description = schema.description;
+      hasValue = true;
+    }
+    if ('deprecated' in schema && schema.deprecated) {
+      (meta as { deprecated: boolean }).deprecated = schema.deprecated;
+      hasValue = true;
+    }
+
+    return hasValue ? meta : undefined;
+  }
+
+  private extractFormula(
+    schema: JsonStringSchema | JsonNumberSchema | JsonBooleanSchema,
+  ): Formula | undefined {
+    const xFormula = schema['x-formula'];
+    if (!xFormula) {
+      return undefined;
+    }
+    return {
+      version: xFormula.version,
+      expression: xFormula.expression,
+    };
+  }
+}

--- a/src/model/schema-model/__tests__/NodeFactory.spec.ts
+++ b/src/model/schema-model/__tests__/NodeFactory.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from '@jest/globals';
+import { NodeFactory } from '../NodeFactory.js';
+
+describe('NodeFactory', () => {
+  const factory = new NodeFactory();
+
+  describe('createNode', () => {
+    it('creates string node with default value', () => {
+      const node = factory.createNode('field', 'string');
+
+      expect(node.nodeType()).toBe('string');
+      expect(node.name()).toBe('field');
+      expect(node.defaultValue()).toBe('');
+    });
+
+    it('creates number node with default value', () => {
+      const node = factory.createNode('count', 'number');
+
+      expect(node.nodeType()).toBe('number');
+      expect(node.name()).toBe('count');
+      expect(node.defaultValue()).toBe(0);
+    });
+
+    it('creates boolean node with default value', () => {
+      const node = factory.createNode('active', 'boolean');
+
+      expect(node.nodeType()).toBe('boolean');
+      expect(node.name()).toBe('active');
+      expect(node.defaultValue()).toBe(false);
+    });
+
+    it('creates empty object node', () => {
+      const node = factory.createNode('nested', 'object');
+
+      expect(node.isObject()).toBe(true);
+      expect(node.name()).toBe('nested');
+      expect(node.properties()).toHaveLength(0);
+    });
+
+    it('creates array node with string items', () => {
+      const node = factory.createNode('list', 'array');
+
+      expect(node.isArray()).toBe(true);
+      expect(node.name()).toBe('list');
+
+      const items = node.items();
+      expect(items.nodeType()).toBe('string');
+      expect(items.name()).toBe('items');
+    });
+
+    it('throws for unknown type', () => {
+      expect(() => {
+        factory.createNode('field', 'unknown' as never);
+      }).toThrow('Unknown field type: unknown');
+    });
+
+    it('generates unique ids for each node', () => {
+      const node1 = factory.createNode('field1', 'string');
+      const node2 = factory.createNode('field2', 'string');
+
+      expect(node1.id()).not.toBe(node2.id());
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.basic.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.basic.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  emptySchema,
+  simpleSchema,
+  nestedSchema,
+  findNodeIdByName,
+  findNestedNodeId,
+} from './test-helpers.js';
+
+describe('SchemaModel basic operations', () => {
+  describe('initialization', () => {
+    it('creates model from empty schema', () => {
+      const model = createSchemaModel(emptySchema());
+
+      expect(model.root().isObject()).toBe(true);
+      expect(model.root().properties()).toHaveLength(0);
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('creates model from schema with fields', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.root().properties()).toHaveLength(2);
+      expect(model.isDirty()).toBe(false);
+    });
+  });
+
+  describe('tree access', () => {
+    it('returns root node', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const root = model.root();
+      expect(root.isObject()).toBe(true);
+    });
+
+    it('finds node by id', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(nameId).toBeDefined();
+      const node = model.nodeById(nameId!);
+      expect(node.name()).toBe('name');
+    });
+
+    it('returns null node for unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const node = model.nodeById('unknown-id');
+      expect(node.isNull()).toBe(true);
+    });
+
+    it('returns path for node', () => {
+      const model = createSchemaModel(nestedSchema());
+      const firstNameId = findNestedNodeId(model, 'user', 'firstName');
+
+      expect(firstNameId).toBeDefined();
+      const path = model.pathOf(firstNameId!);
+      expect(path.asJsonPointer()).toBe('/properties/user/properties/firstName');
+    });
+  });
+
+  describe('addField', () => {
+    it('adds field to root', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      const newNode = model.addField(rootId, 'newField', 'string');
+
+      expect(newNode.name()).toBe('newField');
+      expect(newNode.nodeType()).toBe('string');
+      expect(model.root().properties()).toHaveLength(1);
+      expect(model.isDirty()).toBe(true);
+    });
+
+    it('adds field to nested object', () => {
+      const model = createSchemaModel(nestedSchema());
+      const user = model.root().property('user');
+
+      model.addField(user.id(), 'email', 'string');
+
+      expect(user.properties()).toHaveLength(3);
+      expect(user.property('email').nodeType()).toBe('string');
+    });
+
+    it('adds different field types', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'str', 'string');
+      model.addField(rootId, 'num', 'number');
+      model.addField(rootId, 'bool', 'boolean');
+      model.addField(rootId, 'obj', 'object');
+      model.addField(rootId, 'arr', 'array');
+
+      const props = model.root().properties();
+      expect(props).toHaveLength(5);
+
+      expect(model.root().property('str').nodeType()).toBe('string');
+      expect(model.root().property('num').nodeType()).toBe('number');
+      expect(model.root().property('bool').nodeType()).toBe('boolean');
+      expect(model.root().property('obj').isObject()).toBe(true);
+      expect(model.root().property('arr').isArray()).toBe(true);
+    });
+  });
+
+  describe('removeField', () => {
+    it('removes field from root', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const result = model.removeField(nameId!);
+
+      expect(result).toBe(true);
+      expect(model.root().properties()).toHaveLength(1);
+      expect(model.root().property('name').isNull()).toBe(true);
+      expect(model.isDirty()).toBe(true);
+    });
+
+    it('removes nested field', () => {
+      const model = createSchemaModel(nestedSchema());
+      const firstNameId = findNestedNodeId(model, 'user', 'firstName');
+
+      const result = model.removeField(firstNameId!);
+
+      expect(result).toBe(true);
+      const user = model.root().property('user');
+      expect(user.properties()).toHaveLength(1);
+    });
+
+    it('returns false for root node', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root().id();
+
+      const result = model.removeField(rootId);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const result = model.removeField('unknown-id');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('renameField', () => {
+    it('renames field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.renameField(nameId!, 'fullName');
+
+      expect(model.root().property('fullName').nodeType()).toBe('string');
+      expect(model.root().property('name').isNull()).toBe(true);
+      expect(model.isDirty()).toBe(true);
+    });
+
+    it('ignores unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.renameField('unknown-id', 'newName');
+
+      expect(model.root().properties()).toHaveLength(2);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.edgeCases.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.edgeCases.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  emptySchema,
+  simpleSchema,
+  nestedSchema,
+  arraySchema,
+  findNodeIdByName,
+  findNestedNodeId,
+} from './test-helpers.js';
+
+describe('SchemaModel edge cases', () => {
+  describe('complex operations', () => {
+    it('handles add then remove same field', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      const node = model.addField(rootId, 'temp', 'string');
+      model.removeField(node.id());
+
+      expect(model.root().properties()).toHaveLength(0);
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('handles remove then add same name', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+      const rootId = model.root().id();
+
+      model.removeField(nameId!);
+      model.addField(rootId, 'name', 'number');
+
+      expect(model.root().property('name').nodeType()).toBe('number');
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('handles multiple renames', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.renameField(nameId!, 'firstName');
+      model.renameField(nameId!, 'givenName');
+
+      expect(model.root().property('givenName').isNull()).toBe(false);
+      expect(model.root().property('firstName').isNull()).toBe(true);
+      expect(model.root().property('name').isNull()).toBe(true);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('handles type change then modification', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const newNode = model.changeFieldType(nameId!, 'number');
+      model.updateDefaultValue(newNode.id(), 42);
+
+      expect(model.root().property('name').defaultValue()).toBe(42);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('nested operations', () => {
+    it('adds field to nested object', () => {
+      const model = createSchemaModel(nestedSchema());
+      const user = model.root().property('user');
+
+      model.addField(user.id(), 'age', 'number');
+
+      expect(user.properties()).toHaveLength(3);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('removes nested object with children', () => {
+      const model = createSchemaModel(nestedSchema());
+      const userId = model.root().property('user').id();
+
+      model.removeField(userId);
+
+      expect(model.root().properties()).toHaveLength(0);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('renames nested field', () => {
+      const model = createSchemaModel(nestedSchema());
+      const firstNameId = findNestedNodeId(model, 'user', 'firstName');
+
+      model.renameField(firstNameId!, 'givenName');
+
+      const user = model.root().property('user');
+      expect(user.property('givenName').isNull()).toBe(false);
+      expect(user.property('firstName').isNull()).toBe(true);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('array operations', () => {
+    it('modifies array items type', () => {
+      const model = createSchemaModel(arraySchema());
+      const items = model.root().property('items').items();
+
+      const newItems = model.changeFieldType(items.id(), 'number');
+
+      expect(model.root().property('items').items().nodeType()).toBe('number');
+      expect(newItems.nodeType()).toBe('number');
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('changes array to object', () => {
+      const model = createSchemaModel(arraySchema());
+      const itemsId = model.root().property('items').id();
+
+      model.changeFieldType(itemsId, 'object');
+
+      expect(model.root().property('items').isObject()).toBe(true);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('multiple changes before save', () => {
+    it('accumulates all changes', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field1', 'string');
+      model.addField(rootId, 'field2', 'number');
+      model.addField(rootId, 'field3', 'boolean');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('correctly handles remove after multiple adds', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      const field1 = model.addField(rootId, 'field1', 'string');
+      model.addField(rootId, 'field2', 'number');
+      model.removeField(field1.id());
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('save and continue editing', () => {
+    it('tracks new changes after save', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'saved', 'string');
+      model.markAsSaved();
+
+      model.addField(rootId, 'new', 'number');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('can modify saved fields', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      const field = model.addField(rootId, 'field', 'string');
+      model.markAsSaved();
+
+      model.updateDefaultValue(field.id(), 'changed');
+
+      expect(model.isDirty()).toBe(true);
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('revert scenarios', () => {
+    it('allows editing after revert', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      model.revert();
+
+      model.addField(rootId, 'newField', 'number');
+
+      expect(model.isDirty()).toBe(true);
+      expect(model.root().property('newField').isNull()).toBe(false);
+    });
+
+    it('partial revert scenario - save then change then revert', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field1', 'string');
+      model.markAsSaved();
+
+      model.addField(rootId, 'field2', 'number');
+      model.revert();
+
+      expect(model.root().properties()).toHaveLength(1);
+      expect(model.root().property('field1').isNull()).toBe(false);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.mutations.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.mutations.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  simpleSchema,
+  schemaWithFormula,
+  schemaWithForeignKey,
+  schemaWithMetadata,
+  findNodeIdByName,
+} from './test-helpers.js';
+
+describe('SchemaModel mutations', () => {
+  describe('changeFieldType', () => {
+    it('changes string to number', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const newNode = model.changeFieldType(nameId!, 'number');
+
+      expect(newNode.nodeType()).toBe('number');
+      expect(newNode.name()).toBe('name');
+      expect(model.root().property('name').nodeType()).toBe('number');
+      expect(model.isDirty()).toBe(true);
+    });
+
+    it('changes primitive to object', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const newNode = model.changeFieldType(nameId!, 'object');
+
+      expect(newNode.isObject()).toBe(true);
+      expect(newNode.properties()).toHaveLength(0);
+    });
+
+    it('changes primitive to array', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const newNode = model.changeFieldType(nameId!, 'array');
+
+      expect(newNode.isArray()).toBe(true);
+      expect(newNode.items().nodeType()).toBe('string');
+    });
+
+    it('returns null node for unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const result = model.changeFieldType('unknown-id', 'number');
+
+      expect(result.isNull()).toBe(true);
+    });
+
+    it('tracks replacement for patch generation', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.changeFieldType(nameId!, 'number');
+
+      const patches = model.getPatches();
+      expect(patches.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('updateMetadata', () => {
+    it('adds title to field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.updateMetadata(nameId!, { title: 'Full Name' });
+
+      const meta = model.nodeById(nameId!).metadata();
+      expect(meta.title).toBe('Full Name');
+    });
+
+    it('adds description to field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.updateMetadata(nameId!, { description: 'User name' });
+
+      const meta = model.nodeById(nameId!).metadata();
+      expect(meta.description).toBe('User name');
+    });
+
+    it('sets deprecated flag', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.updateMetadata(nameId!, { deprecated: true });
+
+      const meta = model.nodeById(nameId!).metadata();
+      expect(meta.deprecated).toBe(true);
+    });
+
+    it('merges with existing metadata', () => {
+      const model = createSchemaModel(schemaWithMetadata());
+      const fieldId = findNodeIdByName(model, 'field');
+
+      model.updateMetadata(fieldId!, { title: 'New Title' });
+
+      const meta = model.nodeById(fieldId!).metadata();
+      expect(meta.title).toBe('New Title');
+      expect(meta.description).toBe('Field description');
+    });
+
+    it('ignores unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.updateMetadata('unknown-id', { title: 'Test' });
+
+      expect(model.isDirty()).toBe(false);
+    });
+  });
+
+  describe('updateFormula', () => {
+    it('adds formula to field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const ageId = findNodeIdByName(model, 'age');
+
+      model.updateFormula(ageId!, 'price * 2');
+
+      const formula = model.nodeById(ageId!).formula();
+      expect(formula?.version).toBe(1);
+      expect(formula?.expression).toBe('price * 2');
+    });
+
+    it('updates existing formula', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const totalId = findNodeIdByName(model, 'total');
+
+      model.updateFormula(totalId!, 'price * quantity * 1.1');
+
+      const formula = model.nodeById(totalId!).formula();
+      expect(formula?.expression).toBe('price * quantity * 1.1');
+    });
+
+    it('removes formula when undefined', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const totalId = findNodeIdByName(model, 'total');
+
+      model.updateFormula(totalId!, undefined);
+
+      expect(model.nodeById(totalId!).hasFormula()).toBe(false);
+    });
+
+    it('ignores unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.updateFormula('unknown-id', 'test');
+
+      expect(model.isDirty()).toBe(false);
+    });
+  });
+
+  describe('updateForeignKey', () => {
+    it('adds foreign key to field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.updateForeignKey(nameId!, 'users');
+
+      expect(model.nodeById(nameId!).foreignKey()).toBe('users');
+    });
+
+    it('updates existing foreign key', () => {
+      const model = createSchemaModel(schemaWithForeignKey());
+      const categoryId = findNodeIdByName(model, 'categoryId');
+
+      model.updateForeignKey(categoryId!, 'tags');
+
+      expect(model.nodeById(categoryId!).foreignKey()).toBe('tags');
+    });
+
+    it('removes foreign key when undefined', () => {
+      const model = createSchemaModel(schemaWithForeignKey());
+      const categoryId = findNodeIdByName(model, 'categoryId');
+
+      model.updateForeignKey(categoryId!, undefined);
+
+      expect(model.nodeById(categoryId!).foreignKey()).toBeUndefined();
+    });
+
+    it('ignores unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.updateForeignKey('unknown-id', 'table');
+
+      expect(model.isDirty()).toBe(false);
+    });
+  });
+
+  describe('updateDefaultValue', () => {
+    it('updates string default value', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.updateDefaultValue(nameId!, 'John');
+
+      expect(model.nodeById(nameId!).defaultValue()).toBe('John');
+    });
+
+    it('updates number default value', () => {
+      const model = createSchemaModel(simpleSchema());
+      const ageId = findNodeIdByName(model, 'age');
+
+      model.updateDefaultValue(ageId!, 25);
+
+      expect(model.nodeById(ageId!).defaultValue()).toBe(25);
+    });
+
+    it('ignores unknown id', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.updateDefaultValue('unknown-id', 'test');
+
+      expect(model.isDirty()).toBe(false);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  emptySchema,
+  simpleSchema,
+  findNodeIdByName,
+} from './test-helpers.js';
+
+describe('SchemaModel patches', () => {
+  describe('getPatches', () => {
+    it('returns empty array when no changes', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('returns add patch for new field', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'newField', 'string');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('returns remove patch for deleted field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.removeField(nameId!);
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('returns move patch for renamed field', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.renameField(nameId!, 'fullName');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('returns replace patch for type change', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.changeFieldType(nameId!, 'number');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('returns replace patch for default value change', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.updateDefaultValue(nameId!, 'changed');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('includes formula change info', () => {
+      const model = createSchemaModel(simpleSchema());
+      const ageId = findNodeIdByName(model, 'age');
+
+      model.updateFormula(ageId!, 'x + 1');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('multiple field additions', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field1', 'string');
+      model.addField(rootId, 'field2', 'number');
+      model.addField(rootId, 'field3', 'boolean');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('getJsonPatches', () => {
+    it('returns plain JSON patches', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+
+      expect(model.getJsonPatches()).toMatchSnapshot();
+    });
+  });
+
+  describe('isDirty', () => {
+    it('returns false initially', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('returns true after adding field', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+
+      expect(model.isDirty()).toBe(true);
+    });
+
+    it('returns false after markAsSaved', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      model.markAsSaved();
+
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('returns false after revert', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      model.revert();
+
+      expect(model.isDirty()).toBe(false);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.reactivity.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.reactivity.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import { simpleSchema, emptySchema, findNodeIdByName } from './test-helpers.js';
+import type { ReactivityAdapter } from '../../../core/reactivity/index.js';
+
+describe('SchemaModel reactivity', () => {
+  let mockAdapter: ReactivityAdapter;
+  let makeObservableSpy: jest.Mock;
+
+  beforeEach(() => {
+    makeObservableSpy = jest.fn();
+    mockAdapter = {
+      makeObservable: makeObservableSpy,
+      observableArray: () => [],
+      observableMap: () => new Map(),
+      reaction: () => () => {},
+      runInAction: <T>(fn: () => T) => fn(),
+    };
+  });
+
+  describe('initialization with reactivity', () => {
+    it('calls makeObservable when adapter provided', () => {
+      createSchemaModel(emptySchema(), { reactivity: mockAdapter });
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes correct annotations to makeObservable', () => {
+      createSchemaModel(emptySchema(), { reactivity: mockAdapter });
+
+      const callArgs = makeObservableSpy.mock.calls[0];
+      expect(callArgs).toBeDefined();
+
+      const [target, annotations] = callArgs as [unknown, Record<string, string>];
+
+      expect(target).toBeDefined();
+      expect(annotations['_currentTree']).toBe('observable.ref');
+      expect(annotations['_baseTree']).toBe('observable.ref');
+      expect(annotations['root']).toBe('computed');
+      expect(annotations['isDirty']).toBe('computed');
+      expect(annotations['addField']).toBe('action');
+      expect(annotations['removeField']).toBe('action');
+      expect(annotations['markAsSaved']).toBe('action');
+      expect(annotations['revert']).toBe('action');
+    });
+
+    it('does not call makeObservable when no adapter', () => {
+      createSchemaModel(emptySchema());
+
+      expect(makeObservableSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('operations with reactivity', () => {
+    it('addField works with reactive model', () => {
+      const model = createSchemaModel(emptySchema(), { reactivity: mockAdapter });
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+
+      expect(model.root().properties()).toHaveLength(1);
+    });
+
+    it('removeField works with reactive model', () => {
+      const model = createSchemaModel(simpleSchema(), { reactivity: mockAdapter });
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.removeField(nameId!);
+
+      expect(model.root().properties()).toHaveLength(1);
+    });
+
+    it('markAsSaved works with reactive model', () => {
+      const model = createSchemaModel(emptySchema(), { reactivity: mockAdapter });
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      model.markAsSaved();
+
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('revert works with reactive model', () => {
+      const model = createSchemaModel(emptySchema(), { reactivity: mockAdapter });
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      model.revert();
+
+      expect(model.root().properties()).toHaveLength(0);
+    });
+  });
+
+  describe('changeFieldType on root', () => {
+    it('returns same node when trying to change root type', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root().id();
+
+      const result = model.changeFieldType(rootId, 'array');
+
+      expect(result.id()).toBe(rootId);
+      expect(model.root().isObject()).toBe(true);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  emptySchema,
+  simpleSchema,
+  nestedSchema,
+  schemaWithMetadata,
+  schemaWithFormula,
+  schemaWithForeignKey,
+  findNodeIdByName,
+} from './test-helpers.js';
+
+describe('SchemaModel state management', () => {
+  describe('markAsSaved', () => {
+    it('clears dirty state after save', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      expect(model.isDirty()).toBe(true);
+
+      model.markAsSaved();
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('resets base tree - new changes tracked from saved state', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field1', 'string');
+      model.markAsSaved();
+
+      model.addField(rootId, 'field2', 'number');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('allows multiple save cycles', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field1', 'string');
+      model.markAsSaved();
+
+      model.addField(rootId, 'field2', 'number');
+      model.markAsSaved();
+
+      model.addField(rootId, 'field3', 'boolean');
+
+      expect(model.getPatches()).toHaveLength(1);
+      expect(model.root().properties()).toHaveLength(3);
+    });
+  });
+
+  describe('revert', () => {
+    it('restores original state', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.removeField(nameId!);
+      expect(model.root().properties()).toHaveLength(1);
+
+      model.revert();
+      expect(model.root().properties()).toHaveLength(2);
+      expect(model.root().property('name').isNull()).toBe(false);
+    });
+
+    it('clears dirty state', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field', 'string');
+      model.revert();
+
+      expect(model.isDirty()).toBe(false);
+    });
+
+    it('reverts to last saved state', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'field1', 'string');
+      model.markAsSaved();
+
+      model.addField(rootId, 'field2', 'number');
+      model.revert();
+
+      expect(model.root().properties()).toHaveLength(1);
+      expect(model.root().property('field1').isNull()).toBe(false);
+      expect(model.root().property('field2').isNull()).toBe(true);
+    });
+
+    it('reverts multiple changes', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+      const ageId = findNodeIdByName(model, 'age');
+
+      model.removeField(nameId!);
+      model.renameField(ageId!, 'years');
+
+      model.revert();
+
+      expect(model.root().property('name').isNull()).toBe(false);
+      expect(model.root().property('age').isNull()).toBe(false);
+      expect(model.root().property('years').isNull()).toBe(true);
+    });
+  });
+
+  describe('isValid', () => {
+    it('returns true for valid schema', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.isValid()).toBe(true);
+    });
+
+    it('returns true for empty schema', () => {
+      const model = createSchemaModel(emptySchema());
+
+      expect(model.isValid()).toBe(true);
+    });
+  });
+
+  describe('getPlainSchema', () => {
+    it('serializes empty schema', () => {
+      const model = createSchemaModel(emptySchema());
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+
+    it('serializes simple schema', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+
+    it('serializes nested schema', () => {
+      const model = createSchemaModel(nestedSchema());
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+
+    it('serializes metadata', () => {
+      const model = createSchemaModel(schemaWithMetadata());
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+
+    it('serializes formula', () => {
+      const model = createSchemaModel(schemaWithFormula());
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+
+    it('serializes foreign key', () => {
+      const model = createSchemaModel(schemaWithForeignKey());
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+
+    it('reflects changes before save', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'newField', 'string');
+
+      expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaParser.additional.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaParser.additional.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from '@jest/globals';
+import { SchemaParser } from '../SchemaParser.js';
+import type { JsonObjectSchema, JsonBooleanSchema } from '../../../types/index.js';
+import { JsonSchemaTypeName } from '../../../types/index.js';
+
+describe('SchemaParser additional coverage', () => {
+  const parser = new SchemaParser();
+
+  describe('$ref parsing', () => {
+    it('parses schema with $ref', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['file'],
+        properties: {
+          file: {
+            $ref: 'File',
+          },
+        },
+      };
+
+      const node = parser.parse(schema);
+
+      const file = node.property('file');
+      expect(file.isRef()).toBe(true);
+      expect(file.ref()).toBe('File');
+    });
+
+    it('parses $ref with metadata', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['image'],
+        properties: {
+          image: {
+            $ref: 'Image',
+            title: 'Image File',
+            description: 'User avatar',
+            deprecated: true,
+          },
+        },
+      };
+
+      const node = parser.parse(schema);
+
+      const image = node.property('image');
+      expect(image.isRef()).toBe(true);
+      expect(image.metadata().title).toBe('Image File');
+      expect(image.metadata().description).toBe('User avatar');
+      expect(image.metadata().deprecated).toBe(true);
+    });
+  });
+
+  describe('boolean with formula', () => {
+    it('parses boolean field with formula', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['isValid'],
+        properties: {
+          isValid: {
+            type: JsonSchemaTypeName.Boolean,
+            default: false,
+            readOnly: true,
+            'x-formula': {
+              version: 1,
+              expression: 'count > 0',
+            },
+          } as JsonBooleanSchema,
+        },
+      };
+
+      const node = parser.parse(schema);
+
+      const isValid = node.property('isValid');
+      expect(isValid.nodeType()).toBe('boolean');
+      expect(isValid.hasFormula()).toBe(true);
+      expect(isValid.formula()?.expression).toBe('count > 0');
+    });
+  });
+
+  describe('unknown type error', () => {
+    it('throws for unknown schema type', () => {
+      const schema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['field'],
+        properties: {
+          field: {
+            type: 'unknown-type',
+            default: '',
+          },
+        },
+      } as unknown as JsonObjectSchema;
+
+      expect(() => parser.parse(schema)).toThrow('Unknown schema type: unknown-type');
+    });
+  });
+
+  describe('nested arrays', () => {
+    it('parses nested array with object items', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['items'],
+        properties: {
+          items: {
+            type: JsonSchemaTypeName.Array,
+            items: {
+              type: JsonSchemaTypeName.Object,
+              additionalProperties: false,
+              required: ['name'],
+              properties: {
+                name: {
+                  type: JsonSchemaTypeName.String,
+                  default: '',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const node = parser.parse(schema);
+
+      const items = node.property('items');
+      expect(items.isArray()).toBe(true);
+
+      const itemsObject = items.items();
+      expect(itemsObject.isObject()).toBe(true);
+      expect(itemsObject.property('name').nodeType()).toBe('string');
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaParser.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaParser.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from '@jest/globals';
+import { SchemaParser } from '../SchemaParser.js';
+import {
+  emptySchema,
+  simpleSchema,
+  nestedSchema,
+  arraySchema,
+  schemaWithMetadata,
+  schemaWithFormula,
+  schemaWithForeignKey,
+} from './test-helpers.js';
+
+describe('SchemaParser', () => {
+  const parser = new SchemaParser();
+
+  describe('basic parsing', () => {
+    it('parses empty schema', () => {
+      const node = parser.parse(emptySchema());
+
+      expect(node.isObject()).toBe(true);
+      expect(node.name()).toBe('root');
+      expect(node.properties()).toHaveLength(0);
+    });
+
+    it('parses simple schema with primitives', () => {
+      const node = parser.parse(simpleSchema());
+
+      expect(node.isObject()).toBe(true);
+      expect(node.properties()).toHaveLength(2);
+
+      const props = node.properties();
+      const age = props.find((p) => p.name() === 'age');
+      const name = props.find((p) => p.name() === 'name');
+
+      expect(age).toBeDefined();
+      expect(age?.nodeType()).toBe('number');
+      expect(age?.defaultValue()).toBe(0);
+
+      expect(name).toBeDefined();
+      expect(name?.nodeType()).toBe('string');
+      expect(name?.defaultValue()).toBe('');
+    });
+  });
+
+  describe('nested objects', () => {
+    it('parses nested object schema', () => {
+      const node = parser.parse(nestedSchema());
+
+      expect(node.properties()).toHaveLength(1);
+      const user = node.property('user');
+
+      expect(user.isObject()).toBe(true);
+      expect(user.properties()).toHaveLength(2);
+
+      const firstName = user.property('firstName');
+      const lastName = user.property('lastName');
+
+      expect(firstName.nodeType()).toBe('string');
+      expect(lastName.nodeType()).toBe('string');
+    });
+  });
+
+  describe('arrays', () => {
+    it('parses array schema', () => {
+      const node = parser.parse(arraySchema());
+
+      const items = node.property('items');
+      expect(items.isArray()).toBe(true);
+
+      const itemsNode = items.items();
+      expect(itemsNode.nodeType()).toBe('string');
+    });
+  });
+
+  describe('metadata', () => {
+    it('parses schema with metadata', () => {
+      const node = parser.parse(schemaWithMetadata());
+
+      const field = node.property('field');
+      const meta = field.metadata();
+
+      expect(meta.title).toBe('Field Title');
+      expect(meta.description).toBe('Field description');
+      expect(meta.deprecated).toBe(true);
+    });
+  });
+
+  describe('formulas', () => {
+    it('parses schema with formula', () => {
+      const node = parser.parse(schemaWithFormula());
+
+      const total = node.property('total');
+      expect(total.hasFormula()).toBe(true);
+
+      const formula = total.formula();
+      expect(formula?.version).toBe(1);
+      expect(formula?.expression).toBe('price * quantity');
+    });
+  });
+
+  describe('foreign keys', () => {
+    it('parses schema with foreign key', () => {
+      const node = parser.parse(schemaWithForeignKey());
+
+      const categoryId = node.property('categoryId');
+      expect(categoryId.foreignKey()).toBe('categories');
+    });
+  });
+
+  describe('unique ids', () => {
+    it('generates unique ids for each node', () => {
+      const node = parser.parse(simpleSchema());
+
+      const ids = new Set<string>();
+      ids.add(node.id());
+
+      for (const prop of node.properties()) {
+        expect(ids.has(prop.id())).toBe(false);
+        ids.add(prop.id());
+      }
+
+      expect(ids.size).toBe(3);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.edgeCases.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.edgeCases.spec.ts.snap
@@ -1,0 +1,288 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel edge cases array operations changes array to object 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "items",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items",
+      "value": {
+        "additionalProperties": false,
+        "properties": {},
+        "required": [],
+        "type": "object",
+      },
+    },
+    "typeChange": {
+      "fromType": "array<string>",
+      "toType": "object",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases array operations modifies array items type 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "",
+      "toDefault": 0,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "items[*]",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/items/items",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "number",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases complex operations handles multiple renames 1`] = `
+[
+  {
+    "fieldName": "givenName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/name",
+      "op": "move",
+      "path": "/properties/givenName",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases complex operations handles remove then add same name 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "name",
+    "patch": {
+      "op": "add",
+      "path": "/properties/name",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+  {
+    "fieldName": "name",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/name",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases complex operations handles type change then modification 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "",
+      "toDefault": 42,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "name",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/name",
+      "value": {
+        "default": 42,
+        "type": "number",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "number",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases multiple changes before save accumulates all changes 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "",
+    },
+    "fieldName": "field1",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field1",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "field2",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field2",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": false,
+    },
+    "fieldName": "field3",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field3",
+      "value": {
+        "default": false,
+        "type": "boolean",
+      },
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases multiple changes before save correctly handles remove after multiple adds 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "field2",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field2",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases nested operations adds field to nested object 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "user.age",
+    "patch": {
+      "op": "add",
+      "path": "/properties/user/properties/age",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases nested operations removes nested object with children 1`] = `
+[
+  {
+    "fieldName": "user",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/user",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases nested operations renames nested field 1`] = `
+[
+  {
+    "fieldName": "user.givenName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/user/properties/firstName",
+      "op": "move",
+      "path": "/properties/user/properties/givenName",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel edge cases save and continue editing can modify saved fields 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "",
+      "toDefault": "changed",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "field",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/field",
+      "value": {
+        "default": "changed",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`SchemaModel edge cases save and continue editing tracks new changes after save 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "new",
+    "patch": {
+      "op": "add",
+      "path": "/properties/new",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+]
+`;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel patches getJsonPatches returns plain JSON patches 1`] = `
+[
+  {
+    "op": "add",
+    "path": "/properties/field",
+    "value": {
+      "default": "",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches includes formula change info 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "age",
+    "foreignKeyChange": undefined,
+    "formulaChange": {
+      "fromFormula": undefined,
+      "fromVersion": undefined,
+      "toFormula": "x + 1",
+      "toVersion": 1,
+    },
+    "patch": {
+      "op": "replace",
+      "path": "/properties/age",
+      "value": {
+        "default": 0,
+        "readOnly": true,
+        "type": "number",
+        "x-formula": {
+          "expression": "x + 1",
+          "version": 1,
+        },
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches multiple field additions 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "",
+    },
+    "fieldName": "field1",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field1",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "field2",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field2",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": false,
+    },
+    "fieldName": "field3",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field3",
+      "value": {
+        "default": false,
+        "type": "boolean",
+      },
+    },
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches returns add patch for new field 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "",
+    },
+    "fieldName": "newField",
+    "patch": {
+      "op": "add",
+      "path": "/properties/newField",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches returns empty array when no changes 1`] = `[]`;
+
+exports[`SchemaModel patches getPatches returns move patch for renamed field 1`] = `
+[
+  {
+    "fieldName": "fullName",
+    "formulaChange": undefined,
+    "isRename": true,
+    "patch": {
+      "from": "/properties/name",
+      "op": "move",
+      "path": "/properties/fullName",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches returns remove patch for deleted field 1`] = `
+[
+  {
+    "fieldName": "name",
+    "patch": {
+      "op": "remove",
+      "path": "/properties/name",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches returns replace patch for default value change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "",
+      "toDefault": "changed",
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "name",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/name",
+      "value": {
+        "default": "changed",
+        "type": "string",
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches returns replace patch for type change 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "",
+      "toDefault": 0,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "name",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/name",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "number",
+    },
+  },
+]
+`;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.state.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.state.spec.ts.snap
@@ -1,0 +1,164 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel state management getPlainSchema reflects changes before save 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {
+    "newField": {
+      "default": "",
+      "type": "string",
+    },
+  },
+  "required": [
+    "newField",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management getPlainSchema serializes empty schema 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {},
+  "required": [],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management getPlainSchema serializes foreign key 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {
+    "categoryId": {
+      "default": "",
+      "foreignKey": "categories",
+      "type": "string",
+    },
+  },
+  "required": [
+    "categoryId",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management getPlainSchema serializes formula 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {
+    "price": {
+      "default": 0,
+      "type": "number",
+    },
+    "quantity": {
+      "default": 0,
+      "type": "number",
+    },
+    "total": {
+      "default": 0,
+      "readOnly": true,
+      "type": "number",
+      "x-formula": {
+        "expression": "price * quantity",
+        "version": 1,
+      },
+    },
+  },
+  "required": [
+    "price",
+    "quantity",
+    "total",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management getPlainSchema serializes metadata 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {
+    "field": {
+      "default": "",
+      "deprecated": true,
+      "description": "Field description",
+      "title": "Field Title",
+      "type": "string",
+    },
+  },
+  "required": [
+    "field",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management getPlainSchema serializes nested schema 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {
+    "user": {
+      "additionalProperties": false,
+      "properties": {
+        "firstName": {
+          "default": "",
+          "type": "string",
+        },
+        "lastName": {
+          "default": "",
+          "type": "string",
+        },
+      },
+      "required": [
+        "firstName",
+        "lastName",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "user",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management getPlainSchema serializes simple schema 1`] = `
+{
+  "additionalProperties": false,
+  "properties": {
+    "age": {
+      "default": 0,
+      "type": "number",
+    },
+    "name": {
+      "default": "",
+      "type": "string",
+    },
+  },
+  "required": [
+    "age",
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`SchemaModel state management markAsSaved resets base tree - new changes tracked from saved state 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "fieldName": "field2",
+    "patch": {
+      "op": "add",
+      "path": "/properties/field2",
+      "value": {
+        "default": 0,
+        "type": "number",
+      },
+    },
+  },
+]
+`;

--- a/src/model/schema-model/__tests__/test-helpers.ts
+++ b/src/model/schema-model/__tests__/test-helpers.ts
@@ -1,0 +1,150 @@
+import type { JsonObjectSchema } from '../../../types/index.js';
+import { JsonSchemaTypeName } from '../../../types/index.js';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import type { SchemaModel } from '../types.js';
+
+export const emptySchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: [],
+  properties: {},
+});
+
+export const simpleSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'age'],
+  properties: {
+    name: {
+      type: JsonSchemaTypeName.String,
+      default: '',
+    },
+    age: {
+      type: JsonSchemaTypeName.Number,
+      default: 0,
+    },
+  },
+});
+
+export const nestedSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['user'],
+  properties: {
+    user: {
+      type: JsonSchemaTypeName.Object,
+      additionalProperties: false,
+      required: ['firstName', 'lastName'],
+      properties: {
+        firstName: {
+          type: JsonSchemaTypeName.String,
+          default: '',
+        },
+        lastName: {
+          type: JsonSchemaTypeName.String,
+          default: '',
+        },
+      },
+    },
+  },
+});
+
+export const arraySchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['items'],
+  properties: {
+    items: {
+      type: JsonSchemaTypeName.Array,
+      items: {
+        type: JsonSchemaTypeName.String,
+        default: '',
+      },
+    },
+  },
+});
+
+export const schemaWithMetadata = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['field'],
+  properties: {
+    field: {
+      type: JsonSchemaTypeName.String,
+      default: '',
+      title: 'Field Title',
+      description: 'Field description',
+      deprecated: true,
+    },
+  },
+});
+
+export const schemaWithFormula = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['price', 'quantity', 'total'],
+  properties: {
+    price: {
+      type: JsonSchemaTypeName.Number,
+      default: 0,
+    },
+    quantity: {
+      type: JsonSchemaTypeName.Number,
+      default: 0,
+    },
+    total: {
+      type: JsonSchemaTypeName.Number,
+      default: 0,
+      readOnly: true,
+      'x-formula': {
+        version: 1,
+        expression: 'price * quantity',
+      },
+    },
+  },
+});
+
+export const schemaWithForeignKey = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['categoryId'],
+  properties: {
+    categoryId: {
+      type: JsonSchemaTypeName.String,
+      default: '',
+      foreignKey: 'categories',
+    },
+  },
+});
+
+export const createModel = (schema: JsonObjectSchema): SchemaModel => {
+  return createSchemaModel(schema);
+};
+
+export const findNodeIdByName = (model: SchemaModel, name: string): string | undefined => {
+  const root = model.root();
+  for (const prop of root.properties()) {
+    if (prop.name() === name) {
+      return prop.id();
+    }
+  }
+  return undefined;
+};
+
+export const findNestedNodeId = (
+  model: SchemaModel,
+  parentName: string,
+  childName: string,
+): string | undefined => {
+  const root = model.root();
+  for (const prop of root.properties()) {
+    if (prop.name() === parentName) {
+      for (const child of prop.properties()) {
+        if (child.name() === childName) {
+          return child.id();
+        }
+      }
+    }
+  }
+  return undefined;
+};

--- a/src/model/schema-model/index.ts
+++ b/src/model/schema-model/index.ts
@@ -1,0 +1,4 @@
+export type { SchemaModel, ReactivityOptions, FieldType } from './types.js';
+export { createSchemaModel } from './SchemaModelImpl.js';
+export { SchemaParser } from './SchemaParser.js';
+export { NodeFactory } from './NodeFactory.js';

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -1,0 +1,42 @@
+import type { ReactivityAdapter } from '../../core/reactivity/index.js';
+import type { NodeMetadata, SchemaNode } from '../../core/schema-node/index.js';
+import type { Path } from '../../core/path/index.js';
+import type { SchemaPatch, JsonPatch } from '../../core/schema-patch/index.js';
+import type { JsonObjectSchema } from '../../types/index.js';
+
+export interface ReactivityOptions {
+  reactivity?: ReactivityAdapter;
+}
+
+export type FieldType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'object'
+  | 'array';
+
+export interface SchemaModel {
+  root(): SchemaNode;
+  nodeById(id: string): SchemaNode;
+  pathOf(id: string): Path;
+
+  addField(parentId: string, name: string, type: FieldType): SchemaNode;
+  removeField(nodeId: string): boolean;
+  renameField(nodeId: string, newName: string): void;
+  changeFieldType(nodeId: string, newType: FieldType): SchemaNode;
+  updateMetadata(nodeId: string, meta: Partial<NodeMetadata>): void;
+  updateFormula(nodeId: string, expression: string | undefined): void;
+  updateForeignKey(nodeId: string, foreignKey: string | undefined): void;
+  updateDefaultValue(nodeId: string, value: unknown): void;
+
+  isDirty(): boolean;
+  isValid(): boolean;
+
+  getPatches(): SchemaPatch[];
+  getJsonPatches(): JsonPatch[];
+
+  markAsSaved(): void;
+  revert(): void;
+
+  getPlainSchema(): JsonObjectSchema;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a mutable SchemaModel for editing JSON Schema with change tracking, enriched patch generation, and optional reactivity. Adds a parser and node factory, exports the API, and includes docs and comprehensive tests.

- **New Features**
  - createSchemaModel(schema, { reactivity? }) with add/remove/rename/change-type and updates for metadata, formula, foreignKey, and default.
  - Change tracking APIs: isDirty, getPatches/getJsonPatches, markAsSaved, revert, getPlainSchema.
  - SchemaParser builds the tree from JsonObjectSchema; NodeFactory creates nodes (string/number/boolean/object/array) with sensible defaults.
  - Public exports added and README with usage; extensive tests for basics, mutations, patches, edge cases, state, and reactivity.

- **Migration**
  - No breaking changes. Import createSchemaModel and types from the model package (schema-model) to use the new API.

<sup>Written for commit 7b37fdb1d6b35c4ed1ac959bf4c09c9820618524. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

