### PR TITLE
feat: value node

### DIFF
--- a/src/model/schema-formula/__tests__/FormulaPath.spec.ts
+++ b/src/model/schema-formula/__tests__/FormulaPath.spec.ts
@@ -1,0 +1,241 @@
+import { EMPTY_PATH, jsonPointerToPath } from '../../../core/path/index.js';
+import { FormulaPath } from '../parsing/index.js';
+
+describe('FormulaPath', () => {
+  describe('resolve()', () => {
+    describe('simple identifiers', () => {
+      it('resolves identifier from root', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'fieldName');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/fieldName');
+      });
+
+      it('resolves identifier from nested path', () => {
+        const basePath = jsonPointerToPath('/properties/parent');
+        const formulaPath = new FormulaPath(basePath, 'sibling');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/parent/properties/sibling');
+      });
+    });
+
+    describe('member expressions (dot notation)', () => {
+      it('resolves nested member expression', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'parent.child');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/parent/properties/child');
+      });
+
+      it('resolves deeply nested member expression', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'a.b.c.d');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe(
+          '/properties/a/properties/b/properties/c/properties/d',
+        );
+      });
+    });
+
+    describe('relative paths (..)', () => {
+      it('resolves single parent reference', () => {
+        const basePath = jsonPointerToPath('/properties/parent/properties/child');
+        const formulaPath = new FormulaPath(basePath, '../sibling');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/parent/properties/sibling');
+      });
+
+      it('resolves multiple parent references', () => {
+        const basePath = jsonPointerToPath('/properties/a/properties/b/properties/c');
+        const formulaPath = new FormulaPath(basePath, '../../sibling');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/a/properties/sibling');
+      });
+
+      it('returns null when going above root', () => {
+        const basePath = jsonPointerToPath('/properties/single');
+        const formulaPath = new FormulaPath(basePath, '../../invalid');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('handles path with nested parent and child', () => {
+        const basePath = jsonPointerToPath('/properties/a/properties/b/properties/c');
+        const formulaPath = new FormulaPath(basePath, '../d');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/a/properties/b/properties/d');
+      });
+    });
+
+    describe('root paths (/)', () => {
+      it('resolves absolute root path', () => {
+        const basePath = jsonPointerToPath('/properties/nested/properties/deep');
+        const formulaPath = new FormulaPath(basePath, '/rootField');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/rootField');
+      });
+
+      it('resolves absolute nested path', () => {
+        const basePath = jsonPointerToPath('/properties/somewhere/properties/else');
+        const formulaPath = new FormulaPath(basePath, '/config.settings');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/config/properties/settings');
+      });
+
+      it('returns null for invalid root path with empty segment', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '/a..b');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('returns null for standalone root slash', () => {
+        const basePath = jsonPointerToPath('/properties/field');
+        const formulaPath = new FormulaPath(basePath, '/');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('handles root path with array notation', () => {
+        const basePath = jsonPointerToPath('/properties/other');
+        const formulaPath = new FormulaPath(basePath, '/items[*].value');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/items/items/properties/value');
+      });
+
+      it('handles root path with indexed array', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '/data[0].field');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/data/items/properties/field');
+      });
+    });
+
+    describe('array access ([*] and [n])', () => {
+      it('resolves wildcard array access', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'items[*]');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/items/items');
+      });
+
+      it('resolves indexed array access', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'items[0]');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/items/items');
+      });
+
+      it('resolves chained array and member access', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'items[*].value');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/items/items/properties/value');
+      });
+
+      it('resolves nested array access', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'matrix[0][1]');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/matrix/items/items');
+      });
+    });
+
+    describe('error handling', () => {
+      it('returns null for invalid formula syntax', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '+++invalid');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('returns null for unsupported AST node type', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '1 + 2');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('returns null for empty path after parent navigation', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '../something');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('returns null for function call expression', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'SUM(a, b)');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+
+      it('returns null for ternary expression', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, 'a ? b : c');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).toBeNull();
+      });
+    });
+
+    describe('edge cases for array notation in root path', () => {
+      it('handles multiple array notations in root path', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '/matrix[*].rows[0].value');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe(
+          '/properties/matrix/items/properties/rows/items/properties/value',
+        );
+      });
+
+      it('handles simple field without array notation', () => {
+        const basePath = EMPTY_PATH;
+        const formulaPath = new FormulaPath(basePath, '/simple');
+        const resolved = formulaPath.resolve();
+
+        expect(resolved).not.toBeNull();
+        expect(resolved?.asJsonPointer()).toBe('/properties/simple');
+      });
+    });
+  });
+});

--- a/src/model/value-node/ArrayValueNode.ts
+++ b/src/model/value-node/ArrayValueNode.ts
@@ -1,0 +1,267 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonArraySchema, JsonSchema } from '../../types/schema.types.js';
+import { BaseValueNode } from './BaseValueNode.js';
+import type { NodeFactory } from './NodeFactory.js';
+import type { ArrayValueNode as IArrayValueNode, ValueNode } from './types.js';
+import { ValueType } from './types.js';
+
+export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
+  readonly type = ValueType.Array;
+
+  private _items: ValueNode[];
+  private _baseItems: ValueNode[];
+  private _nodeFactory: NodeFactory | null = null;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    items?: ValueNode[],
+    private readonly reactivity?: ReactivityAdapter,
+  ) {
+    super(id, name, schema);
+
+    this._items = reactivity?.observableArray<ValueNode>() ?? [];
+    this._baseItems = [];
+
+    if (items) {
+      for (const item of items) {
+        item.parent = this;
+        this._items.push(item);
+      }
+    }
+
+    this._baseItems = [...this._items];
+
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    if (!this.reactivity) {
+      return;
+    }
+
+    this.reactivity.makeObservable(this, {
+      _items: 'observable',
+      _baseItems: 'observable',
+      value: 'computed',
+      length: 'computed',
+      isDirty: 'computed',
+      errors: 'computed',
+      warnings: 'computed',
+      push: 'action',
+      insertAt: 'action',
+      removeAt: 'action',
+      move: 'action',
+      replaceAt: 'action',
+      clear: 'action',
+      commit: 'action',
+      revert: 'action',
+      pushValue: 'action',
+      insertValueAt: 'action',
+    } as Record<string, 'observable' | 'computed' | 'action'>);
+  }
+
+  get value(): readonly ValueNode[] {
+    return this._items;
+  }
+
+  get length(): number {
+    return this._items.length;
+  }
+
+  getPlainValue(): unknown[] {
+    return this._items.map((item) => item.getPlainValue());
+  }
+
+  at(index: number): ValueNode | undefined {
+    if (index < 0) {
+      return this._items[this._items.length + index];
+    }
+    return this._items[index];
+  }
+
+  push(node: ValueNode): void {
+    node.parent = this;
+    this._items.push(node);
+  }
+
+  insertAt(index: number, node: ValueNode): void {
+    if (index < 0 || index > this._items.length) {
+      throw new Error(`Index out of bounds: ${index}`);
+    }
+    node.parent = this;
+    this._items.splice(index, 0, node);
+  }
+
+  removeAt(index: number): void {
+    if (index < 0 || index >= this._items.length) {
+      throw new Error(`Index out of bounds: ${index}`);
+    }
+    const removed = this._items.splice(index, 1)[0];
+    if (removed) {
+      removed.parent = null;
+    }
+  }
+
+  move(fromIndex: number, toIndex: number): void {
+    if (fromIndex < 0 || fromIndex >= this._items.length) {
+      throw new Error(`Source index out of bounds: ${fromIndex}`);
+    }
+    if (toIndex < 0 || toIndex >= this._items.length) {
+      throw new Error(`Target index out of bounds: ${toIndex}`);
+    }
+    if (fromIndex === toIndex) {
+      return;
+    }
+
+    const [item] = this._items.splice(fromIndex, 1);
+    if (item) {
+      this._items.splice(toIndex, 0, item);
+    }
+  }
+
+  replaceAt(index: number, node: ValueNode): void {
+    if (index < 0 || index >= this._items.length) {
+      throw new Error(`Index out of bounds: ${index}`);
+    }
+    const oldNode = this._items[index];
+    if (oldNode) {
+      oldNode.parent = null;
+    }
+    node.parent = this;
+    this._items[index] = node;
+  }
+
+  clear(): void {
+    for (const item of this._items) {
+      item.parent = null;
+    }
+    this._items.length = 0;
+  }
+
+  setNodeFactory(factory: NodeFactory): void {
+    this._nodeFactory = factory;
+  }
+
+  pushValue(value?: unknown): void {
+    const node = this.createItemNode(this._items.length, value);
+    this.push(node);
+  }
+
+  insertValueAt(index: number, value?: unknown): void {
+    const node = this.createItemNode(index, value);
+    this.insertAt(index, node);
+  }
+
+  private createItemNode(index: number, value?: unknown): ValueNode {
+    if (!this._nodeFactory) {
+      throw new Error('NodeFactory not set');
+    }
+
+    const arraySchema = this.schema as JsonArraySchema;
+    const itemSchema = arraySchema.items;
+    if (!itemSchema) {
+      throw new Error('No items schema');
+    }
+
+    const itemValue =
+      value === undefined && 'default' in itemSchema
+        ? itemSchema.default
+        : value;
+    const node = this._nodeFactory.create(String(index), itemSchema, itemValue);
+
+    this.propagateFactory(node);
+
+    return node;
+  }
+
+  private propagateFactory(node: ValueNode): void {
+    if (!this._nodeFactory) {
+      return;
+    }
+
+    if (node.isArray()) {
+      node.setNodeFactory(this._nodeFactory);
+      for (const item of node.value) {
+        this.propagateFactory(item);
+      }
+    } else if (node.isObject()) {
+      for (const child of node.children) {
+        this.propagateFactory(child);
+      }
+    }
+  }
+
+  get isDirty(): boolean {
+    if (this._items.length !== this._baseItems.length) {
+      return true;
+    }
+
+    for (let i = 0; i < this._items.length; i++) {
+      if (this._items[i] !== this._baseItems[i]) {
+        return true;
+      }
+    }
+
+    for (const item of this._items) {
+      if ('isDirty' in item && (item as { isDirty: boolean }).isDirty) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  commit(): void {
+    this._baseItems = [...this._items];
+    for (const item of this._items) {
+      if ('commit' in item && typeof item.commit === 'function') {
+        (item as { commit: () => void }).commit();
+      }
+    }
+  }
+
+  revert(): void {
+    for (const item of this._items) {
+      item.parent = null;
+    }
+
+    this._items = this.reactivity?.observableArray<ValueNode>() ?? [];
+    for (const baseItem of this._baseItems) {
+      this._items.push(baseItem);
+    }
+
+    for (const item of this._items) {
+      item.parent = this;
+      if ('revert' in item && typeof item.revert === 'function') {
+        (item as { revert: () => void }).revert();
+      }
+    }
+  }
+
+  override isArray(): this is IArrayValueNode {
+    return true;
+  }
+
+  override get errors(): readonly Diagnostic[] {
+    const errors: Diagnostic[] = [];
+
+    for (const item of this._items) {
+      errors.push(...item.errors);
+    }
+
+    return errors;
+  }
+
+  override get warnings(): readonly Diagnostic[] {
+    const warnings: Diagnostic[] = [];
+
+    for (const item of this._items) {
+      warnings.push(...item.warnings);
+    }
+
+    return warnings;
+  }
+}

--- a/src/model/value-node/BasePrimitiveValueNode.ts
+++ b/src/model/value-node/BasePrimitiveValueNode.ts
@@ -1,0 +1,145 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonSchema } from '../../types/schema.types.js';
+import { BaseValueNode } from './BaseValueNode.js';
+import type {
+  FormulaDefinition,
+  FormulaWarning,
+  PrimitiveValueNode,
+} from './types.js';
+import { extractFormulaDefinition } from './types.js';
+
+export abstract class BasePrimitiveValueNode<T extends string | number | boolean>
+  extends BaseValueNode
+  implements PrimitiveValueNode
+{
+  protected _value: T;
+  protected _baseValue: T;
+  protected _formulaWarning: FormulaWarning | null = null;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    value: T | undefined,
+    defaultValue: T,
+    protected readonly reactivity?: ReactivityAdapter,
+  ) {
+    super(id, name, schema);
+    const schemaDefault = 'default' in schema ? (schema.default as T) : undefined;
+    const initialValue = value ?? schemaDefault ?? defaultValue;
+    this._value = initialValue;
+    this._baseValue = initialValue;
+  }
+
+  protected initObservable(): void {
+    if (!this.reactivity) {
+      return;
+    }
+
+    this.reactivity.makeObservable(this, {
+      _value: 'observable',
+      _baseValue: 'observable',
+      _formulaWarning: 'observable',
+      value: 'computed',
+      baseValue: 'computed',
+      isDirty: 'computed',
+      errors: 'computed',
+      warnings: 'computed',
+      setValue: 'action',
+      setFormulaWarning: 'action',
+      commit: 'action',
+      revert: 'action',
+    } as Record<string, 'observable' | 'computed' | 'action'>);
+  }
+
+  get value(): T {
+    return this._value;
+  }
+
+  set value(newValue: T) {
+    if (this.isReadOnly) {
+      throw new Error(`Cannot set value on read-only field: ${this.name}`);
+    }
+    this._value = newValue;
+  }
+
+  get baseValue(): T {
+    return this._baseValue;
+  }
+
+  get isDirty(): boolean {
+    return this._value !== this._baseValue;
+  }
+
+  abstract get defaultValue(): T;
+
+  get formula(): FormulaDefinition | undefined {
+    return extractFormulaDefinition(this.schema);
+  }
+
+  get formulaWarning(): FormulaWarning | null {
+    return this._formulaWarning;
+  }
+
+  get isReadOnly(): boolean {
+    const readOnly = 'readOnly' in this.schema ? this.schema.readOnly : false;
+    return readOnly === true || this.formula !== undefined;
+  }
+
+  getPlainValue(): T {
+    return this._value;
+  }
+
+  setValue(value: unknown, options?: { internal?: boolean }): void {
+    if (this.isReadOnly && !options?.internal) {
+      throw new Error(`Cannot set value on read-only field: ${this.name}`);
+    }
+    this._value = this.coerceValue(value);
+  }
+
+  protected abstract coerceValue(value: unknown): T;
+
+  setFormulaWarning(warning: FormulaWarning | null): void {
+    this._formulaWarning = warning;
+  }
+
+  commit(): void {
+    this._baseValue = this._value;
+  }
+
+  revert(): void {
+    this._value = this._baseValue;
+  }
+
+  override isPrimitive(): this is PrimitiveValueNode {
+    return true;
+  }
+
+  override get errors(): readonly Diagnostic[] {
+    return this.computeErrors();
+  }
+
+  protected computeErrors(): readonly Diagnostic[] {
+    return [];
+  }
+
+  override get warnings(): readonly Diagnostic[] {
+    if (!this._formulaWarning) {
+      return [];
+    }
+
+    return [
+      {
+        severity: 'warning',
+        type: this._formulaWarning.type,
+        message: this._formulaWarning.message,
+        path: this.name,
+        params: {
+          expression: this._formulaWarning.expression,
+          computedValue: this._formulaWarning.computedValue,
+        },
+      },
+    ];
+  }
+}

