### PR TITLE
feat: model row

### DIFF
--- a/src/core/types/annotations.ts
+++ b/src/core/types/annotations.ts
@@ -1,4 +1,4 @@
-export type AnnotationType = 'observable' | 'computed' | 'action';
+export type AnnotationType = 'observable' | 'observable.ref' | 'computed' | 'action';
 
 export type AnnotationsMap<T> = {
   [K in keyof T]?: AnnotationType;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,3 +1,4 @@
 export * from './schema/index.js';
 export * from './value/index.js';
 export * from './schema-model/index.js';
+export * from './table/index.js';

--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -138,14 +138,14 @@ row.revert();   // discards changes
 ### Navigation (requires TableModel)
 
 ```typescript
-// After TableModel sets itself as parent
-row.setTableModel(tableModel);
-
-// Navigation becomes available
+// TableModel calls setTableModel internally when adding rows
+// Navigation becomes available after row is added to table
 console.log(row.index);  // 0, 1, 2, etc.
 console.log(row.prev);   // previous RowModel or null
 console.log(row.next);   // next RowModel or null
 ```
+
+Note: `setTableModel` is an implementation detail on `RowModelImpl`, not part of the `RowModel` interface. TableModel is responsible for calling it when managing rows.
 
 ### With Reactivity
 

--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -1,0 +1,188 @@
+# Table Model
+
+Multi-row table model with schema and row management.
+
+## Overview
+
+The table module provides models for working with tabular data. It consists of:
+
+- **RowModel** - A wrapper around ValueTree that represents a single row in a table
+- **TableModel** (planned) - A container for multiple rows with shared schema
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  table-model                                                    │
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │ TableModel                                              │    │
+│  │   - schema: SchemaModel                                 │    │
+│  │   - rows: Map<string, RowModel>                         │    │
+│  │   - addRow(), removeRow(), getRow()                     │    │
+│  └────────────────────────┬────────────────────────────────┘    │
+│                           │ contains                            │
+│                           ▼                                     │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │ RowModel                                                │    │
+│  │   - rowId: string                                       │    │
+│  │   - tableModel: TableModel | null (parent ref)          │    │
+│  │   - tree: ValueTreeLike                                 │    │
+│  │   - index, prev, next (navigation)                      │    │
+│  │   - delegates: get, getValue, setValue, isDirty, etc.   │    │
+│  └─────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+            │
+            │ wraps
+            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  value-node + value-formula (Layer 2)                           │
+│  ┌─────────────────┐  ┌─────────────────┐                       │
+│  │ ValueTree       │  │ FormulaEngine   │                       │
+│  │ (value-node)    │  │ (value-formula) │                       │
+│  └─────────────────┘  └─────────────────┘                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## API
+
+### RowModel
+
+```typescript
+interface RowModel {
+  readonly rowId: string;
+  readonly tableModel: TableModelLike | null;
+  readonly tree: ValueTreeLike;
+
+  // Navigation within table
+  readonly index: number;        // -1 if not in table
+  readonly prev: RowModel | null;
+  readonly next: RowModel | null;
+
+  // Value operations (delegated to ValueTree)
+  get(path: string): ValueNode | undefined;
+  getValue(path: string): unknown;
+  setValue(path: string, value: unknown): void;
+  getPlainValue(): unknown;
+
+  // State (delegated to ValueTree)
+  readonly isDirty: boolean;
+  readonly isValid: boolean;
+  readonly errors: readonly Diagnostic[];
+
+  // Patch operations (delegated to ValueTree)
+  getPatches(): readonly JsonValuePatch[];
+  commit(): void;
+  revert(): void;
+}
+```
+
+### ValueTreeLike
+
+Interface for ValueTree compatibility:
+
+```typescript
+interface ValueTreeLike {
+  readonly root: ValueNode;
+  get(path: string): ValueNode | undefined;
+  getValue(path: string): unknown;
+  setValue(path: string, value: unknown): void;
+  getPlainValue(): unknown;
+  readonly isDirty: boolean;
+  readonly isValid: boolean;
+  readonly errors: readonly Diagnostic[];
+  getPatches(): readonly JsonValuePatch[];
+  commit(): void;
+  revert(): void;
+}
+```
+
+### TableModelLike
+
+Interface for TableModel compatibility (enables navigation):
+
+```typescript
+interface TableModelLike {
+  getRowIndex(rowId: string): number;
+  getRowAt(index: number): RowModel | undefined;
+  readonly rowCount: number;
+}
+```
+
+## Usage Examples
+
+### Creating a standalone RowModel
+
+```typescript
+import { RowModelImpl } from '@revisium/schema-toolkit';
+
+// Create with a ValueTree
+const row = new RowModelImpl('row-1', valueTree);
+
+// Access values
+const name = row.getValue('name');
+row.setValue('name', 'John');
+
+// Check state
+console.log(row.isDirty);  // true after setValue
+console.log(row.isValid);  // depends on validation
+
+// Get changes
+const patches = row.getPatches();
+
+// Commit or revert
+row.commit();   // saves changes
+row.revert();   // discards changes
+```
+
+### Navigation (requires TableModel)
+
+```typescript
+// After TableModel sets itself as parent
+row.setTableModel(tableModel);
+
+// Navigation becomes available
+console.log(row.index);  // 0, 1, 2, etc.
+console.log(row.prev);   // previous RowModel or null
+console.log(row.next);   // next RowModel or null
+```
+
+### With Reactivity
+
+```typescript
+import { RowModelImpl } from '@revisium/schema-toolkit';
+import { mobxAdapter } from '@revisium/schema-toolkit-ui';
+
+const row = new RowModelImpl('row-1', valueTree, mobxAdapter);
+
+// Now isDirty, isValid, index, prev, next are observable
+// React components wrapped with observer() will auto-update
+```
+
+## Dependencies
+
+### Internal Dependencies
+
+- `core/validation` - Diagnostic types for validation errors
+- `core/reactivity` - ReactivityAdapter for optional MobX integration
+- `types/json-value-patch.types` - JsonValuePatch type for change tracking
+- `model/value-node` - ValueNode interface
+
+### External Dependencies
+
+None
+
+## Design Decisions
+
+1. **Delegation Pattern**: RowModel delegates all value operations to ValueTreeLike rather than reimplementing them. This keeps RowModel focused on row-specific concerns (navigation, table relationship).
+
+2. **Interface-based Dependencies**: Uses `ValueTreeLike` and `TableModelLike` interfaces instead of concrete types. This allows for:
+   - Easy mocking in tests
+   - Flexibility in implementation
+   - Breaking circular dependencies (RowModel and TableModel reference each other)
+
+3. **Navigation as Computed Properties**: `index`, `prev`, and `next` are computed from the parent TableModel on access. This ensures they're always current without manual synchronization.
+
+4. **Optional TableModel**: RowModel can exist without a TableModel (e.g., during creation or in standalone mode). Navigation returns safe defaults (-1, null) in this case.
+
+5. **Reactivity-aware**: Accepts optional ReactivityAdapter for MobX integration. Without it, works as plain JavaScript object (suitable for backend).

--- a/src/model/table/index.ts
+++ b/src/model/table/index.ts
@@ -1,0 +1,1 @@
+export * from './row/index.js';

--- a/src/model/table/row/RowModelImpl.ts
+++ b/src/model/table/row/RowModelImpl.ts
@@ -1,0 +1,117 @@
+import type { ReactivityAdapter } from '../../../core/reactivity/types.js';
+import type { AnnotationsMap } from '../../../core/types/index.js';
+import type { Diagnostic } from '../../../core/validation/types.js';
+import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
+import type { ValueNode } from '../../value-node/types.js';
+import type { RowModel, TableModelLike, ValueTreeLike } from './types.js';
+
+const UNSET_INDEX = -1;
+
+export class RowModelImpl implements RowModel {
+  private _tableModel: TableModelLike | null = null;
+
+  constructor(
+    private readonly _rowId: string,
+    private readonly _tree: ValueTreeLike,
+    private readonly _reactivity?: ReactivityAdapter,
+  ) {
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    this._reactivity?.makeObservable(this, {
+      _tableModel: 'observable.ref',
+      index: 'computed',
+      prev: 'computed',
+      next: 'computed',
+      isDirty: 'computed',
+      isValid: 'computed',
+      errors: 'computed',
+    } as AnnotationsMap<this>);
+  }
+
+  get rowId(): string {
+    return this._rowId;
+  }
+
+  get tableModel(): TableModelLike | null {
+    return this._tableModel;
+  }
+
+  get tree(): ValueTreeLike {
+    return this._tree;
+  }
+
+  get index(): number {
+    if (!this._tableModel) {
+      return UNSET_INDEX;
+    }
+    return this._tableModel.getRowIndex(this._rowId);
+  }
+
+  get prev(): RowModel | null {
+    if (!this._tableModel) {
+      return null;
+    }
+    const currentIndex = this.index;
+    if (currentIndex <= 0) {
+      return null;
+    }
+    return this._tableModel.getRowAt(currentIndex - 1) ?? null;
+  }
+
+  get next(): RowModel | null {
+    if (!this._tableModel) {
+      return null;
+    }
+    const currentIndex = this.index;
+    if (currentIndex === UNSET_INDEX || currentIndex >= this._tableModel.rowCount - 1) {
+      return null;
+    }
+    return this._tableModel.getRowAt(currentIndex + 1) ?? null;
+  }
+
+  get(path: string): ValueNode | undefined {
+    return this._tree.get(path);
+  }
+
+  getValue(path: string): unknown {
+    return this._tree.getValue(path);
+  }
+
+  setValue(path: string, value: unknown): void {
+    this._tree.setValue(path, value);
+  }
+
+  getPlainValue(): unknown {
+    return this._tree.getPlainValue();
+  }
+
+  get isDirty(): boolean {
+    return this._tree.isDirty;
+  }
+
+  get isValid(): boolean {
+    return this._tree.isValid;
+  }
+
+  get errors(): readonly Diagnostic[] {
+    return this._tree.errors;
+  }
+
+  getPatches(): readonly JsonValuePatch[] {
+    return this._tree.getPatches();
+  }
+
+  commit(): void {
+    this._tree.commit();
+  }
+
+  revert(): void {
+    this._tree.revert();
+  }
+
+  setTableModel(tableModel: TableModelLike | null): void {
+    this._tableModel = tableModel;
+  }
+}

--- a/src/model/table/row/__tests__/RowModel.spec.ts
+++ b/src/model/table/row/__tests__/RowModel.spec.ts
@@ -441,12 +441,11 @@ describe('RowModelImpl', () => {
       expect(annotations['errors']).toBe('computed');
     });
 
-    it('does not call makeObservable when no adapter', () => {
-      const makeObservableMock = jest.fn();
+    it('works without adapter (no reactivity)', () => {
+      const row = new RowModelImpl('row-1', mockTree);
 
-      new RowModelImpl('row-1', mockTree);
-
-      expect(makeObservableMock).not.toHaveBeenCalled();
+      expect(row.rowId).toBe('row-1');
+      expect(row.index).toBe(-1);
     });
   });
 });