--- a/src/model/value-node/BaseValueNode.ts
+++ b/src/model/value-node/BaseValueNode.ts
@@ -1,0 +1,77 @@
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonSchema } from '../../types/schema.types.js';
+import type {
+  ArrayValueNode,
+  ObjectValueNode,
+  PrimitiveValueNode,
+  ValueNode,
+  ValueType,
+} from './types.js';
+
+let nodeIdCounter = 0;
+
+export function generateNodeId(): string {
+  return `node-${++nodeIdCounter}`;
+}
+
+export function resetNodeIdCounter(): void {
+  nodeIdCounter = 0;
+}
+
+export abstract class BaseValueNode implements ValueNode {
+  readonly id: string;
+  abstract readonly type: ValueType;
+  readonly schema: JsonSchema;
+
+  private _parent: ValueNode | null = null;
+  private readonly _name: string;
+
+  constructor(id: string | undefined, name: string, schema: JsonSchema) {
+    this.id = id ?? generateNodeId();
+    this._name = name;
+    this.schema = schema;
+  }
+
+  get parent(): ValueNode | null {
+    return this._parent;
+  }
+
+  set parent(value: ValueNode | null) {
+    this._parent = value;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  abstract get value(): unknown;
+  abstract getPlainValue(): unknown;
+
+  isObject(): this is ObjectValueNode {
+    return false;
+  }
+
+  isArray(): this is ArrayValueNode {
+    return false;
+  }
+
+  isPrimitive(): this is PrimitiveValueNode {
+    return false;
+  }
+
+  get errors(): readonly Diagnostic[] {
+    return [];
+  }
+
+  get warnings(): readonly Diagnostic[] {
+    return [];
+  }
+
+  get isValid(): boolean {
+    return this.errors.length === 0;
+  }
+
+  get hasWarnings(): boolean {
+    return this.warnings.length > 0;
+  }
+}

--- a/src/model/value-node/BooleanValueNode.ts
+++ b/src/model/value-node/BooleanValueNode.ts
@@ -1,0 +1,30 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { JsonSchema } from '../../types/schema.types.js';
+import { BasePrimitiveValueNode } from './BasePrimitiveValueNode.js';
+import { ValueType } from './types.js';
+
+export class BooleanValueNode extends BasePrimitiveValueNode<boolean> {
+  readonly type = ValueType.Boolean;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    value?: boolean,
+    reactivity?: ReactivityAdapter,
+  ) {
+    super(id, name, schema, value, false, reactivity);
+    this.initObservable();
+  }
+
+  get defaultValue(): boolean {
+    return 'default' in this.schema ? (this.schema.default as boolean) : false;
+  }
+
+  protected coerceValue(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    return Boolean(value);
+  }
+}

--- a/src/model/value-node/NodeFactory.ts
+++ b/src/model/value-node/NodeFactory.ts
@@ -86,7 +86,7 @@ export class NodeFactory {
       return schema;
     }
 
-    const refSchema = schema as JsonRefSchema;
+    const refSchema: JsonRefSchema = schema;
     const resolved = this.refSchemas[refSchema.$ref];
     if (!resolved) {
       return schema;

--- a/src/model/value-node/NodeFactory.ts
+++ b/src/model/value-node/NodeFactory.ts
@@ -1,0 +1,208 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type {
+  JsonArraySchema,
+  JsonObjectSchema,
+  JsonRefSchema,
+  JsonSchema,
+} from '../../types/schema.types.js';
+import { ArrayValueNode } from './ArrayValueNode.js';
+import { BooleanValueNode } from './BooleanValueNode.js';
+import { NumberValueNode } from './NumberValueNode.js';
+import { ObjectValueNode } from './ObjectValueNode.js';
+import { StringValueNode } from './StringValueNode.js';
+import type { ValueNode } from './types.js';
+
+export type NodeFactoryFn = (
+  name: string,
+  schema: JsonSchema,
+  value: unknown,
+  id?: string,
+) => ValueNode;
+
+export class NodeFactoryRegistry {
+  private readonly factories = new Map<string, NodeFactoryFn>();
+
+  register(schemaType: string, factory: NodeFactoryFn): this {
+    this.factories.set(schemaType, factory);
+    return this;
+  }
+
+  get(schemaType: string): NodeFactoryFn | undefined {
+    return this.factories.get(schemaType);
+  }
+
+  has(schemaType: string): boolean {
+    return this.factories.has(schemaType);
+  }
+}
+
+export type RefSchemas = Record<string, JsonSchema>;
+
+export interface NodeFactoryOptions {
+  refSchemas?: RefSchemas;
+  reactivity?: ReactivityAdapter;
+}
+
+export class NodeFactory {
+  private readonly refSchemas: RefSchemas | undefined;
+
+  constructor(
+    private readonly registry: NodeFactoryRegistry,
+    options?: NodeFactoryOptions,
+  ) {
+    this.refSchemas = options?.refSchemas;
+  }
+
+  create(
+    name: string,
+    schema: JsonSchema,
+    value: unknown,
+    id?: string,
+  ): ValueNode {
+    const resolvedSchema = this.resolveSchema(schema);
+    const schemaType = this.getSchemaType(resolvedSchema);
+    const factory = this.registry.get(schemaType);
+
+    if (!factory) {
+      throw new Error(`Unknown schema type: ${schemaType}`);
+    }
+
+    return factory(name, resolvedSchema, value, id);
+  }
+
+  createTree(schema: JsonSchema, value: unknown): ValueNode {
+    return this.create('', schema, value);
+  }
+
+  private getSchemaType(schema: JsonSchema): string {
+    if ('type' in schema) {
+      return schema.type;
+    }
+    return 'object';
+  }
+
+  private resolveSchema(schema: JsonSchema): JsonSchema {
+    if (!('$ref' in schema) || !this.refSchemas) {
+      return schema;
+    }
+
+    const refSchema = schema as JsonRefSchema;
+    const resolved = this.refSchemas[refSchema.$ref];
+    if (!resolved) {
+      return schema;
+    }
+
+    return {
+      ...resolved,
+      $ref: refSchema.$ref,
+      title: refSchema.title ?? ('title' in resolved ? resolved.title : undefined),
+      description:
+        refSchema.description ??
+        ('description' in resolved ? resolved.description : undefined),
+      deprecated:
+        refSchema.deprecated ??
+        ('deprecated' in resolved ? resolved.deprecated : undefined),
+    } as JsonSchema;
+  }
+}
+
+function createStringFactory(reactivity?: ReactivityAdapter): NodeFactoryFn {
+  return (name, schema, value, id) => {
+    return new StringValueNode(
+      id,
+      name,
+      schema,
+      value as string | undefined,
+      reactivity,
+    );
+  };
+}
+
+function createNumberFactory(reactivity?: ReactivityAdapter): NodeFactoryFn {
+  return (name, schema, value, id) => {
+    return new NumberValueNode(
+      id,
+      name,
+      schema,
+      value as number | undefined,
+      reactivity,
+    );
+  };
+}
+
+function createBooleanFactory(reactivity?: ReactivityAdapter): NodeFactoryFn {
+  return (name, schema, value, id) => {
+    return new BooleanValueNode(
+      id,
+      name,
+      schema,
+      value as boolean | undefined,
+      reactivity,
+    );
+  };
+}
+
+function createObjectFactory(
+  nodeFactory: NodeFactory,
+  reactivity?: ReactivityAdapter,
+): NodeFactoryFn {
+  return (name, schema, value, id) => {
+    const objValue = (value ?? {}) as Record<string, unknown>;
+    const children: ValueNode[] = [];
+
+    const objectSchema = schema as JsonObjectSchema;
+    const properties = objectSchema.properties ?? {};
+    for (const [propName, propSchema] of Object.entries(properties)) {
+      const propValue = objValue[propName];
+      const childNode = nodeFactory.create(propName, propSchema, propValue);
+      children.push(childNode);
+    }
+
+    return new ObjectValueNode(id, name, schema, children, reactivity);
+  };
+}
+
+function createArrayFactory(
+  nodeFactory: NodeFactory,
+  reactivity?: ReactivityAdapter,
+): NodeFactoryFn {
+  return (name, schema, value, id) => {
+    const arrValue = (value ?? []) as unknown[];
+    const arraySchema = schema as JsonArraySchema;
+    const itemSchema = arraySchema.items ?? { type: 'string', default: '' };
+    const items: ValueNode[] = [];
+
+    for (let i = 0; i < arrValue.length; i++) {
+      const itemValue = arrValue[i];
+      const itemNode = nodeFactory.create(String(i), itemSchema, itemValue);
+      items.push(itemNode);
+    }
+
+    const arrayNode = new ArrayValueNode(id, name, schema, items, reactivity);
+    arrayNode.setNodeFactory(nodeFactory);
+
+    return arrayNode;
+  };
+}
+
+export function createDefaultRegistry(
+  reactivity?: ReactivityAdapter,
+): NodeFactoryRegistry {
+  const registry = new NodeFactoryRegistry();
+
+  registry.register('string', createStringFactory(reactivity));
+  registry.register('number', createNumberFactory(reactivity));
+  registry.register('boolean', createBooleanFactory(reactivity));
+
+  return registry;
+}
+
+export function createNodeFactory(options?: NodeFactoryOptions): NodeFactory {
+  const registry = createDefaultRegistry(options?.reactivity);
+  const factory = new NodeFactory(registry, options);
+
+  registry.register('object', createObjectFactory(factory, options?.reactivity));
+  registry.register('array', createArrayFactory(factory, options?.reactivity));
+
+  return factory;
+}

--- a/src/model/value-node/NumberValueNode.ts
+++ b/src/model/value-node/NumberValueNode.ts
@@ -1,0 +1,81 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonSchema } from '../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../types/schema.types.js';
+import { BasePrimitiveValueNode } from './BasePrimitiveValueNode.js';
+import { ValueType } from './types.js';
+
+export class NumberValueNode extends BasePrimitiveValueNode<number> {
+  readonly type = ValueType.Number;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    value?: number,
+    reactivity?: ReactivityAdapter,
+  ) {
+    super(id, name, schema, value, 0, reactivity);
+    this.initObservable();
+  }
+
+  get defaultValue(): number {
+    return 'default' in this.schema ? (this.schema.default as number) : 0;
+  }
+
+  protected coerceValue(value: unknown): number {
+    if (typeof value === 'number') {
+      return value;
+    }
+    return Number(value) || 0;
+  }
+
+  protected override computeErrors(): readonly Diagnostic[] {
+    const errors: Diagnostic[] = [];
+
+    if (!('type' in this.schema) || this.schema.type !== JsonSchemaTypeName.Number) {
+      return errors;
+    }
+
+    const numberSchema = this.schema;
+
+    const minimum = numberSchema.minimum;
+    if (minimum !== undefined && this._value < minimum) {
+      errors.push({
+        severity: 'error',
+        type: 'min',
+        message: `Value must be at least ${minimum}`,
+        path: this.name,
+        params: { min: minimum, actual: this._value },
+      });
+    }
+
+    const maximum = numberSchema.maximum;
+    if (maximum !== undefined && this._value > maximum) {
+      errors.push({
+        severity: 'error',
+        type: 'max',
+        message: `Value must be at most ${maximum}`,
+        path: this.name,
+        params: { max: maximum, actual: this._value },
+      });
+    }
+
+    const enumValues = numberSchema.enum;
+    if (
+      enumValues &&
+      enumValues.length > 0 &&
+      !enumValues.includes(this._value)
+    ) {
+      errors.push({
+        severity: 'error',
+        type: 'enum',
+        message: 'Value is not in allowed list',
+        path: this.name,
+        params: { allowed: enumValues, actual: this._value },
+      });
+    }
+
+    return errors;
+  }
+}

--- a/src/model/value-node/ObjectValueNode.ts
+++ b/src/model/value-node/ObjectValueNode.ts
@@ -1,0 +1,169 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonSchema } from '../../types/schema.types.js';
+import { BaseValueNode } from './BaseValueNode.js';
+import type { ObjectValueNode as IObjectValueNode, ValueNode } from './types.js';
+import { ValueType } from './types.js';
+
+export class ObjectValueNode extends BaseValueNode implements IObjectValueNode {
+  readonly type = ValueType.Object;
+
+  private _children: Map<string, ValueNode>;
+  private _baseChildren: Map<string, ValueNode>;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    children?: ValueNode[],
+    private readonly reactivity?: ReactivityAdapter,
+  ) {
+    super(id, name, schema);
+
+    this._children = reactivity?.observableMap<string, ValueNode>() ?? new Map();
+    this._baseChildren = new Map();
+
+    if (children) {
+      for (const child of children) {
+        this._children.set(child.name, child);
+        child.parent = this;
+      }
+    }
+
+    this._baseChildren = new Map(this._children);
+
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    if (!this.reactivity) {
+      return;
+    }
+
+    this.reactivity.makeObservable(this, {
+      _children: 'observable',
+      _baseChildren: 'observable',
+      value: 'computed',
+      children: 'computed',
+      isDirty: 'computed',
+      errors: 'computed',
+      warnings: 'computed',
+      addChild: 'action',
+      removeChild: 'action',
+      commit: 'action',
+      revert: 'action',
+    } as Record<string, 'observable' | 'computed' | 'action'>);
+  }
+
+  get value(): Record<string, ValueNode> {
+    return Object.fromEntries(this._children);
+  }
+
+  get children(): readonly ValueNode[] {
+    return Array.from(this._children.values());
+  }
+
+  getPlainValue(): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, node] of this._children) {
+      result[key] = node.getPlainValue();
+    }
+    return result;
+  }
+
+  child(name: string): ValueNode | undefined {
+    return this._children.get(name);
+  }
+
+  hasChild(name: string): boolean {
+    return this._children.has(name);
+  }
+
+  addChild(node: ValueNode): void {
+    const existing = this._children.get(node.name);
+    if (existing) {
+      existing.parent = null;
+    }
+    node.parent = this;
+    this._children.set(node.name, node);
+  }
+
+  removeChild(name: string): void {
+    const node = this._children.get(name);
+    if (node) {
+      node.parent = null;
+      this._children.delete(name);
+    }
+  }
+
+  get isDirty(): boolean {
+    if (this._children.size !== this._baseChildren.size) {
+      return true;
+    }
+
+    for (const [key, child] of this._children) {
+      if (this._baseChildren.get(key) !== child) {
+        return true;
+      }
+    }
+
+    for (const child of this._children.values()) {
+      if ('isDirty' in child && (child as { isDirty: boolean }).isDirty) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  commit(): void {
+    this._baseChildren = new Map(this._children);
+    for (const child of this._children.values()) {
+      if ('commit' in child && typeof child.commit === 'function') {
+        (child as { commit: () => void }).commit();
+      }
+    }
+  }
+
+  revert(): void {
+    for (const child of this._children.values()) {
+      child.parent = null;
+    }
+
+    this._children = this.reactivity?.observableMap<string, ValueNode>() ?? new Map();
+    for (const [key, value] of this._baseChildren) {
+      this._children.set(key, value);
+    }
+
+    for (const child of this._children.values()) {
+      child.parent = this;
+      if ('revert' in child && typeof child.revert === 'function') {
+        (child as { revert: () => void }).revert();
+      }
+    }
+  }
+
+  override isObject(): this is IObjectValueNode {
+    return true;
+  }
+
+  override get errors(): readonly Diagnostic[] {
+    const errors: Diagnostic[] = [];
+
+    for (const child of this._children.values()) {
+      errors.push(...child.errors);
+    }
+
+    return errors;
+  }
+
+  override get warnings(): readonly Diagnostic[] {
+    const warnings: Diagnostic[] = [];
+
+    for (const child of this._children.values()) {
+      warnings.push(...child.warnings);
+    }
+
+    return warnings;
+  }
+}

--- a/src/model/value-node/README.md
+++ b/src/model/value-node/README.md
@@ -13,7 +13,7 @@ The `value-node` module provides a tree-based representation of JSON values that
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │  ValueNode Hierarchy                                            │
 │                                                                 │
@@ -54,7 +54,7 @@ enum ValueType {
 // Formula definition from schema
 interface FormulaDefinition {
   readonly expression: string;
-  readonly version: number;
+  readonly version: 1; // Currently only version 1 is supported
 }
 
 // Formula computation warning

--- a/src/model/value-node/README.md
+++ b/src/model/value-node/README.md
@@ -1,0 +1,341 @@
+# value-node
+
+Reactive value tree implementation for JSON data with dirty tracking, validation, and formula support.
+
+## Overview
+
+The `value-node` module provides a tree-based representation of JSON values that:
+- Maps to a JSON Schema structure
+- Supports reactive updates via `ReactivityAdapter`
+- Tracks dirty state (commit/revert)
+- Validates data against schema constraints
+- Supports formula fields (read-only computed values)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ValueNode Hierarchy                                            │
+│                                                                 │
+│  ValueNode (interface)                                          │
+│      │                                                          │
+│      ├── BaseValueNode (abstract)                               │
+│      │       │                                                  │
+│      │       ├── BasePrimitiveValueNode<T>                      │
+│      │       │       ├── StringValueNode                        │
+│      │       │       ├── NumberValueNode                        │
+│      │       │       └── BooleanValueNode                       │
+│      │       │                                                  │
+│      │       ├── ObjectValueNode                                │
+│      │       │       └── children: Map<string, ValueNode>       │
+│      │       │                                                  │
+│      │       └── ArrayValueNode                                 │
+│      │               └── items: ValueNode[]                     │
+│      │                                                          │
+│      └── DirtyTrackable (interface)                             │
+│              └── isDirty, commit(), revert()                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## API
+
+### Types
+
+```typescript
+// Value node types
+enum ValueType {
+  String = 'string',
+  Number = 'number',
+  Boolean = 'boolean',
+  Object = 'object',
+  Array = 'array',
+}
+
+// Formula definition from schema
+interface FormulaDefinition {
+  readonly expression: string;
+  readonly version: number;
+}
+
+// Formula computation warning
+interface FormulaWarning {
+  readonly type: 'nan' | 'infinity' | 'type-coercion' | 'division-by-zero' | 'null-reference' | 'runtime-error';
+  readonly message: string;
+  readonly expression: string;
+  readonly computedValue: unknown;
+}
+```
+
+### ValueNode Interface
+
+```typescript
+interface ValueNode {
+  readonly id: string;
+  readonly type: ValueType;
+  readonly schema: JsonSchema;
+
+  parent: ValueNode | null;
+  readonly name: string;
+
+  readonly value: unknown;
+  getPlainValue(): unknown;
+
+  isObject(): this is ObjectValueNode;
+  isArray(): this is ArrayValueNode;
+  isPrimitive(): this is PrimitiveValueNode;
+
+  readonly errors: readonly Diagnostic[];
+  readonly warnings: readonly Diagnostic[];
+  readonly isValid: boolean;
+  readonly hasWarnings: boolean;
+}
+```
+
+### PrimitiveValueNode
+
+```typescript
+interface PrimitiveValueNode extends ValueNode, DirtyTrackable {
+  value: string | number | boolean;
+  readonly baseValue: string | number | boolean;
+  readonly defaultValue: unknown;
+  readonly formula: FormulaDefinition | undefined;
+  readonly formulaWarning: FormulaWarning | null;
+  readonly isReadOnly: boolean;
+
+  setValue(value: unknown, options?: { internal?: boolean }): void;
+  setFormulaWarning(warning: FormulaWarning | null): void;
+}
+```
+
+### ObjectValueNode
+
+```typescript
+interface ObjectValueNode extends ValueNode, DirtyTrackable {
+  readonly value: Record<string, ValueNode>;
+  readonly children: readonly ValueNode[];
+
+  child(name: string): ValueNode | undefined;
+  addChild(node: ValueNode): void;
+  removeChild(name: string): void;
+  hasChild(name: string): boolean;
+}
+```
+
+### ArrayValueNode
+
+```typescript
+interface ArrayValueNode extends ValueNode, DirtyTrackable {
+  readonly value: readonly ValueNode[];
+  readonly length: number;
+
+  at(index: number): ValueNode | undefined;
+  push(node: ValueNode): void;
+  insertAt(index: number, node: ValueNode): void;
+  removeAt(index: number): void;
+  move(fromIndex: number, toIndex: number): void;
+  replaceAt(index: number, node: ValueNode): void;
+  clear(): void;
+
+  setNodeFactory(factory: NodeFactory): void;
+  pushValue(value?: unknown): void;
+  insertValueAt(index: number, value?: unknown): void;
+}
+```
+
+### NodeFactory
+
+```typescript
+function createNodeFactory(options?: NodeFactoryOptions): NodeFactory;
+
+interface NodeFactoryOptions {
+  refSchemas?: RefSchemas;     // For resolving $ref schemas
+  reactivity?: ReactivityAdapter;  // For reactive updates
+}
+
+class NodeFactory {
+  create(name: string, schema: JsonSchema, value: unknown, id?: string): ValueNode;
+  createTree(schema: JsonSchema, value: unknown): ValueNode;
+}
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { createNodeFactory } from '@revisium/schema-toolkit/model/value-node';
+import { JsonSchemaTypeName } from '@revisium/schema-toolkit/types';
+
+const factory = createNodeFactory();
+
+const schema = {
+  type: JsonSchemaTypeName.Object,
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    age: { type: JsonSchemaTypeName.Number, default: 0 },
+  },
+  additionalProperties: false,
+  required: ['name', 'age'],
+};
+
+const data = { name: 'John', age: 25 };
+const root = factory.createTree(schema, data);
+
+// Access values
+if (root.isObject()) {
+  const nameNode = root.child('name');
+  console.log(nameNode?.getPlainValue()); // 'John'
+}
+```
+
+### With Reactivity (MobX)
+
+```typescript
+import { createNodeFactory } from '@revisium/schema-toolkit/model/value-node';
+import { createMobxAdapter } from '@revisium/schema-toolkit/core/reactivity';
+
+const reactivity = createMobxAdapter();
+const factory = createNodeFactory({ reactivity });
+
+const root = factory.createTree(schema, data);
+
+// Changes trigger MobX reactions
+if (root.isObject()) {
+  const nameNode = root.child('name');
+  if (nameNode?.isPrimitive()) {
+    nameNode.setValue('Jane'); // Triggers reactive update
+  }
+}
+```
+
+### Dirty Tracking
+
+```typescript
+const root = factory.createTree(schema, data);
+
+if (root.isObject()) {
+  const nameNode = root.child('name');
+  if (nameNode?.isPrimitive()) {
+    console.log(nameNode.isDirty); // false
+
+    nameNode.setValue('Jane');
+    console.log(nameNode.isDirty); // true
+    console.log(nameNode.baseValue); // 'John'
+    console.log(nameNode.value); // 'Jane'
+
+    nameNode.revert();
+    console.log(nameNode.value); // 'John'
+    console.log(nameNode.isDirty); // false
+
+    nameNode.setValue('Jane');
+    nameNode.commit();
+    console.log(nameNode.baseValue); // 'Jane'
+    console.log(nameNode.isDirty); // false
+  }
+}
+```
+
+### Validation
+
+```typescript
+const schema = {
+  type: JsonSchemaTypeName.String,
+  default: '',
+  required: true,
+  minLength: 3,
+  maxLength: 50,
+  pattern: '^[A-Za-z]+$',
+};
+
+const node = new StringValueNode(undefined, 'name', schema, '');
+
+console.log(node.errors);
+// [{ severity: 'error', type: 'required', message: 'Field is required', path: 'name' }]
+
+node.setValue('ab');
+console.log(node.errors);
+// [{ severity: 'error', type: 'minLength', message: 'Minimum length is 3', path: 'name', params: { min: 3, actual: 2 } }]
+
+node.setValue('John123');
+console.log(node.errors);
+// [{ severity: 'error', type: 'pattern', message: 'Value does not match pattern', path: 'name', params: { pattern: '^[A-Za-z]+$' } }]
+
+node.setValue('John');
+console.log(node.isValid); // true
+console.log(node.errors); // []
+```
+
+### Formula Fields
+
+```typescript
+const schema = {
+  type: JsonSchemaTypeName.String,
+  default: '',
+  readOnly: true,
+  'x-formula': { version: 1, expression: 'firstName + " " + lastName' },
+};
+
+const node = new StringValueNode(undefined, 'fullName', schema);
+
+console.log(node.isReadOnly); // true
+console.log(node.formula); // { version: 1, expression: 'firstName + " " + lastName' }
+
+// Cannot set value on formula field
+node.setValue('Test'); // throws: Cannot set value on read-only field: fullName
+
+// But internal setValue works (for formula engine)
+node.setValue('John Doe', { internal: true }); // OK
+```
+
+### Array Operations
+
+```typescript
+const schema = {
+  type: JsonSchemaTypeName.Array,
+  items: { type: JsonSchemaTypeName.String, default: '' },
+};
+
+const root = factory.createTree(schema, ['a', 'b', 'c']);
+
+if (root.isArray()) {
+  // Access items
+  console.log(root.length); // 3
+  console.log(root.at(0)?.getPlainValue()); // 'a'
+  console.log(root.at(-1)?.getPlainValue()); // 'c'
+
+  // Add items
+  root.pushValue('d');
+  root.insertValueAt(0, 'z');
+
+  // Remove items
+  root.removeAt(1);
+
+  // Move items
+  root.move(0, 2);
+
+  // Get plain value
+  console.log(root.getPlainValue()); // ['b', 'c', 'z', 'd']
+}
+```
+
+## Dependencies
+
+### Internal
+- `../../core/reactivity/types.js` - ReactivityAdapter interface
+- `../../core/validation/types.js` - Diagnostic type
+- `../../types/schema.types.js` - JSON Schema types
+
+### External
+None (framework-agnostic)
+
+## Testing
+
+```bash
+npm test -- src/model/value-node
+```
+
+## Related Modules
+
+- `schema-model` - Schema tree operations
+- `schema-formula` - Formula parsing and serialization (for `x-formula` support)
+- `value-formula` (PR 2.9) - Runtime formula evaluation for value trees

--- a/src/model/value-node/StringValueNode.ts
+++ b/src/model/value-node/StringValueNode.ts
@@ -29,6 +29,9 @@ export class StringValueNode extends BasePrimitiveValueNode<string> {
     if (value === null || value === undefined) {
       return '';
     }
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
     return String(value);
   }
 

--- a/src/model/value-node/StringValueNode.ts
+++ b/src/model/value-node/StringValueNode.ts
@@ -1,0 +1,151 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonSchema, JsonStringSchema } from '../../types/schema.types.js';
+import { BasePrimitiveValueNode } from './BasePrimitiveValueNode.js';
+import { ValueType } from './types.js';
+
+export class StringValueNode extends BasePrimitiveValueNode<string> {
+  readonly type = ValueType.String;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    value?: string,
+    reactivity?: ReactivityAdapter,
+  ) {
+    super(id, name, schema, value, '', reactivity);
+    this.initObservable();
+  }
+
+  get defaultValue(): string {
+    return 'default' in this.schema ? (this.schema.default as string) : '';
+  }
+
+  protected coerceValue(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value);
+  }
+
+  protected override computeErrors(): readonly Diagnostic[] {
+    const errors: Diagnostic[] = [];
+
+    this.validateRequired(errors);
+    this.validateForeignKey(errors);
+    this.validateMinLength(errors);
+    this.validateMaxLength(errors);
+    this.validatePattern(errors);
+    this.validateEnum(errors);
+
+    return errors;
+  }
+
+  private validateRequired(errors: Diagnostic[]): void {
+    const stringSchema = this.schema as JsonStringSchema;
+    if ('required' in stringSchema && stringSchema.required && this._value === '') {
+      errors.push({
+        severity: 'error',
+        type: 'required',
+        message: 'Field is required',
+        path: this.name,
+      });
+    }
+  }
+
+  private validateForeignKey(errors: Diagnostic[]): void {
+    const stringSchema = this.schema as JsonStringSchema;
+    const foreignKey = stringSchema.foreignKey;
+    if (foreignKey && this._value === '') {
+      errors.push({
+        severity: 'error',
+        type: 'foreignKey',
+        message: `Reference to ${foreignKey} is required`,
+        path: this.name,
+        params: { table: foreignKey },
+      });
+    }
+  }
+
+  private validateMinLength(errors: Diagnostic[]): void {
+    const stringSchema = this.schema as Partial<{ minLength?: number }>;
+    const minLength = stringSchema.minLength;
+    if (
+      minLength !== undefined &&
+      this._value.length > 0 &&
+      this._value.length < minLength
+    ) {
+      errors.push({
+        severity: 'error',
+        type: 'minLength',
+        message: `Minimum length is ${minLength}`,
+        path: this.name,
+        params: { min: minLength, actual: this._value.length },
+      });
+    }
+  }
+
+  private validateMaxLength(errors: Diagnostic[]): void {
+    const stringSchema = this.schema as Partial<{ maxLength?: number }>;
+    const maxLength = stringSchema.maxLength;
+    if (maxLength !== undefined && this._value.length > maxLength) {
+      errors.push({
+        severity: 'error',
+        type: 'maxLength',
+        message: `Maximum length is ${maxLength}`,
+        path: this.name,
+        params: { max: maxLength, actual: this._value.length },
+      });
+    }
+  }
+
+  private validatePattern(errors: Diagnostic[]): void {
+    const stringSchema = this.schema as JsonStringSchema;
+    const pattern = stringSchema.pattern;
+    if (!pattern || this._value.length === 0) {
+      return;
+    }
+
+    try {
+      if (!new RegExp(pattern).test(this._value)) {
+        errors.push({
+          severity: 'error',
+          type: 'pattern',
+          message: 'Value does not match pattern',
+          path: this.name,
+          params: { pattern },
+        });
+      }
+    } catch {
+      errors.push({
+        severity: 'error',
+        type: 'invalidPattern',
+        message: 'Invalid regex pattern in schema',
+        path: this.name,
+        params: { pattern },
+      });
+    }
+  }
+
+  private validateEnum(errors: Diagnostic[]): void {
+    const stringSchema = this.schema as JsonStringSchema;
+    const enumValues = stringSchema.enum;
+    if (
+      enumValues &&
+      enumValues.length > 0 &&
+      !enumValues.includes(this._value)
+    ) {
+      errors.push({
+        severity: 'error',
+        type: 'enum',
+        message: 'Value is not in allowed list',
+        path: this.name,
+        params: { allowed: enumValues, actual: this._value },
+      });
+    }
+  }
+}