--- a/src/model/table/row/__tests__/RowModel.spec.ts
+++ b/src/model/table/row/__tests__/RowModel.spec.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import type { ReactivityAdapter } from '../../../../core/reactivity/types.js';
+import type { Diagnostic } from '../../../../core/validation/types.js';
+import type { JsonValuePatch } from '../../../../types/json-value-patch.types.js';
+import type { ValueNode } from '../../../value-node/types.js';
+import { RowModelImpl } from '../RowModelImpl.js';
+import type { RowModel, TableModelLike, ValueTreeLike } from '../types.js';
+
+class MockValueTree implements ValueTreeLike {
+  root = {} as ValueNode;
+  isDirty = false;
+  isValid = true;
+  errors: readonly Diagnostic[] = [];
+
+  private _getResult: ValueNode | undefined = undefined;
+  private _getValueResult: unknown = undefined;
+  private _plainValue: unknown = {};
+  private _patches: readonly JsonValuePatch[] = [];
+
+  getCalls: string[] = [];
+  getValueCalls: string[] = [];
+  setValueCalls: Array<{ path: string; value: unknown }> = [];
+  getPlainValueCalls = 0;
+  getPatchesCalls = 0;
+  commitCalls = 0;
+  revertCalls = 0;
+
+  setGetResult(result: ValueNode | undefined): void {
+    this._getResult = result;
+  }
+
+  setGetValueResult(result: unknown): void {
+    this._getValueResult = result;
+  }
+
+  setPlainValue(value: unknown): void {
+    this._plainValue = value;
+  }
+
+  setPatches(patches: readonly JsonValuePatch[]): void {
+    this._patches = patches;
+  }
+
+  get(path: string): ValueNode | undefined {
+    this.getCalls.push(path);
+    return this._getResult;
+  }
+
+  getValue(path: string): unknown {
+    this.getValueCalls.push(path);
+    return this._getValueResult;
+  }
+
+  setValue(path: string, value: unknown): void {
+    this.setValueCalls.push({ path, value });
+  }
+
+  getPlainValue(): unknown {
+    this.getPlainValueCalls++;
+    return this._plainValue;
+  }
+
+  getPatches(): readonly JsonValuePatch[] {
+    this.getPatchesCalls++;
+    return this._patches;
+  }
+
+  commit(): void {
+    this.commitCalls++;
+  }
+
+  revert(): void {
+    this.revertCalls++;
+  }
+}
+
+class MockTableModel implements TableModelLike {
+  private _rows: RowModel[] = [];
+  private _getRowAtOverride?: (index: number) => RowModel | undefined;
+
+  constructor(rows: RowModel[] = []) {
+    this._rows = rows;
+  }
+
+  get rowCount(): number {
+    return this._rows.length;
+  }
+
+  getRowIndex(rowId: string): number {
+    return this._rows.findIndex((r) => r.rowId === rowId);
+  }
+
+  getRowAt(index: number): RowModel | undefined {
+    if (this._getRowAtOverride) {
+      return this._getRowAtOverride(index);
+    }
+    return this._rows[index];
+  }
+
+  setGetRowAtOverride(fn: (index: number) => RowModel | undefined): void {
+    this._getRowAtOverride = fn;
+  }
+}
+
+describe('RowModelImpl', () => {
+  let mockTree: MockValueTree;
+
+  beforeEach(() => {
+    mockTree = new MockValueTree();
+  });
+
+  describe('construction', () => {
+    it('creates row with rowId and tree', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.rowId).toBe('row-1');
+      expect(row.tree).toBe(mockTree);
+    });
+
+    it('creates row without tableModel by default', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.tableModel).toBeNull();
+    });
+  });
+
+  describe('navigation without tableModel', () => {
+    it('returns -1 for index when no tableModel', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.index).toBe(-1);
+    });
+
+    it('returns null for prev when no tableModel', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.prev).toBeNull();
+    });
+
+    it('returns null for next when no tableModel', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.next).toBeNull();
+    });
+  });
+
+  describe('navigation with tableModel', () => {
+    it('returns correct index from tableModel', () => {
+      const row = new RowModelImpl('row-2', mockTree);
+      const mockTable = new MockTableModel([
+        { rowId: 'row-1' } as RowModel,
+        row,
+        { rowId: 'row-3' } as RowModel,
+      ]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.index).toBe(1);
+    });
+
+    it('returns prev row when exists', () => {
+      const prevRow = { rowId: 'row-1' } as RowModel;
+      const row = new RowModelImpl('row-2', mockTree);
+      const mockTable = new MockTableModel([prevRow, row]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.prev).toBe(prevRow);
+    });
+
+    it('returns null for prev when first row', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([row, { rowId: 'row-2' } as RowModel]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.prev).toBeNull();
+    });
+
+    it('returns next row when exists', () => {
+      const nextRow = { rowId: 'row-2' } as RowModel;
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([row, nextRow]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.next).toBe(nextRow);
+    });
+
+    it('returns null for next when last row', () => {
+      const row = new RowModelImpl('row-2', mockTree);
+      const mockTable = new MockTableModel([{ rowId: 'row-1' } as RowModel, row]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.next).toBeNull();
+    });
+
+    it('returns null for next when row not found in table', () => {
+      const row = new RowModelImpl('row-unknown', mockTree);
+      const mockTable = new MockTableModel([{ rowId: 'row-1' } as RowModel]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.next).toBeNull();
+    });
+  });
+
+  describe('value operations delegation', () => {
+    it('delegates get to tree', () => {
+      const mockNode = { id: 'node-1' } as ValueNode;
+      mockTree.setGetResult(mockNode);
+      const row = new RowModelImpl('row-1', mockTree);
+
+      const result = row.get('name');
+
+      expect(mockTree.getCalls).toContain('name');
+      expect(result).toBe(mockNode);
+    });
+
+    it('delegates getValue to tree', () => {
+      mockTree.setGetValueResult('John');
+      const row = new RowModelImpl('row-1', mockTree);
+
+      const result = row.getValue('name');
+
+      expect(mockTree.getValueCalls).toContain('name');
+      expect(result).toBe('John');
+    });
+
+    it('delegates setValue to tree', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      row.setValue('name', 'Jane');
+
+      expect(mockTree.setValueCalls).toContainEqual({ path: 'name', value: 'Jane' });
+    });
+
+    it('delegates getPlainValue to tree', () => {
+      const plainValue = { name: 'John', age: 25 };
+      mockTree.setPlainValue(plainValue);
+      const row = new RowModelImpl('row-1', mockTree);
+
+      const result = row.getPlainValue();
+
+      expect(mockTree.getPlainValueCalls).toBe(1);
+      expect(result).toBe(plainValue);
+    });
+  });
+
+  describe('state delegation', () => {
+    it('delegates isDirty to tree', () => {
+      mockTree.isDirty = true;
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.isDirty).toBe(true);
+    });
+
+    it('delegates isValid to tree', () => {
+      mockTree.isValid = false;
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.isValid).toBe(false);
+    });
+
+    it('delegates errors to tree', () => {
+      const errors: Diagnostic[] = [
+        { severity: 'error', type: 'required', message: 'Required', path: 'name' },
+      ];
+      mockTree.errors = errors;
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.errors).toBe(errors);
+    });
+  });
+
+  describe('patch operations delegation', () => {
+    it('delegates getPatches to tree', () => {
+      const patches: JsonValuePatch[] = [{ op: 'replace', path: '/name', value: 'Jane' }];
+      mockTree.setPatches(patches);
+      const row = new RowModelImpl('row-1', mockTree);
+
+      const result = row.getPatches();
+
+      expect(mockTree.getPatchesCalls).toBe(1);
+      expect(result).toBe(patches);
+    });
+
+    it('delegates commit to tree', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      row.commit();
+
+      expect(mockTree.commitCalls).toBe(1);
+    });
+
+    it('delegates revert to tree', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      row.revert();
+
+      expect(mockTree.revertCalls).toBe(1);
+    });
+  });
+
+  describe('setTableModel', () => {
+    it('sets tableModel', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([row]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.tableModel).toBe(mockTable);
+    });
+
+    it('clears tableModel when set to null', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([row]);
+
+      row.setTableModel(mockTable);
+      row.setTableModel(null);
+
+      expect(row.tableModel).toBeNull();
+    });
+
+    it('updates navigation after setting tableModel', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+
+      expect(row.index).toBe(-1);
+
+      const mockTable = new MockTableModel([row]);
+      row.setTableModel(mockTable);
+
+      expect(row.index).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty table for navigation', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.index).toBe(-1);
+      expect(row.prev).toBeNull();
+      expect(row.next).toBeNull();
+    });
+
+    it('handles single row in table', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([row]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.index).toBe(0);
+      expect(row.prev).toBeNull();
+      expect(row.next).toBeNull();
+    });
+
+    it('handles row at middle of table', () => {
+      const prevRow = { rowId: 'row-1' } as RowModel;
+      const nextRow = { rowId: 'row-3' } as RowModel;
+      const row = new RowModelImpl('row-2', mockTree);
+      const mockTable = new MockTableModel([prevRow, row, nextRow]);
+
+      row.setTableModel(mockTable);
+
+      expect(row.index).toBe(1);
+      expect(row.prev).toBe(prevRow);
+      expect(row.next).toBe(nextRow);
+    });
+
+    it('returns null for prev when getRowAt returns undefined', () => {
+      const row = new RowModelImpl('row-2', mockTree);
+      const mockTable = new MockTableModel([
+        { rowId: 'row-1' } as RowModel,
+        row,
+      ]);
+      mockTable.setGetRowAtOverride(() => undefined);
+
+      row.setTableModel(mockTable);
+
+      expect(row.prev).toBeNull();
+    });
+
+    it('returns null for next when getRowAt returns undefined', () => {
+      const row = new RowModelImpl('row-1', mockTree);
+      const mockTable = new MockTableModel([
+        row,
+        { rowId: 'row-2' } as RowModel,
+      ]);
+      mockTable.setGetRowAtOverride(() => undefined);
+
+      row.setTableModel(mockTable);
+
+      expect(row.next).toBeNull();
+    });
+  });
+
+  describe('reactivity', () => {
+    it('calls makeObservable when adapter provided', () => {
+      const makeObservableMock = jest.fn();
+      const mockAdapter: ReactivityAdapter = {
+        makeObservable: makeObservableMock,
+        observableArray: () => [],
+        observableMap: () => new Map(),
+        reaction: () => () => {},
+        runInAction: <T>(fn: () => T) => fn(),
+      };
+
+      new RowModelImpl('row-1', mockTree, mockAdapter);
+
+      expect(makeObservableMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes correct annotations to makeObservable', () => {
+      const makeObservableMock = jest.fn();
+      const mockAdapter: ReactivityAdapter = {
+        makeObservable: makeObservableMock,
+        observableArray: () => [],
+        observableMap: () => new Map(),
+        reaction: () => () => {},
+        runInAction: <T>(fn: () => T) => fn(),
+      };
+
+      new RowModelImpl('row-1', mockTree, mockAdapter);
+
+      const callArgs = makeObservableMock.mock.calls[0];
+      expect(callArgs).toBeDefined();
+
+      const [target, annotations] = callArgs as [unknown, Record<string, string>];
+
+      expect(target).toBeDefined();
+      expect(annotations['_tableModel']).toBe('observable.ref');
+      expect(annotations['index']).toBe('computed');
+      expect(annotations['prev']).toBe('computed');
+      expect(annotations['next']).toBe('computed');
+      expect(annotations['isDirty']).toBe('computed');
+      expect(annotations['isValid']).toBe('computed');
+      expect(annotations['errors']).toBe('computed');
+    });
+
+    it('does not call makeObservable when no adapter', () => {
+      const makeObservableMock = jest.fn();
+
+      new RowModelImpl('row-1', mockTree);
+
+      expect(makeObservableMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/model/table/row/index.ts
+++ b/src/model/table/row/index.ts
@@ -1,0 +1,2 @@
+export type { RowModel, TableModelLike, ValueTreeLike } from './types.js';
+export { RowModelImpl } from './RowModelImpl.js';

--- a/src/model/table/row/types.ts
+++ b/src/model/table/row/types.ts
@@ -1,0 +1,46 @@
+import type { Diagnostic } from '../../../core/validation/types.js';
+import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
+import type { ValueNode } from '../../value-node/types.js';
+
+export interface ValueTreeLike {
+  readonly root: ValueNode;
+  get(path: string): ValueNode | undefined;
+  getValue(path: string): unknown;
+  setValue(path: string, value: unknown): void;
+  getPlainValue(): unknown;
+  readonly isDirty: boolean;
+  readonly isValid: boolean;
+  readonly errors: readonly Diagnostic[];
+  getPatches(): readonly JsonValuePatch[];
+  commit(): void;
+  revert(): void;
+}
+
+export interface TableModelLike {
+  getRowIndex(rowId: string): number;
+  getRowAt(index: number): RowModel | undefined;
+  readonly rowCount: number;
+}
+
+export interface RowModel {
+  readonly rowId: string;
+  readonly tableModel: TableModelLike | null;
+  readonly tree: ValueTreeLike;
+
+  readonly index: number;
+  readonly prev: RowModel | null;
+  readonly next: RowModel | null;
+
+  get(path: string): ValueNode | undefined;
+  getValue(path: string): unknown;
+  setValue(path: string, value: unknown): void;
+  getPlainValue(): unknown;
+
+  readonly isDirty: boolean;
+  readonly isValid: boolean;
+  readonly errors: readonly Diagnostic[];
+
+  getPatches(): readonly JsonValuePatch[];
+  commit(): void;
+  revert(): void;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a RowModel for table rows that wraps a ValueTree and adds table navigation (index/prev/next). Also adds observable.ref annotation support and exposes the new table module.

- **New Features**
  - RowModelImpl: delegates value ops and patches to ValueTreeLike; exposes isDirty, isValid, errors, getPatches, commit, revert.
  - Navigation: index, prev, next computed via TableModelLike; safe defaults when not in a table.
  - Reactivity: optional adapter; uses observable.ref for the tableModel ref and computed for navigation/state.
  - Docs, types, exports, and comprehensive tests added.

<sup>Written for commit 1d4a4cde41ed3ffe5649db7219df3ef9326357a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