--- a/src/model/value-node/__tests__/ArrayValueNode.spec.ts
+++ b/src/model/value-node/__tests__/ArrayValueNode.spec.ts
@@ -1,0 +1,697 @@
+import type { JsonArraySchema, JsonSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import {
+  ArrayValueNode,
+  StringValueNode,
+  createNodeFactory,
+  resetNodeIdCounter,
+} from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+const createSchema = (
+  items: JsonSchema = { type: JsonSchemaTypeName.String, default: '' },
+): JsonArraySchema => ({
+  type: JsonSchemaTypeName.Array,
+  items,
+});
+
+describe('ArrayValueNode', () => {
+  describe('construction', () => {
+    it('creates empty array node', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(node.type).toBe('array');
+      expect(node.name).toBe('items');
+      expect(node.length).toBe(0);
+    });
+
+    it('creates array node with items', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item2,
+      ]);
+
+      expect(node.length).toBe(2);
+      expect(node.at(0)).toBe(item1);
+      expect(node.at(1)).toBe(item2);
+    });
+
+    it('sets parent on items', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(item.parent).toBe(node);
+    });
+
+    it('uses provided id', () => {
+      const node = new ArrayValueNode('custom-id', 'items', createSchema());
+
+      expect(node.id).toBe('custom-id');
+    });
+
+    it('generates id when not provided', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(node.id).toBe('node-1');
+    });
+  });
+
+  describe('value', () => {
+    it('returns array of items', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+      ]);
+
+      expect(node.value).toEqual([item1]);
+    });
+  });
+
+  describe('getPlainValue', () => {
+    it('returns plain array', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item2,
+      ]);
+
+      expect(node.getPlainValue()).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('at', () => {
+    it('returns item at positive index', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(node.at(0)).toBe(item);
+    });
+
+    it('returns item at negative index', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item2,
+      ]);
+
+      expect(node.at(-1)).toBe(item2);
+    });
+
+    it('returns undefined for out of bounds index', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(node.at(5)).toBeUndefined();
+    });
+  });
+
+  describe('push', () => {
+    it('adds item to end', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      node.push(item);
+
+      expect(node.length).toBe(1);
+      expect(node.at(0)).toBe(item);
+      expect(item.parent).toBe(node);
+    });
+  });
+
+  describe('insertAt', () => {
+    it('inserts item at beginning', () => {
+      const existing = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        existing,
+      ]);
+
+      const newItem = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      node.insertAt(0, newItem);
+
+      expect(node.length).toBe(2);
+      expect(node.at(0)).toBe(newItem);
+      expect(node.at(1)).toBe(existing);
+      expect(newItem.parent).toBe(node);
+    });
+
+    it('inserts item at middle', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item3 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'c',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item3,
+      ]);
+
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+      node.insertAt(1, item2);
+
+      expect(node.getPlainValue()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('throws for negative index', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      expect(() => node.insertAt(-1, item)).toThrow('Index out of bounds: -1');
+    });
+
+    it('throws for index beyond length', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      expect(() => node.insertAt(5, item)).toThrow('Index out of bounds: 5');
+    });
+  });
+
+  describe('removeAt', () => {
+    it('removes item at index', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      node.removeAt(0);
+
+      expect(node.length).toBe(0);
+      expect(item.parent).toBeNull();
+    });
+
+    it('throws for negative index', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(() => node.removeAt(-1)).toThrow('Index out of bounds: -1');
+    });
+
+    it('throws for index out of bounds', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(() => node.removeAt(0)).toThrow('Index out of bounds: 0');
+    });
+  });
+
+  describe('move', () => {
+    it('moves item forward', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+      const item3 = new StringValueNode(
+        undefined,
+        '2',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'c',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item2,
+        item3,
+      ]);
+
+      node.move(0, 2);
+
+      expect(node.getPlainValue()).toEqual(['b', 'c', 'a']);
+    });
+
+    it('moves item backward', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+      const item3 = new StringValueNode(
+        undefined,
+        '2',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'c',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item2,
+        item3,
+      ]);
+
+      node.move(2, 0);
+
+      expect(node.getPlainValue()).toEqual(['c', 'a', 'b']);
+    });
+
+    it('does nothing when moving to same index', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      node.move(0, 0);
+
+      expect(node.at(0)).toBe(item);
+    });
+
+    it('throws for invalid source index', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(() => node.move(-1, 0)).toThrow('Source index out of bounds: -1');
+    });
+
+    it('throws for invalid target index', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(() => node.move(0, 5)).toThrow('Target index out of bounds: 5');
+    });
+  });
+
+  describe('replaceAt', () => {
+    it('replaces item at index', () => {
+      const oldItem = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        oldItem,
+      ]);
+
+      const newItem = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+      node.replaceAt(0, newItem);
+
+      expect(node.at(0)).toBe(newItem);
+      expect(oldItem.parent).toBeNull();
+      expect(newItem.parent).toBe(node);
+    });
+
+    it('throws for invalid index', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      expect(() => node.replaceAt(0, item)).toThrow('Index out of bounds: 0');
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all items', () => {
+      const item1 = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const item2 = new StringValueNode(
+        undefined,
+        '1',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'b',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item1,
+        item2,
+      ]);
+
+      node.clear();
+
+      expect(node.length).toBe(0);
+      expect(item1.parent).toBeNull();
+      expect(item2.parent).toBeNull();
+    });
+  });
+
+  describe('pushValue and insertValueAt', () => {
+    it('pushValue creates and adds node', () => {
+      const factory = createNodeFactory();
+      const schema = createSchema();
+      const node = factory.createTree(schema, []) as ArrayValueNode;
+
+      node.pushValue('a');
+
+      expect(node.length).toBe(1);
+      expect(node.getPlainValue()).toEqual(['a']);
+    });
+
+    it('pushValue uses default value', () => {
+      const factory = createNodeFactory();
+      const schema = createSchema({
+        type: JsonSchemaTypeName.String,
+        default: 'default',
+      });
+      const node = factory.createTree(schema, []) as ArrayValueNode;
+
+      node.pushValue();
+
+      expect(node.getPlainValue()).toEqual(['default']);
+    });
+
+    it('insertValueAt creates and inserts node', () => {
+      const factory = createNodeFactory();
+      const schema = createSchema();
+      const node = factory.createTree(schema, ['a', 'c']) as ArrayValueNode;
+
+      node.insertValueAt(1, 'b');
+
+      expect(node.getPlainValue()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('throws when no factory set', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(() => node.pushValue('a')).toThrow('NodeFactory not set');
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty is false initially', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('isDirty is true when item value changes', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      item.setValue('b');
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('isDirty is true when item added', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+      node.commit();
+
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      node.push(item);
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('isDirty is true when item removed', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+      node.commit();
+
+      node.removeAt(0);
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('commit updates baseItems', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      item.setValue('b');
+      node.commit();
+
+      expect(node.isDirty).toBe(false);
+      expect(item.isDirty).toBe(false);
+    });
+
+    it('revert restores items', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+      node.commit();
+
+      item.setValue('b');
+      node.revert();
+
+      expect(item.value).toBe('a');
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('revert restores removed items', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+      node.commit();
+
+      node.removeAt(0);
+      node.revert();
+
+      expect(node.length).toBe(1);
+      expect(node.at(0)).toBe(item);
+      expect(item.parent).toBe(node);
+    });
+  });
+
+  describe('errors and warnings', () => {
+    it('collects errors from items', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '', required: true },
+        '',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(node.errors).toHaveLength(1);
+      expect(node.errors[0]?.type).toBe('required');
+    });
+
+    it('collects warnings from items', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      item.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'test',
+        expression: 'test',
+        computedValue: 42,
+      });
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(node.warnings).toHaveLength(1);
+    });
+
+    it('isValid is false when item has errors', () => {
+      const item = new StringValueNode(
+        undefined,
+        '0',
+        { type: JsonSchemaTypeName.String, default: '', required: true },
+        '',
+      );
+      const node = new ArrayValueNode(undefined, 'items', createSchema(), [
+        item,
+      ]);
+
+      expect(node.isValid).toBe(false);
+    });
+  });
+
+  describe('type checks', () => {
+    it('isArray returns true', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(node.isArray()).toBe(true);
+    });
+
+    it('isPrimitive returns false', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(node.isPrimitive()).toBe(false);
+    });
+
+    it('isObject returns false', () => {
+      const node = new ArrayValueNode(undefined, 'items', createSchema());
+
+      expect(node.isObject()).toBe(false);
+    });
+  });
+});

--- a/src/model/value-node/__tests__/BaseValueNode.spec.ts
+++ b/src/model/value-node/__tests__/BaseValueNode.spec.ts
@@ -1,0 +1,98 @@
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import { StringValueNode, resetNodeIdCounter } from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+describe('BaseValueNode', () => {
+  describe('parent', () => {
+    it('parent is null by default', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      expect(node.parent).toBeNull();
+    });
+
+    it('parent can be set and read', () => {
+      const parent = new StringValueNode(
+        undefined,
+        'parent',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'Parent',
+      );
+      const child = new StringValueNode(
+        undefined,
+        'child',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'Child',
+      );
+
+      child.parent = parent;
+
+      expect(child.parent).toBe(parent);
+    });
+  });
+
+  describe('errors and warnings defaults', () => {
+    it('errors is empty by default', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('warnings is empty by default', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      expect(node.warnings).toHaveLength(0);
+    });
+
+    it('isValid is true by default', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      expect(node.isValid).toBe(true);
+    });
+
+    it('hasWarnings is false by default', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      expect(node.hasWarnings).toBe(false);
+    });
+  });
+
+  describe('schema', () => {
+    it('returns schema passed to constructor', () => {
+      const schema = {
+        type: JsonSchemaTypeName.String as const,
+        default: 'test',
+      };
+      const node = new StringValueNode(undefined, 'name', schema);
+
+      expect(node.schema).toBe(schema);
+    });
+  });
+});

--- a/src/model/value-node/__tests__/BooleanValueNode.spec.ts
+++ b/src/model/value-node/__tests__/BooleanValueNode.spec.ts
@@ -1,0 +1,246 @@
+import type { JsonBooleanSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import { BooleanValueNode, resetNodeIdCounter } from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+const createSchema = (
+  overrides: Partial<JsonBooleanSchema> = {},
+): JsonBooleanSchema => ({
+  type: JsonSchemaTypeName.Boolean,
+  default: false,
+  ...overrides,
+});
+
+describe('BooleanValueNode', () => {
+  describe('construction', () => {
+    it('creates node with value', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'active',
+        createSchema(),
+        true,
+      );
+
+      expect(node.value).toBe(true);
+      expect(node.name).toBe('active');
+      expect(node.type).toBe('boolean');
+    });
+
+    it('uses default from schema when no value provided', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'enabled',
+        createSchema({ default: true }),
+      );
+
+      expect(node.value).toBe(true);
+    });
+
+    it('uses false when no value and no default', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.value).toBe(false);
+    });
+
+    it('uses provided id', () => {
+      const node = new BooleanValueNode('custom-id', 'flag', createSchema());
+
+      expect(node.id).toBe('custom-id');
+    });
+
+    it('generates id when not provided', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.id).toBe('node-1');
+    });
+  });
+
+  describe('setValue', () => {
+    it('sets boolean value', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      node.setValue(true);
+
+      expect(node.value).toBe(true);
+    });
+
+    it('converts truthy string to true', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      node.setValue('yes');
+
+      expect(node.value).toBe(true);
+    });
+
+    it('converts empty string to false', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        true,
+      );
+
+      node.setValue('');
+
+      expect(node.value).toBe(false);
+    });
+
+    it('converts number 1 to true', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      node.setValue(1);
+
+      expect(node.value).toBe(true);
+    });
+
+    it('converts number 0 to false', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        true,
+      );
+
+      node.setValue(0);
+
+      expect(node.value).toBe(false);
+    });
+
+    it('converts null to false', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        true,
+      );
+
+      node.setValue(null);
+
+      expect(node.value).toBe(false);
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty is false initially', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        false,
+      );
+
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('isDirty is true after setValue', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        false,
+      );
+
+      node.setValue(true);
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('commit updates baseValue', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        false,
+      );
+      node.setValue(true);
+
+      node.commit();
+
+      expect(node.baseValue).toBe(true);
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('revert restores value', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        false,
+      );
+      node.setValue(true);
+
+      node.revert();
+
+      expect(node.value).toBe(false);
+      expect(node.isDirty).toBe(false);
+    });
+  });
+
+  describe('defaultValue', () => {
+    it('returns default from schema', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema({ default: true }),
+      );
+
+      expect(node.defaultValue).toBe(true);
+    });
+
+    it('returns false when no default in schema', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.defaultValue).toBe(false);
+    });
+  });
+
+  describe('getPlainValue', () => {
+    it('returns boolean value', () => {
+      const node = new BooleanValueNode(
+        undefined,
+        'flag',
+        createSchema(),
+        true,
+      );
+
+      expect(node.getPlainValue()).toBe(true);
+    });
+  });
+
+  describe('type checks', () => {
+    it('isPrimitive returns true', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.isPrimitive()).toBe(true);
+    });
+
+    it('isObject returns false', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.isObject()).toBe(false);
+    });
+
+    it('isArray returns false', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.isArray()).toBe(false);
+    });
+  });
+
+  describe('errors and warnings', () => {
+    it('returns empty errors', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('isValid returns true', () => {
+      const node = new BooleanValueNode(undefined, 'flag', createSchema());
+
+      expect(node.isValid).toBe(true);
+    });
+  });
+});

--- a/src/model/value-node/__tests__/NodeFactory.spec.ts
+++ b/src/model/value-node/__tests__/NodeFactory.spec.ts
@@ -1,0 +1,615 @@
+import { jest } from '@jest/globals';
+import type { JsonObjectSchema, JsonSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import {
+  createNodeFactory,
+  NodeFactoryRegistry,
+  NodeFactory,
+  resetNodeIdCounter,
+  type NodeFactoryFn,
+} from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+describe('NodeFactoryRegistry', () => {
+  it('registers and retrieves factory', () => {
+    const registry = new NodeFactoryRegistry();
+    const factory = jest.fn() as unknown as NodeFactoryFn;
+
+    registry.register('custom', factory);
+
+    expect(registry.get('custom')).toBe(factory);
+  });
+
+  it('has returns true for registered type', () => {
+    const registry = new NodeFactoryRegistry();
+    registry.register('custom', jest.fn() as unknown as NodeFactoryFn);
+
+    expect(registry.has('custom')).toBe(true);
+    expect(registry.has('unknown')).toBe(false);
+  });
+
+  it('supports chaining', () => {
+    const registry = new NodeFactoryRegistry();
+    const mockFn = jest.fn() as unknown as NodeFactoryFn;
+
+    const result = registry.register('a', mockFn).register('b', mockFn);
+
+    expect(result).toBe(registry);
+  });
+});
+
+describe('NodeFactory', () => {
+  let factory: NodeFactory;
+
+  beforeEach(() => {
+    factory = createNodeFactory();
+  });
+
+  describe('primitive types', () => {
+    it('creates string node', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.String,
+        default: '',
+      };
+      const node = factory.create('name', schema, 'John');
+
+      expect(node.isPrimitive()).toBe(true);
+      expect(node.name).toBe('name');
+      expect(node.getPlainValue()).toBe('John');
+    });
+
+    it('creates string node with default value', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.String,
+        default: 'default',
+      };
+      const node = factory.create('name', schema, undefined);
+
+      expect(node.getPlainValue()).toBe('default');
+    });
+
+    it('creates number node', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+      };
+      const node = factory.create('age', schema, 25);
+
+      expect(node.isPrimitive()).toBe(true);
+      expect(node.getPlainValue()).toBe(25);
+    });
+
+    it('creates number node with default', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+      };
+      const node = factory.create('count', schema, undefined);
+
+      expect(node.getPlainValue()).toBe(0);
+    });
+
+    it('creates boolean node', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Boolean,
+        default: false,
+      };
+      const node = factory.create('active', schema, true);
+
+      expect(node.isPrimitive()).toBe(true);
+      expect(node.getPlainValue()).toBe(true);
+    });
+
+    it('creates boolean node with default', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Boolean,
+        default: false,
+      };
+      const node = factory.create('enabled', schema, undefined);
+
+      expect(node.getPlainValue()).toBe(false);
+    });
+  });
+
+  describe('object type', () => {
+    it('creates empty object node', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {},
+        additionalProperties: false,
+        required: [],
+      };
+      const node = factory.create('user', schema, {});
+
+      expect(node.isObject()).toBe(true);
+      expect(node.getPlainValue()).toEqual({});
+    });
+
+    it('creates object node with properties', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+          age: { type: JsonSchemaTypeName.Number, default: 0 },
+        },
+        additionalProperties: false,
+        required: ['name', 'age'],
+      };
+      const node = factory.create('user', schema, { name: 'John', age: 25 });
+
+      expect(node.isObject()).toBe(true);
+      expect(node.getPlainValue()).toEqual({ name: 'John', age: 25 });
+    });
+
+    it('creates nested object', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          address: {
+            type: JsonSchemaTypeName.Object,
+            properties: {
+              city: { type: JsonSchemaTypeName.String, default: '' },
+            },
+            additionalProperties: false,
+            required: ['city'],
+          },
+        },
+        additionalProperties: false,
+        required: ['address'],
+      };
+      const node = factory.create('user', schema, {
+        address: { city: 'NYC' },
+      });
+
+      expect(node.getPlainValue()).toEqual({
+        address: { city: 'NYC' },
+      });
+    });
+
+    it('uses default values for missing properties', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: 'Unknown' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+      const node = factory.create('user', schema, {});
+
+      expect(node.getPlainValue()).toEqual({ name: 'Unknown' });
+    });
+
+    it('handles null value as empty object', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+      const node = factory.create('user', schema, null);
+
+      expect(node.getPlainValue()).toEqual({ name: '' });
+    });
+  });
+
+  describe('array type', () => {
+    it('creates empty array node', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+      const node = factory.create('tags', schema, []);
+
+      expect(node.isArray()).toBe(true);
+      expect(node.getPlainValue()).toEqual([]);
+    });
+
+    it('creates array of strings', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+      const node = factory.create('tags', schema, ['a', 'b', 'c']);
+
+      expect(node.getPlainValue()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('creates array of numbers', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.Number, default: 0 },
+      };
+      const node = factory.create('scores', schema, [1, 2, 3]);
+
+      expect(node.getPlainValue()).toEqual([1, 2, 3]);
+    });
+
+    it('creates array of objects', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Object,
+          properties: {
+            id: { type: JsonSchemaTypeName.Number, default: 0 },
+            name: { type: JsonSchemaTypeName.String, default: '' },
+          },
+          additionalProperties: false,
+          required: ['id', 'name'],
+        },
+      };
+      const node = factory.create('items', schema, [
+        { id: 1, name: 'First' },
+        { id: 2, name: 'Second' },
+      ]);
+
+      expect(node.getPlainValue()).toEqual([
+        { id: 1, name: 'First' },
+        { id: 2, name: 'Second' },
+      ]);
+    });
+
+    it('creates nested arrays', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Array,
+          items: { type: JsonSchemaTypeName.Number, default: 0 },
+        },
+      };
+      const node = factory.create('matrix', schema, [
+        [1, 2],
+        [3, 4],
+      ]);
+
+      expect(node.getPlainValue()).toEqual([
+        [1, 2],
+        [3, 4],
+      ]);
+    });
+
+    it('handles null value as empty array', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+      const node = factory.create('tags', schema, null);
+
+      expect(node.getPlainValue()).toEqual([]);
+    });
+
+    it('handles undefined value as empty array', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+      const node = factory.create('tags', schema, undefined);
+
+      expect(node.getPlainValue()).toEqual([]);
+    });
+  });
+
+  describe('createTree', () => {
+    it('creates root with empty name', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+      const node = factory.createTree(schema, { name: 'John' });
+
+      expect(node.name).toBe('');
+      expect(node.getPlainValue()).toEqual({ name: 'John' });
+    });
+
+    it('creates array as root', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.Number, default: 0 },
+      };
+      const node = factory.createTree(schema, [1, 2, 3]);
+
+      expect(node.isArray()).toBe(true);
+      expect(node.getPlainValue()).toEqual([1, 2, 3]);
+    });
+
+    it('creates primitive as root', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.String,
+        default: '',
+      };
+      const node = factory.createTree(schema, 'hello');
+
+      expect(node.isPrimitive()).toBe(true);
+      expect(node.getPlainValue()).toBe('hello');
+    });
+  });
+
+  describe('custom id', () => {
+    it('uses provided id', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.String,
+        default: '',
+      };
+      const node = factory.create('name', schema, 'John', 'custom-id');
+
+      expect(node.id).toBe('custom-id');
+    });
+
+    it('generates id when not provided', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.String,
+        default: '',
+      };
+      const node = factory.create('name', schema, 'John');
+
+      expect(node.id).toBe('node-1');
+    });
+  });
+
+  describe('complex schema', () => {
+    it('creates complex nested structure', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          user: {
+            type: JsonSchemaTypeName.Object,
+            properties: {
+              name: { type: JsonSchemaTypeName.String, default: '' },
+              addresses: {
+                type: JsonSchemaTypeName.Array,
+                items: {
+                  type: JsonSchemaTypeName.Object,
+                  properties: {
+                    city: { type: JsonSchemaTypeName.String, default: '' },
+                    zip: { type: JsonSchemaTypeName.String, default: '' },
+                  },
+                  additionalProperties: false,
+                  required: ['city', 'zip'],
+                },
+              },
+            },
+            additionalProperties: false,
+            required: ['name', 'addresses'],
+          },
+          tags: {
+            type: JsonSchemaTypeName.Array,
+            items: { type: JsonSchemaTypeName.String, default: '' },
+          },
+        },
+        additionalProperties: false,
+        required: ['user', 'tags'],
+      };
+
+      const value = {
+        user: {
+          name: 'John',
+          addresses: [
+            { city: 'NYC', zip: '10001' },
+            { city: 'LA', zip: '90001' },
+          ],
+        },
+        tags: ['admin', 'user'],
+      };
+
+      const node = factory.createTree(schema, value);
+
+      expect(node.getPlainValue()).toEqual(value);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws for unknown schema type', () => {
+      const registry = new NodeFactoryRegistry();
+      const localFactory = new NodeFactory(registry);
+
+      expect(() =>
+        localFactory.create(
+          'field',
+          { type: 'unknown' } as unknown as JsonSchema,
+          null,
+        ),
+      ).toThrow('Unknown schema type: unknown');
+    });
+
+    it('defaults to object when type is missing', () => {
+      const schema = {
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      } as unknown as JsonSchema;
+      const node = factory.create('data', schema, { name: 'John' });
+
+      expect(node.isObject()).toBe(true);
+    });
+  });
+
+  describe('parent relationships', () => {
+    it('sets parent on object children', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+      const node = factory.create('user', schema, { name: 'John' });
+
+      if (node.isObject()) {
+        const nameNode = node.child('name');
+        expect(nameNode?.parent).toBe(node);
+      }
+    });
+
+    it('sets parent on array items', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.Number, default: 0 },
+      };
+      const node = factory.create('items', schema, [1, 2]);
+
+      if (node.isArray()) {
+        const item = node.at(0);
+        expect(item?.parent).toBe(node);
+      }
+    });
+  });
+
+  describe('refSchemas resolution', () => {
+    const fileSchema: JsonObjectSchema = {
+      type: JsonSchemaTypeName.Object,
+      properties: {
+        status: {
+          type: JsonSchemaTypeName.String,
+          default: '',
+          readOnly: true,
+        },
+        fileId: {
+          type: JsonSchemaTypeName.String,
+          default: '',
+          readOnly: true,
+        },
+        url: { type: JsonSchemaTypeName.String, default: '', readOnly: true },
+        fileName: { type: JsonSchemaTypeName.String, default: '' },
+      },
+      additionalProperties: false,
+      required: ['status', 'fileId', 'url', 'fileName'],
+    };
+
+    const refSchemas = {
+      File: fileSchema,
+    };
+
+    it('resolves $ref to full schema', () => {
+      const factory = createNodeFactory({ refSchemas });
+      const schema: JsonSchema = { $ref: 'File' };
+      const value = {
+        status: 'ready',
+        fileId: 'abc123',
+        url: '',
+        fileName: 'test.jpg',
+      };
+
+      const node = factory.create('avatar', schema, value);
+
+      expect(node.isObject()).toBe(true);
+      expect(node.getPlainValue()).toEqual(value);
+      expect((node.schema as { $ref?: string }).$ref).toBe('File');
+    });
+
+    it('resolves nested $ref in object properties', () => {
+      const factory = createNodeFactory({ refSchemas });
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+          avatar: { $ref: 'File' },
+        },
+        additionalProperties: false,
+        required: ['name', 'avatar'],
+      };
+      const value = {
+        name: 'John',
+        avatar: {
+          status: 'uploaded',
+          fileId: 'xyz789',
+          url: 'http://example.com/file.jpg',
+          fileName: 'photo.jpg',
+        },
+      };
+
+      const node = factory.createTree(schema, value);
+
+      expect(node.getPlainValue()).toEqual(value);
+      if (node.isObject()) {
+        const avatarNode = node.child('avatar');
+        expect(avatarNode?.isObject()).toBe(true);
+        expect((avatarNode?.schema as { $ref?: string }).$ref).toBe('File');
+        if (avatarNode?.isObject()) {
+          expect(avatarNode.child('fileName')?.getPlainValue()).toBe(
+            'photo.jpg',
+          );
+        }
+      }
+    });
+
+    it('resolves $ref in array items', () => {
+      const factory = createNodeFactory({ refSchemas });
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { $ref: 'File' },
+      };
+      const value = [
+        { status: 'ready', fileId: '1', url: '', fileName: 'a.jpg' },
+        { status: 'ready', fileId: '2', url: '', fileName: 'b.jpg' },
+      ];
+
+      const node = factory.createTree(schema, value);
+
+      expect(node.isArray()).toBe(true);
+      if (node.isArray()) {
+        expect(node.length).toBe(2);
+        const first = node.at(0);
+        expect(first?.isObject()).toBe(true);
+        expect((first?.schema as { $ref?: string }).$ref).toBe('File');
+      }
+    });
+
+    it('preserves title/description/deprecated from original schema', () => {
+      const factory = createNodeFactory({ refSchemas });
+      const schema: JsonSchema = {
+        $ref: 'File',
+        title: 'User Avatar',
+        description: 'Profile picture',
+        deprecated: true,
+      };
+
+      const node = factory.create('avatar', schema, {});
+
+      expect((node.schema as { title?: string }).title).toBe('User Avatar');
+      expect((node.schema as { description?: string }).description).toBe(
+        'Profile picture',
+      );
+      expect((node.schema as { deprecated?: boolean }).deprecated).toBe(true);
+      expect((node.schema as { $ref?: string }).$ref).toBe('File');
+    });
+
+    it('returns original schema when $ref not found in refSchemas', () => {
+      const factory = createNodeFactory({ refSchemas });
+      const schema: JsonSchema = { $ref: 'Unknown' };
+
+      const node = factory.create('field', schema, {});
+
+      expect(node.isObject()).toBe(true);
+      expect((node.schema as { $ref?: string }).$ref).toBe('Unknown');
+      expect(node.getPlainValue()).toEqual({});
+    });
+
+    it('works without refSchemas option', () => {
+      const factory = createNodeFactory();
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+
+      const node = factory.create('user', schema, { name: 'John' });
+
+      expect(node.getPlainValue()).toEqual({ name: 'John' });
+    });
+  });
+});

--- a/src/model/value-node/__tests__/NumberValueNode.spec.ts
+++ b/src/model/value-node/__tests__/NumberValueNode.spec.ts
@@ -1,0 +1,285 @@
+import type { JsonNumberSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import { NumberValueNode, resetNodeIdCounter } from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+const createSchema = (
+  overrides: Partial<JsonNumberSchema> = {},
+): JsonNumberSchema => ({
+  type: JsonSchemaTypeName.Number,
+  default: 0,
+  ...overrides,
+});
+
+describe('NumberValueNode', () => {
+  describe('construction', () => {
+    it('creates node with value', () => {
+      const node = new NumberValueNode(undefined, 'age', createSchema(), 25);
+
+      expect(node.value).toBe(25);
+      expect(node.name).toBe('age');
+      expect(node.type).toBe('number');
+    });
+
+    it('uses default from schema when no value provided', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'count',
+        createSchema({ default: 10 }),
+      );
+
+      expect(node.value).toBe(10);
+    });
+
+    it('uses 0 when no value and no default', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      expect(node.value).toBe(0);
+    });
+
+    it('uses provided id', () => {
+      const node = new NumberValueNode('custom-id', 'count', createSchema());
+
+      expect(node.id).toBe('custom-id');
+    });
+
+    it('generates id when not provided', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      expect(node.id).toBe('node-1');
+    });
+  });
+
+  describe('setValue', () => {
+    it('sets number value', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      node.setValue(42);
+
+      expect(node.value).toBe(42);
+    });
+
+    it('converts string to number', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      node.setValue('42');
+
+      expect(node.value).toBe(42);
+    });
+
+    it('converts invalid string to 0', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      node.setValue('not a number');
+
+      expect(node.value).toBe(0);
+    });
+
+    it('converts null to 0', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      node.setValue(null);
+
+      expect(node.value).toBe(0);
+    });
+
+    it('converts boolean to number', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      node.setValue(true);
+
+      expect(node.value).toBe(1);
+    });
+  });
+
+  describe('validation - minimum', () => {
+    it('returns error when below minimum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'age',
+        createSchema({ minimum: 18 }),
+        10,
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('min');
+      expect(errors[0]?.params).toEqual({ min: 18, actual: 10 });
+    });
+
+    it('returns no error when at minimum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'age',
+        createSchema({ minimum: 18 }),
+        18,
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('returns no error when above minimum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'age',
+        createSchema({ minimum: 18 }),
+        25,
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - maximum', () => {
+    it('returns error when above maximum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'score',
+        createSchema({ maximum: 100 }),
+        150,
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('max');
+      expect(errors[0]?.params).toEqual({ max: 100, actual: 150 });
+    });
+
+    it('returns no error when at maximum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'score',
+        createSchema({ maximum: 100 }),
+        100,
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('returns no error when below maximum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'score',
+        createSchema({ maximum: 100 }),
+        50,
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - enum', () => {
+    it('returns error when value not in enum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'status',
+        createSchema({ enum: [1, 2, 3] }),
+        5,
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('enum');
+      expect(errors[0]?.params).toEqual({ allowed: [1, 2, 3], actual: 5 });
+    });
+
+    it('returns no error when value in enum', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'status',
+        createSchema({ enum: [1, 2, 3] }),
+        2,
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty is false initially', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema(), 10);
+
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('isDirty is true after setValue', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema(), 10);
+
+      node.setValue(20);
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('commit updates baseValue', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema(), 10);
+      node.setValue(20);
+
+      node.commit();
+
+      expect(node.baseValue).toBe(20);
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('revert restores value', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema(), 10);
+      node.setValue(20);
+
+      node.revert();
+
+      expect(node.value).toBe(10);
+      expect(node.isDirty).toBe(false);
+    });
+  });
+
+  describe('defaultValue', () => {
+    it('returns default from schema', () => {
+      const node = new NumberValueNode(
+        undefined,
+        'count',
+        createSchema({ default: 42 }),
+      );
+
+      expect(node.defaultValue).toBe(42);
+    });
+
+    it('returns 0 when no default in schema', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      expect(node.defaultValue).toBe(0);
+    });
+  });
+
+  describe('getPlainValue', () => {
+    it('returns number value', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema(), 42);
+
+      expect(node.getPlainValue()).toBe(42);
+    });
+  });
+
+  describe('type checks', () => {
+    it('isPrimitive returns true', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      expect(node.isPrimitive()).toBe(true);
+    });
+
+    it('isObject returns false', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      expect(node.isObject()).toBe(false);
+    });
+
+    it('isArray returns false', () => {
+      const node = new NumberValueNode(undefined, 'count', createSchema());
+
+      expect(node.isArray()).toBe(false);
+    });
+  });
+});

--- a/src/model/value-node/__tests__/ObjectValueNode.spec.ts
+++ b/src/model/value-node/__tests__/ObjectValueNode.spec.ts
@@ -1,0 +1,451 @@
+import type { JsonObjectSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import {
+  ObjectValueNode,
+  StringValueNode,
+  NumberValueNode,
+  resetNodeIdCounter,
+} from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+const createSchema = (
+  properties: JsonObjectSchema['properties'] = {},
+): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  properties,
+  additionalProperties: false,
+  required: Object.keys(properties),
+});
+
+describe('ObjectValueNode', () => {
+  describe('construction', () => {
+    it('creates empty object node', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.type).toBe('object');
+      expect(node.name).toBe('user');
+      expect(node.children).toHaveLength(0);
+    });
+
+    it('creates object node with children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const ageNode = new NumberValueNode(
+        undefined,
+        'age',
+        { type: JsonSchemaTypeName.Number, default: 0 },
+        25,
+      );
+
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+        ageNode,
+      ]);
+
+      expect(node.children).toHaveLength(2);
+      expect(node.child('name')).toBe(nameNode);
+      expect(node.child('age')).toBe(ageNode);
+    });
+
+    it('sets parent on children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(nameNode.parent).toBe(node);
+    });
+
+    it('uses provided id', () => {
+      const node = new ObjectValueNode('custom-id', 'user', createSchema());
+
+      expect(node.id).toBe('custom-id');
+    });
+
+    it('generates id when not provided', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.id).toBe('node-1');
+    });
+  });
+
+  describe('value', () => {
+    it('returns object with children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.value).toEqual({ name: nameNode });
+    });
+  });
+
+  describe('getPlainValue', () => {
+    it('returns plain object', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const ageNode = new NumberValueNode(
+        undefined,
+        'age',
+        { type: JsonSchemaTypeName.Number, default: 0 },
+        25,
+      );
+
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+        ageNode,
+      ]);
+
+      expect(node.getPlainValue()).toEqual({ name: 'John', age: 25 });
+    });
+  });
+
+  describe('child', () => {
+    it('returns child by name', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.child('name')).toBe(nameNode);
+    });
+
+    it('returns undefined for non-existent child', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.child('unknown')).toBeUndefined();
+    });
+  });
+
+  describe('hasChild', () => {
+    it('returns true for existing child', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.hasChild('name')).toBe(true);
+    });
+
+    it('returns false for non-existent child', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.hasChild('unknown')).toBe(false);
+    });
+  });
+
+  describe('addChild', () => {
+    it('adds new child', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+
+      node.addChild(nameNode);
+
+      expect(node.child('name')).toBe(nameNode);
+      expect(nameNode.parent).toBe(node);
+    });
+
+    it('replaces existing child', () => {
+      const oldNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        oldNode,
+      ]);
+
+      const newNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'Jane',
+      );
+      node.addChild(newNode);
+
+      expect(node.child('name')).toBe(newNode);
+      expect(oldNode.parent).toBeNull();
+      expect(newNode.parent).toBe(node);
+    });
+  });
+
+  describe('removeChild', () => {
+    it('removes existing child', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      node.removeChild('name');
+
+      expect(node.child('name')).toBeUndefined();
+      expect(nameNode.parent).toBeNull();
+    });
+
+    it('does nothing for non-existent child', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      node.removeChild('unknown');
+
+      expect(node.children).toHaveLength(0);
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty is false initially', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('isDirty is true when child value changes', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      nameNode.setValue('Jane');
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('isDirty is true when child added', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+      node.commit();
+
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      node.addChild(nameNode);
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('isDirty is true when child removed', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+      node.commit();
+
+      node.removeChild('name');
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('commit updates baseChildren', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      nameNode.setValue('Jane');
+      node.commit();
+
+      expect(node.isDirty).toBe(false);
+      expect(nameNode.isDirty).toBe(false);
+    });
+
+    it('revert restores children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+      node.commit();
+
+      nameNode.setValue('Jane');
+      node.revert();
+
+      expect(nameNode.value).toBe('John');
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('revert restores removed children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+      node.commit();
+
+      node.removeChild('name');
+      node.revert();
+
+      expect(node.child('name')).toBe(nameNode);
+      expect(nameNode.parent).toBe(node);
+    });
+  });
+
+  describe('errors and warnings', () => {
+    it('collects errors from children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '', required: true },
+        '',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.errors).toHaveLength(1);
+      expect(node.errors[0]?.type).toBe('required');
+    });
+
+    it('collects warnings from children', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      nameNode.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'test',
+        expression: 'test',
+        computedValue: 42,
+      });
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.warnings).toHaveLength(1);
+      expect(node.warnings[0]?.type).toBe('type-coercion');
+    });
+
+    it('isValid is false when child has errors', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '', required: true },
+        '',
+      );
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.isValid).toBe(false);
+    });
+
+    it('hasWarnings is true when child has warnings', () => {
+      const nameNode = new StringValueNode(
+        undefined,
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'John',
+      );
+      nameNode.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'test',
+        expression: 'test',
+        computedValue: 42,
+      });
+      const node = new ObjectValueNode(undefined, 'user', createSchema(), [
+        nameNode,
+      ]);
+
+      expect(node.hasWarnings).toBe(true);
+    });
+  });
+
+  describe('type checks', () => {
+    it('isObject returns true', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.isObject()).toBe(true);
+    });
+
+    it('isPrimitive returns false', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.isPrimitive()).toBe(false);
+    });
+
+    it('isArray returns false', () => {
+      const node = new ObjectValueNode(undefined, 'user', createSchema());
+
+      expect(node.isArray()).toBe(false);
+    });
+  });
+});

--- a/src/model/value-node/__tests__/Reactivity.spec.ts
+++ b/src/model/value-node/__tests__/Reactivity.spec.ts
@@ -1,0 +1,219 @@
+import type { JsonArraySchema, JsonObjectSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import type { ReactivityAdapter } from '../../../core/reactivity/types.js';
+import { StringValueNode, resetNodeIdCounter } from '../index.js';
+import { NumberValueNode } from '../NumberValueNode.js';
+import { ObjectValueNode } from '../ObjectValueNode.js';
+import { ArrayValueNode } from '../ArrayValueNode.js';
+import { createNodeFactory } from '../NodeFactory.js';
+
+const createMockReactivity = (): ReactivityAdapter => {
+  return {
+    makeObservable: () => {},
+    observableArray: <T>(): T[] => [],
+    observableMap: <K, V>(): Map<K, V> => new Map<K, V>(),
+    reaction: () => () => {},
+    runInAction: <T>(fn: () => T): T => fn(),
+  };
+};
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+describe('Value nodes with reactivity', () => {
+  describe('StringValueNode', () => {
+    it('initializes observable when reactivity provided', () => {
+      const reactivity = createMockReactivity();
+
+      const node = new StringValueNode(
+        'id',
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'value',
+        reactivity,
+      );
+
+      expect(node.value).toBe('value');
+    });
+  });
+
+  describe('NumberValueNode', () => {
+    it('initializes observable when reactivity provided', () => {
+      const reactivity = createMockReactivity();
+
+      const node = new NumberValueNode(
+        'id',
+        'count',
+        { type: JsonSchemaTypeName.Number, default: 0 },
+        42,
+        reactivity,
+      );
+
+      expect(node.value).toBe(42);
+    });
+  });
+
+  describe('ObjectValueNode', () => {
+    it('uses observable map when reactivity provided', () => {
+      const reactivity = createMockReactivity();
+      const child = new StringValueNode(
+        'c1',
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'test',
+      );
+
+      const node = new ObjectValueNode(
+        'id',
+        'root',
+        {
+          type: JsonSchemaTypeName.Object,
+          properties: {},
+          additionalProperties: false,
+          required: [],
+        },
+        [child],
+        reactivity,
+      );
+
+      expect(node.children).toHaveLength(1);
+      expect(node.child('name')).toBe(child);
+    });
+
+    it('revert uses observable map', () => {
+      const reactivity = createMockReactivity();
+      const child = new StringValueNode(
+        'c1',
+        'name',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'test',
+      );
+      const node = new ObjectValueNode(
+        'id',
+        'root',
+        {
+          type: JsonSchemaTypeName.Object,
+          properties: {},
+          additionalProperties: false,
+          required: [],
+        },
+        [child],
+        reactivity,
+      );
+      node.commit();
+
+      node.removeChild('name');
+      node.revert();
+
+      expect(node.child('name')).toBe(child);
+    });
+  });
+
+  describe('ArrayValueNode', () => {
+    it('uses observable array when reactivity provided', () => {
+      const reactivity = createMockReactivity();
+      const item = new StringValueNode(
+        'i1',
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+
+      const schema: JsonArraySchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+      const node = new ArrayValueNode('id', 'items', schema, [item], reactivity);
+
+      expect(node.length).toBe(1);
+      expect(node.at(0)).toBe(item);
+    });
+
+    it('revert uses observable array', () => {
+      const reactivity = createMockReactivity();
+      const item = new StringValueNode(
+        'i1',
+        '0',
+        { type: JsonSchemaTypeName.String, default: '' },
+        'a',
+      );
+      const schema: JsonArraySchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+      const node = new ArrayValueNode('id', 'items', schema, [item], reactivity);
+      node.commit();
+
+      node.removeAt(0);
+      node.revert();
+
+      expect(node.length).toBe(1);
+      expect(node.at(0)).toBe(item);
+    });
+  });
+
+  describe('NodeFactory with reactivity', () => {
+    it('passes reactivity to created nodes', () => {
+      const reactivity = createMockReactivity();
+      const factory = createNodeFactory({ reactivity });
+
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+          tags: {
+            type: JsonSchemaTypeName.Array,
+            items: { type: JsonSchemaTypeName.String, default: '' },
+          },
+        },
+        additionalProperties: false,
+        required: ['name', 'tags'],
+      };
+
+      const node = factory.create('root', schema, { name: 'test', tags: ['a', 'b'] });
+
+      expect(node.isObject()).toBe(true);
+      if (node.isObject()) {
+        const tags = node.child('tags');
+        expect(tags?.isArray()).toBe(true);
+        if (tags?.isArray()) {
+          tags.pushValue('c');
+          expect(tags.length).toBe(3);
+        }
+      }
+    });
+
+    it('propagates factory to nested arrays', () => {
+      const reactivity = createMockReactivity();
+      const factory = createNodeFactory({ reactivity });
+
+      const schema: JsonArraySchema = {
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Object,
+          properties: {
+            values: {
+              type: JsonSchemaTypeName.Array,
+              items: { type: JsonSchemaTypeName.Number, default: 0 },
+            },
+          },
+          additionalProperties: false,
+          required: ['values'],
+        },
+      };
+
+      const node = factory.create('root', schema, [{ values: [1, 2] }]);
+
+      expect(node.isArray()).toBe(true);
+      if (node.isArray()) {
+        const item = node.at(0);
+        expect(item?.isObject()).toBe(true);
+        if (item?.isObject()) {
+          const values = item.child('values');
+          expect(values?.isArray()).toBe(true);
+        }
+      }
+    });
+  });
+});

--- a/src/model/value-node/__tests__/StringValueNode.spec.ts
+++ b/src/model/value-node/__tests__/StringValueNode.spec.ts
@@ -94,6 +94,22 @@ describe('StringValueNode', () => {
 
       expect(node.value).toBe('true');
     });
+
+    it('converts object to JSON string', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.setValue({ key: 'value' });
+
+      expect(node.value).toBe('{"key":"value"}');
+    });
+
+    it('converts array to JSON string', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.setValue([1, 2, 3]);
+
+      expect(node.value).toBe('[1,2,3]');
+    });
   });
 
   describe('readOnly', () => {

--- a/src/model/value-node/__tests__/StringValueNode.spec.ts
+++ b/src/model/value-node/__tests__/StringValueNode.spec.ts
@@ -1,0 +1,632 @@
+import type { JsonStringSchema } from '../../../types/schema.types.js';
+import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import { StringValueNode, resetNodeIdCounter } from '../index.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+const createSchema = (
+  overrides: Partial<JsonStringSchema> = {},
+): JsonStringSchema => ({
+  type: JsonSchemaTypeName.String,
+  default: '',
+  ...overrides,
+});
+
+describe('StringValueNode', () => {
+  describe('construction', () => {
+    it('creates node with value', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema(), 'John');
+
+      expect(node.value).toBe('John');
+      expect(node.name).toBe('name');
+      expect(node.type).toBe('string');
+    });
+
+    it('uses default from schema when no value provided', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ default: 'default value' }),
+      );
+
+      expect(node.value).toBe('default value');
+    });
+
+    it('uses empty string when no value and no default', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.value).toBe('');
+    });
+
+    it('uses provided id', () => {
+      const node = new StringValueNode('custom-id', 'name', createSchema());
+
+      expect(node.id).toBe('custom-id');
+    });
+
+    it('generates id when not provided', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.id).toBe('node-1');
+    });
+  });
+
+  describe('setValue', () => {
+    it('sets string value', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.setValue('new value');
+
+      expect(node.value).toBe('new value');
+    });
+
+    it('converts null to empty string', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.setValue(null);
+
+      expect(node.value).toBe('');
+    });
+
+    it('converts undefined to empty string', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+      node.setValue('initial');
+
+      node.setValue(undefined);
+
+      expect(node.value).toBe('');
+    });
+
+    it('converts number to string', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.setValue(42);
+
+      expect(node.value).toBe('42');
+    });
+
+    it('converts boolean to string', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.setValue(true);
+
+      expect(node.value).toBe('true');
+    });
+  });
+
+  describe('readOnly', () => {
+    it('throws when setting value on readOnly field', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ readOnly: true }),
+      );
+
+      expect(() => node.setValue('new')).toThrow(
+        'Cannot set value on read-only field: name',
+      );
+    });
+
+    it('throws when using value setter on readOnly field', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ readOnly: true }),
+      );
+
+      expect(() => {
+        node.value = 'new';
+      }).toThrow('Cannot set value on read-only field: name');
+    });
+
+    it('allows value setter on normal field', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      node.value = 'new';
+
+      expect(node.value).toBe('new');
+    });
+
+    it('throws when field has formula', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ 'x-formula': { version: 1, expression: 'other' } }),
+      );
+
+      expect(() => node.setValue('new')).toThrow(
+        'Cannot set value on read-only field: name',
+      );
+    });
+
+    it('allows internal setValue on readOnly field', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ readOnly: true }),
+      );
+
+      node.setValue('new', { internal: true });
+
+      expect(node.value).toBe('new');
+    });
+
+    it('isReadOnly returns true for readOnly schema', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ readOnly: true }),
+      );
+
+      expect(node.isReadOnly).toBe(true);
+    });
+
+    it('isReadOnly returns true for formula field', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ 'x-formula': { version: 1, expression: 'other' } }),
+      );
+
+      expect(node.isReadOnly).toBe(true);
+    });
+
+    it('isReadOnly returns false for normal field', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.isReadOnly).toBe(false);
+    });
+  });
+
+  describe('formula', () => {
+    it('returns formula definition from schema', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({
+          'x-formula': { version: 1, expression: 'other + "_suffix"' },
+        }),
+      );
+
+      expect(node.formula).toEqual({
+        expression: 'other + "_suffix"',
+        version: 1,
+      });
+    });
+
+    it('returns undefined when no formula', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.formula).toBeUndefined();
+    });
+  });
+
+  describe('formulaWarning', () => {
+    it('returns null by default', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.formulaWarning).toBeNull();
+    });
+
+    it('sets and gets formula warning', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+      const warning = {
+        type: 'type-coercion' as const,
+        message: 'Value coerced',
+        expression: 'test',
+        computedValue: 42,
+      };
+
+      node.setFormulaWarning(warning);
+
+      expect(node.formulaWarning).toEqual(warning);
+    });
+
+    it('clears formula warning', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+      node.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'test',
+        expression: 'test',
+        computedValue: 42,
+      });
+
+      node.setFormulaWarning(null);
+
+      expect(node.formulaWarning).toBeNull();
+    });
+  });
+
+  describe('validation - required', () => {
+    it('returns error when required and empty', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ required: true }),
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('required');
+      expect(errors[0]?.severity).toBe('error');
+    });
+
+    it('returns no error when required and has value', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ required: true }),
+        'John',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('returns no error when not required and empty', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - foreignKey', () => {
+    it('returns error when foreignKey and empty', () => {
+      const node = new StringValueNode(
+        undefined,
+        'categoryId',
+        createSchema({ foreignKey: 'categories' }),
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('foreignKey');
+      expect(errors[0]?.params).toEqual({ table: 'categories' });
+    });
+
+    it('returns no error when foreignKey has value', () => {
+      const node = new StringValueNode(
+        undefined,
+        'categoryId',
+        createSchema({ foreignKey: 'categories' }),
+        'cat-123',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - minLength', () => {
+    it('returns error when below minLength', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ minLength: 5 }),
+        'abc',
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('minLength');
+      expect(errors[0]?.params).toEqual({ min: 5, actual: 3 });
+    });
+
+    it('skips minLength check for empty string', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ minLength: 5 }),
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('returns no error when meets minLength', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ minLength: 3 }),
+        'John',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - maxLength', () => {
+    it('returns error when above maxLength', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ maxLength: 3 }),
+        'John',
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('maxLength');
+      expect(errors[0]?.params).toEqual({ max: 3, actual: 4 });
+    });
+
+    it('returns no error when within maxLength', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ maxLength: 10 }),
+        'John',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - pattern', () => {
+    it('returns error when pattern does not match', () => {
+      const node = new StringValueNode(
+        undefined,
+        'email',
+        createSchema({ pattern: '^[a-z]+@[a-z]+\\.[a-z]+$' }),
+        'invalid',
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('pattern');
+    });
+
+    it('skips pattern check for empty string', () => {
+      const node = new StringValueNode(
+        undefined,
+        'email',
+        createSchema({ pattern: '^[a-z]+@[a-z]+\\.[a-z]+$' }),
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+
+    it('returns no error when pattern matches', () => {
+      const node = new StringValueNode(
+        undefined,
+        'email',
+        createSchema({ pattern: '^[a-z]+@[a-z]+\\.[a-z]+$' }),
+        'test@example.com',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('validation - enum', () => {
+    it('returns error when value not in enum', () => {
+      const node = new StringValueNode(
+        undefined,
+        'status',
+        createSchema({ enum: ['active', 'inactive'] }),
+        'pending',
+      );
+
+      const errors = node.errors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('enum');
+      expect(errors[0]?.params).toEqual({
+        allowed: ['active', 'inactive'],
+        actual: 'pending',
+      });
+    });
+
+    it('returns no error when value in enum', () => {
+      const node = new StringValueNode(
+        undefined,
+        'status',
+        createSchema({ enum: ['active', 'inactive'] }),
+        'active',
+      );
+
+      expect(node.errors).toHaveLength(0);
+    });
+  });
+
+  describe('warnings', () => {
+    it('returns empty when no formula warning', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.warnings).toHaveLength(0);
+    });
+
+    it('returns warning from formula', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+      node.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'Value coerced to string',
+        expression: 'number',
+        computedValue: 42,
+      });
+
+      const warnings = node.warnings;
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.severity).toBe('warning');
+      expect(warnings[0]?.type).toBe('type-coercion');
+    });
+  });
+
+  describe('isValid and hasWarnings', () => {
+    it('isValid is true when no errors', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.isValid).toBe(true);
+    });
+
+    it('isValid is false when has errors', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema({ required: true }),
+      );
+
+      expect(node.isValid).toBe(false);
+    });
+
+    it('hasWarnings is false when no warnings', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.hasWarnings).toBe(false);
+    });
+
+    it('hasWarnings is true when has formula warning', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+      node.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'test',
+        expression: 'test',
+        computedValue: 42,
+      });
+
+      expect(node.hasWarnings).toBe(true);
+    });
+
+    it('isValid is true even with warnings', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'value',
+      );
+      node.setFormulaWarning({
+        type: 'type-coercion',
+        message: 'test',
+        expression: 'test',
+        computedValue: 42,
+      });
+
+      expect(node.isValid).toBe(true);
+      expect(node.hasWarnings).toBe(true);
+    });
+  });
+
+  describe('getPlainValue', () => {
+    it('returns string value', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+
+      expect(node.getPlainValue()).toBe('John');
+    });
+  });
+
+  describe('isPrimitive', () => {
+    it('returns true', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.isPrimitive()).toBe(true);
+    });
+  });
+
+  describe('type checks', () => {
+    it('isObject returns false', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.isObject()).toBe(false);
+    });
+
+    it('isArray returns false', () => {
+      const node = new StringValueNode(undefined, 'name', createSchema());
+
+      expect(node.isArray()).toBe(false);
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty is false initially', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('isDirty is true after setValue', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+
+      node.setValue('Jane');
+
+      expect(node.isDirty).toBe(true);
+    });
+
+    it('isDirty is false when value set back to base', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+      node.setValue('Jane');
+
+      node.setValue('John');
+
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('baseValue reflects initial value', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+      node.setValue('Jane');
+
+      expect(node.baseValue).toBe('John');
+      expect(node.value).toBe('Jane');
+    });
+
+    it('commit updates baseValue', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+      node.setValue('Jane');
+
+      node.commit();
+
+      expect(node.baseValue).toBe('Jane');
+      expect(node.value).toBe('Jane');
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('revert restores value to baseValue', () => {
+      const node = new StringValueNode(
+        undefined,
+        'name',
+        createSchema(),
+        'John',
+      );
+      node.setValue('Jane');
+
+      node.revert();
+
+      expect(node.value).toBe('John');
+      expect(node.isDirty).toBe(false);
+    });
+  });
+});

--- a/src/model/value-node/index.ts
+++ b/src/model/value-node/index.ts
@@ -1,0 +1,39 @@
+// Types
+export type {
+  ValueNode,
+  PrimitiveValueNode,
+  ObjectValueNode as ObjectValueNodeInterface,
+  ArrayValueNode as ArrayValueNodeInterface,
+  DirtyTrackable,
+  FormulaDefinition,
+  FormulaWarning,
+  ValueNodeOptions,
+  PrimitiveNodeOptions,
+  ObjectNodeOptions,
+  ArrayNodeOptions,
+} from './types.js';
+export { ValueType, extractFormulaDefinition } from './types.js';
+
+// Base classes
+export {
+  BaseValueNode,
+  generateNodeId,
+  resetNodeIdCounter,
+} from './BaseValueNode.js';
+export { BasePrimitiveValueNode } from './BasePrimitiveValueNode.js';
+
+// Concrete implementations
+export { StringValueNode } from './StringValueNode.js';
+export { NumberValueNode } from './NumberValueNode.js';
+export { BooleanValueNode } from './BooleanValueNode.js';
+export { ObjectValueNode } from './ObjectValueNode.js';
+export { ArrayValueNode } from './ArrayValueNode.js';
+
+// Factory
+export {
+  NodeFactory,
+  NodeFactoryRegistry,
+  createNodeFactory,
+  createDefaultRegistry,
+} from './NodeFactory.js';
+export type { NodeFactoryFn, NodeFactoryOptions, RefSchemas } from './NodeFactory.js';

--- a/src/model/value-node/types.ts
+++ b/src/model/value-node/types.ts
@@ -1,0 +1,124 @@
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonSchema, XFormula } from '../../types/schema.types.js';
+import type { NodeFactory } from './NodeFactory.js';
+
+export enum ValueType {
+  String = 'string',
+  Number = 'number',
+  Boolean = 'boolean',
+  Object = 'object',
+  Array = 'array',
+}
+
+export interface FormulaDefinition {
+  readonly expression: string;
+  readonly version: number;
+}
+
+export interface FormulaWarning {
+  readonly type:
+    | 'nan'
+    | 'infinity'
+    | 'type-coercion'
+    | 'division-by-zero'
+    | 'null-reference'
+    | 'runtime-error';
+  readonly message: string;
+  readonly expression: string;
+  readonly computedValue: unknown;
+}
+
+export interface ValueNode {
+  readonly id: string;
+  readonly type: ValueType;
+  readonly schema: JsonSchema;
+
+  parent: ValueNode | null;
+  readonly name: string;
+
+  readonly value: unknown;
+  getPlainValue(): unknown;
+
+  isObject(): this is ObjectValueNode;
+  isArray(): this is ArrayValueNode;
+  isPrimitive(): this is PrimitiveValueNode;
+
+  readonly errors: readonly Diagnostic[];
+  readonly warnings: readonly Diagnostic[];
+  readonly isValid: boolean;
+  readonly hasWarnings: boolean;
+}
+
+export interface DirtyTrackable {
+  readonly isDirty: boolean;
+  commit(): void;
+  revert(): void;
+}
+
+export interface PrimitiveValueNode extends ValueNode, DirtyTrackable {
+  value: string | number | boolean;
+  readonly baseValue: string | number | boolean;
+  readonly defaultValue: unknown;
+  readonly formula: FormulaDefinition | undefined;
+  readonly formulaWarning: FormulaWarning | null;
+  readonly isReadOnly: boolean;
+
+  setValue(value: unknown, options?: { internal?: boolean }): void;
+  setFormulaWarning(warning: FormulaWarning | null): void;
+}
+
+export interface ObjectValueNode extends ValueNode, DirtyTrackable {
+  readonly value: Record<string, ValueNode>;
+  readonly children: readonly ValueNode[];
+
+  child(name: string): ValueNode | undefined;
+  addChild(node: ValueNode): void;
+  removeChild(name: string): void;
+  hasChild(name: string): boolean;
+}
+
+export interface ArrayValueNode extends ValueNode, DirtyTrackable {
+  readonly value: readonly ValueNode[];
+  readonly length: number;
+
+  at(index: number): ValueNode | undefined;
+  push(node: ValueNode): void;
+  insertAt(index: number, node: ValueNode): void;
+  removeAt(index: number): void;
+  move(fromIndex: number, toIndex: number): void;
+  replaceAt(index: number, node: ValueNode): void;
+  clear(): void;
+
+  setNodeFactory(factory: NodeFactory): void;
+  pushValue(value?: unknown): void;
+  insertValueAt(index: number, value?: unknown): void;
+}
+
+export interface ValueNodeOptions {
+  readonly id?: string;
+  readonly name: string;
+  readonly schema: JsonSchema;
+  readonly parent?: ValueNode | null;
+}
+
+export interface PrimitiveNodeOptions extends ValueNodeOptions {
+  readonly value?: unknown;
+}
+
+export interface ObjectNodeOptions extends ValueNodeOptions {
+  readonly children?: ValueNode[];
+}
+
+export interface ArrayNodeOptions extends ValueNodeOptions {
+  readonly items?: ValueNode[];
+}
+
+export function extractFormulaDefinition(
+  schema: JsonSchema,
+): FormulaDefinition | undefined {
+  if ('x-formula' in schema && schema['x-formula']) {
+    const xFormula = schema['x-formula'] as XFormula;
+    return { expression: xFormula.expression, version: xFormula.version };
+  }
+  return undefined;
+}

--- a/src/model/value-node/types.ts
+++ b/src/model/value-node/types.ts
@@ -1,5 +1,5 @@
 import type { Diagnostic } from '../../core/validation/types.js';
-import type { JsonSchema, XFormula } from '../../types/schema.types.js';
+import type { JsonSchema } from '../../types/schema.types.js';
 import type { NodeFactory } from './NodeFactory.js';
 
 export enum ValueType {
@@ -117,7 +117,7 @@ export function extractFormulaDefinition(
   schema: JsonSchema,
 ): FormulaDefinition | undefined {
   if ('x-formula' in schema && schema['x-formula']) {
-    const xFormula = schema['x-formula'] as XFormula;
+    const xFormula = schema['x-formula'];
     return { expression: xFormula.expression, version: xFormula.version };
   }
   return undefined;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a reactive ValueNode tree for JSON data mapped to JSON Schema, with dirty tracking, validation hooks, and formula support. Adds a NodeFactory to build string, number, boolean, object, and array nodes, plus tests and docs.

- **New Features**
  - ValueNode hierarchy for schema-mapped data (Base + String/Number/Boolean/Object/Array).
  - NodeFactory/Registry (createNodeFactory) for schema-driven node creation.
  - Dirty-state API (isDirty/commit/revert) and getPlainValue for serialization.
  - ReactivityAdapter integration and formula support with warning reporting.

- **Migration**
  - Import createNodeFactory and optionally pass a ReactivityAdapter to enable reactivity.
  - Build nodes from your JSON Schema, read node.value, and use getPlainValue() to serialize.

<sup>Written for commit ddd653220d9c3459cfb98c1e5acae2fad316a8a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

