### PR TITLE
feat: table model

### DIFF
--- a/src/core/base-path/AbstractBasePath.ts
+++ b/src/core/base-path/AbstractBasePath.ts
@@ -1,0 +1,53 @@
+import type { BasePath, BasePathSegment } from './types.js';
+
+export abstract class AbstractBasePath<
+  TSegment extends BasePathSegment,
+  TSelf extends BasePath<TSegment, TSelf>,
+> implements BasePath<TSegment, TSelf>
+{
+  constructor(protected readonly segs: readonly TSegment[]) {}
+
+  segments(): readonly TSegment[] {
+    return this.segs;
+  }
+
+  abstract parent(): TSelf;
+
+  equals(other: TSelf): boolean {
+    const otherSegs = other.segments();
+    if (this.segs.length !== otherSegs.length) {
+      return false;
+    }
+    for (let i = 0; i < this.segs.length; i++) {
+      const a = this.segs[i];
+      const b = otherSegs[i];
+      if (!a || !b || !a.equals(b)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  isEmpty(): boolean {
+    return this.segs.length === 0;
+  }
+
+  length(): number {
+    return this.segs.length;
+  }
+
+  isChildOf(parent: TSelf): boolean {
+    const parentSegs = parent.segments();
+    if (this.segs.length <= parentSegs.length) {
+      return false;
+    }
+    for (let i = 0; i < parentSegs.length; i++) {
+      const a = this.segs[i];
+      const b = parentSegs[i];
+      if (!a || !b || !a.equals(b)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/core/base-path/index.ts
+++ b/src/core/base-path/index.ts
@@ -1,0 +1,2 @@
+export type { BasePath, BasePathSegment } from './types.js';
+export { AbstractBasePath } from './AbstractBasePath.js';

--- a/src/core/base-path/types.ts
+++ b/src/core/base-path/types.ts
@@ -1,0 +1,12 @@
+export interface BasePathSegment {
+  equals(other: BasePathSegment): boolean;
+}
+
+export interface BasePath<TSegment extends BasePathSegment, TSelf extends BasePath<TSegment, TSelf>> {
+  segments(): readonly TSegment[];
+  parent(): TSelf;
+  equals(other: TSelf): boolean;
+  isEmpty(): boolean;
+  length(): number;
+  isChildOf(parent: TSelf): boolean;
+}

--- a/src/core/path/Path.ts
+++ b/src/core/path/Path.ts
@@ -1,13 +1,8 @@
+import { AbstractBasePath } from '../base-path/AbstractBasePath.js';
 import type { Path, PathSegment } from './types.js';
 import { PropertySegment, ItemsSegment } from './PathSegment.js';
 
-class PathImpl implements Path {
-  constructor(private readonly segs: readonly PathSegment[]) {}
-
-  segments(): readonly PathSegment[] {
-    return this.segs;
-  }
-
+class PathImpl extends AbstractBasePath<PathSegment, Path> implements Path {
   asJsonPointer(): string {
     return this.segs
       .map((seg) =>
@@ -51,44 +46,6 @@ class PathImpl implements Path {
 
   childItems(): Path {
     return new PathImpl([...this.segs, new ItemsSegment()]);
-  }
-
-  equals(other: Path): boolean {
-    const otherSegs = other.segments();
-    if (this.segs.length !== otherSegs.length) {
-      return false;
-    }
-    for (let i = 0; i < this.segs.length; i++) {
-      const a = this.segs[i];
-      const b = otherSegs[i];
-      if (!a || !b || !a.equals(b)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  isEmpty(): boolean {
-    return this.segs.length === 0;
-  }
-
-  length(): number {
-    return this.segs.length;
-  }
-
-  isChildOf(parent: Path): boolean {
-    const parentSegs = parent.segments();
-    if (this.segs.length <= parentSegs.length) {
-      return false;
-    }
-    for (let i = 0; i < parentSegs.length; i++) {
-      const a = this.segs[i];
-      const b = parentSegs[i];
-      if (!a || !b || !a.equals(b)) {
-        return false;
-      }
-    }
-    return true;
   }
 }
 

--- a/src/core/path/types.ts
+++ b/src/core/path/types.ts
@@ -1,19 +1,15 @@
-export interface PathSegment {
+import type { BasePath, BasePathSegment } from '../base-path/types.js';
+
+export interface PathSegment extends BasePathSegment {
   isProperty(): boolean;
   isItems(): boolean;
   propertyName(): string;
   equals(other: PathSegment): boolean;
 }
 
-export interface Path {
-  segments(): readonly PathSegment[];
+export interface Path extends BasePath<PathSegment, Path> {
   asJsonPointer(): string;
   asSimple(): string;
-  parent(): Path;
   child(name: string): Path;
   childItems(): Path;
-  equals(other: Path): boolean;
-  isEmpty(): boolean;
-  length(): number;
-  isChildOf(parent: Path): boolean;
 }

--- a/src/core/value-path/README.md
+++ b/src/core/value-path/README.md
@@ -1,0 +1,128 @@
+# Value Path
+
+Path abstraction for navigating value trees (e.g., `address.city`, `items[0].name`).
+
+## Overview
+
+This module provides a structured way to represent and manipulate paths in value data structures. Unlike `core/path` which handles JSON Schema paths (`/properties/name/items`), this module handles value paths with property access and array indexing.
+
+## Path Format
+
+```
+name                    # Single property
+address.city            # Nested property
+items[0]                # Array index
+items[0].name           # Property after index
+users[0].addresses[1]   # Multiple indices
+matrix[0][1]            # Consecutive indices
+```
+
+## API
+
+### ValuePathSegment
+
+```typescript
+interface ValuePathSegment {
+  isProperty(): boolean;
+  isIndex(): boolean;
+  propertyName(): string;   // throws if isIndex()
+  indexValue(): number;     // throws if isProperty()
+  equals(other: ValuePathSegment): boolean;
+}
+```
+
+Implementations:
+- `PropertySegment` - represents property access (e.g., `name`)
+- `IndexSegment` - represents array index (e.g., `[0]`)
+
+### ValuePath
+
+```typescript
+interface ValuePath {
+  segments(): readonly ValuePathSegment[];
+  asString(): string;
+  parent(): ValuePath;
+  child(name: string): ValuePath;
+  childIndex(index: number): ValuePath;
+  equals(other: ValuePath): boolean;
+  isEmpty(): boolean;
+  length(): number;
+  isChildOf(parent: ValuePath): boolean;
+}
+```
+
+### Parser
+
+```typescript
+// Parse string to segments
+parseValuePath(path: string): ValuePathSegment[]
+
+// Parse string to ValuePath
+stringToValuePath(path: string): ValuePath
+```
+
+## Usage Examples
+
+### Creating paths
+
+```typescript
+import {
+  createValuePath,
+  EMPTY_VALUE_PATH,
+  PropertySegment,
+  IndexSegment
+} from '@revisium/schema-toolkit';
+
+// From segments
+const path = createValuePath([
+  new PropertySegment('users'),
+  new IndexSegment(0),
+  new PropertySegment('name'),
+]);
+console.log(path.asString()); // 'users[0].name'
+
+// Building with fluent API
+const path2 = EMPTY_VALUE_PATH
+  .child('users')
+  .childIndex(0)
+  .child('name');
+console.log(path2.asString()); // 'users[0].name'
+```
+
+### Parsing paths
+
+```typescript
+import { stringToValuePath, parseValuePath } from '@revisium/schema-toolkit';
+
+const path = stringToValuePath('users[0].addresses[1].city');
+console.log(path.length()); // 5
+
+const segments = parseValuePath('items[0].name');
+// [PropertySegment('items'), IndexSegment(0), PropertySegment('name')]
+```
+
+### Navigation
+
+```typescript
+const path = stringToValuePath('users[0].addresses[1].city');
+
+// Get parent
+console.log(path.parent().asString()); // 'users[0].addresses[1]'
+
+// Check relationship
+const parent = stringToValuePath('users[0]');
+console.log(path.isChildOf(parent)); // true
+```
+
+## Comparison with core/path
+
+| Feature | core/path | core/value-path |
+|---------|-----------|-----------------|
+| Purpose | JSON Schema paths | Value data paths |
+| Format | `/properties/name/items` | `name[0].city` |
+| Segments | PropertySegment, ItemsSegment | PropertySegment, IndexSegment |
+| Array notation | `items` (schema definition) | `[0]` (specific index) |
+
+## Dependencies
+
+None (standalone module)

--- a/src/core/value-path/ValuePath.ts
+++ b/src/core/value-path/ValuePath.ts
@@ -1,13 +1,11 @@
+import { AbstractBasePath } from '../base-path/AbstractBasePath.js';
 import type { ValuePath, ValuePathSegment } from './types.js';
 import { PropertySegment, IndexSegment } from './ValuePathSegment.js';
 
-class ValuePathImpl implements ValuePath {
-  constructor(private readonly segs: readonly ValuePathSegment[]) {}
-
-  segments(): readonly ValuePathSegment[] {
-    return this.segs;
-  }
-
+class ValuePathImpl
+  extends AbstractBasePath<ValuePathSegment, ValuePath>
+  implements ValuePath
+{
   asString(): string {
     const parts: string[] = [];
 
@@ -38,44 +36,6 @@ class ValuePathImpl implements ValuePath {
 
   childIndex(index: number): ValuePath {
     return new ValuePathImpl([...this.segs, new IndexSegment(index)]);
-  }
-
-  equals(other: ValuePath): boolean {
-    const otherSegs = other.segments();
-    if (this.segs.length !== otherSegs.length) {
-      return false;
-    }
-    for (let i = 0; i < this.segs.length; i++) {
-      const a = this.segs[i];
-      const b = otherSegs[i];
-      if (!a || !b || !a.equals(b)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  isEmpty(): boolean {
-    return this.segs.length === 0;
-  }
-
-  length(): number {
-    return this.segs.length;
-  }
-
-  isChildOf(parent: ValuePath): boolean {
-    const parentSegs = parent.segments();
-    if (this.segs.length <= parentSegs.length) {
-      return false;
-    }
-    for (let i = 0; i < parentSegs.length; i++) {
-      const a = this.segs[i];
-      const b = parentSegs[i];
-      if (!a || !b || !a.equals(b)) {
-        return false;
-      }
-    }
-    return true;
   }
 }
 

--- a/src/core/value-path/ValuePath.ts
+++ b/src/core/value-path/ValuePath.ts
@@ -1,0 +1,86 @@
+import type { ValuePath, ValuePathSegment } from './types.js';
+import { PropertySegment, IndexSegment } from './ValuePathSegment.js';
+
+class ValuePathImpl implements ValuePath {
+  constructor(private readonly segs: readonly ValuePathSegment[]) {}
+
+  segments(): readonly ValuePathSegment[] {
+    return this.segs;
+  }
+
+  asString(): string {
+    const parts: string[] = [];
+
+    for (const seg of this.segs) {
+      if (seg.isProperty()) {
+        if (parts.length > 0) {
+          parts.push('.');
+        }
+        parts.push(seg.propertyName());
+      } else if (seg.isIndex()) {
+        parts.push(`[${seg.indexValue()}]`);
+      }
+    }
+
+    return parts.join('');
+  }
+
+  parent(): ValuePath {
+    if (this.segs.length <= 1) {
+      return EMPTY_VALUE_PATH;
+    }
+    return new ValuePathImpl(this.segs.slice(0, -1));
+  }
+
+  child(name: string): ValuePath {
+    return new ValuePathImpl([...this.segs, new PropertySegment(name)]);
+  }
+
+  childIndex(index: number): ValuePath {
+    return new ValuePathImpl([...this.segs, new IndexSegment(index)]);
+  }
+
+  equals(other: ValuePath): boolean {
+    const otherSegs = other.segments();
+    if (this.segs.length !== otherSegs.length) {
+      return false;
+    }
+    for (let i = 0; i < this.segs.length; i++) {
+      const a = this.segs[i];
+      const b = otherSegs[i];
+      if (!a || !b || !a.equals(b)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  isEmpty(): boolean {
+    return this.segs.length === 0;
+  }
+
+  length(): number {
+    return this.segs.length;
+  }
+
+  isChildOf(parent: ValuePath): boolean {
+    const parentSegs = parent.segments();
+    if (this.segs.length <= parentSegs.length) {
+      return false;
+    }
+    for (let i = 0; i < parentSegs.length; i++) {
+      const a = this.segs[i];
+      const b = parentSegs[i];
+      if (!a || !b || !a.equals(b)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+export const EMPTY_VALUE_PATH: ValuePath = new ValuePathImpl([]);
+
+export function createValuePath(segments: readonly ValuePathSegment[]): ValuePath {
+  return segments.length === 0 ? EMPTY_VALUE_PATH : new ValuePathImpl(segments);
+}

--- a/src/core/value-path/ValuePathParser.ts
+++ b/src/core/value-path/ValuePathParser.ts
@@ -1,0 +1,53 @@
+import type { ValuePath, ValuePathSegment } from './types.js';
+import { createValuePath } from './ValuePath.js';
+import { PropertySegment, IndexSegment } from './ValuePathSegment.js';
+
+export function parseValuePath(path: string): ValuePathSegment[] {
+  if (!path) {
+    return [];
+  }
+
+  const segments: ValuePathSegment[] = [];
+  let current = '';
+  let i = 0;
+
+  while (i < path.length) {
+    const char = path[i];
+
+    if (char === '.') {
+      if (current) {
+        segments.push(new PropertySegment(current));
+        current = '';
+      }
+      i++;
+    } else if (char === '[') {
+      if (current) {
+        segments.push(new PropertySegment(current));
+        current = '';
+      }
+      i++;
+      let indexStr = '';
+      while (i < path.length && path[i] !== ']') {
+        indexStr += path[i];
+        i++;
+      }
+      if (path[i] === ']') {
+        i++;
+      }
+      segments.push(new IndexSegment(parseInt(indexStr, 10)));
+    } else {
+      current += char;
+      i++;
+    }
+  }
+
+  if (current) {
+    segments.push(new PropertySegment(current));
+  }
+
+  return segments;
+}
+
+export function stringToValuePath(path: string): ValuePath {
+  return createValuePath(parseValuePath(path));
+}

--- a/src/core/value-path/ValuePathParser.ts
+++ b/src/core/value-path/ValuePathParser.ts
@@ -31,8 +31,14 @@ export function parseValuePath(path: string): ValuePathSegment[] {
         indexStr += path[i];
         i++;
       }
-      if (path[i] === ']') {
-        i++;
+      if (path[i] !== ']') {
+        throw new Error(`Invalid path: missing closing bracket in "${path}"`);
+      }
+      i++;
+      if (indexStr === '' || !/^\d+$/.test(indexStr)) {
+        throw new Error(
+          `Invalid path: index must be a non-negative integer, got "${indexStr}" in "${path}"`,
+        );
       }
       segments.push(new IndexSegment(parseInt(indexStr, 10)));
     } else {

--- a/src/core/value-path/ValuePathSegment.ts
+++ b/src/core/value-path/ValuePathSegment.ts
@@ -1,0 +1,49 @@
+import type { ValuePathSegment } from './types.js';
+
+export class PropertySegment implements ValuePathSegment {
+  constructor(private readonly name: string) {}
+
+  isProperty(): boolean {
+    return true;
+  }
+
+  isIndex(): boolean {
+    return false;
+  }
+
+  propertyName(): string {
+    return this.name;
+  }
+
+  indexValue(): number {
+    throw new Error('Property segment has no index value');
+  }
+
+  equals(other: ValuePathSegment): boolean {
+    return other.isProperty() && other.propertyName() === this.name;
+  }
+}
+
+export class IndexSegment implements ValuePathSegment {
+  constructor(private readonly index: number) {}
+
+  isProperty(): boolean {
+    return false;
+  }
+
+  isIndex(): boolean {
+    return true;
+  }
+
+  propertyName(): string {
+    throw new Error('Index segment has no property name');
+  }
+
+  indexValue(): number {
+    return this.index;
+  }
+
+  equals(other: ValuePathSegment): boolean {
+    return other.isIndex() && other.indexValue() === this.index;
+  }
+}

--- a/src/core/value-path/__tests__/ValuePath.spec.ts
+++ b/src/core/value-path/__tests__/ValuePath.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from '@jest/globals';
+import { EMPTY_VALUE_PATH, createValuePath } from '../ValuePath.js';
+import { PropertySegment, IndexSegment } from '../ValuePathSegment.js';
+
+describe('ValuePath', () => {
+  describe('EMPTY_VALUE_PATH', () => {
+    it('isEmpty returns true', () => {
+      expect(EMPTY_VALUE_PATH.isEmpty()).toBe(true);
+    });
+
+    it('length returns 0', () => {
+      expect(EMPTY_VALUE_PATH.length()).toBe(0);
+    });
+
+    it('segments returns empty array', () => {
+      expect(EMPTY_VALUE_PATH.segments()).toEqual([]);
+    });
+
+    it('asString returns empty string', () => {
+      expect(EMPTY_VALUE_PATH.asString()).toBe('');
+    });
+
+    it('parent returns empty path', () => {
+      expect(EMPTY_VALUE_PATH.parent()).toBe(EMPTY_VALUE_PATH);
+    });
+  });
+
+  describe('createValuePath', () => {
+    it('returns EMPTY_VALUE_PATH for empty segments', () => {
+      expect(createValuePath([])).toBe(EMPTY_VALUE_PATH);
+    });
+
+    it('creates path from segments', () => {
+      const path = createValuePath([new PropertySegment('name')]);
+      expect(path.length()).toBe(1);
+    });
+  });
+
+  describe('asString', () => {
+    it('returns property name for single property', () => {
+      const path = createValuePath([new PropertySegment('name')]);
+      expect(path.asString()).toBe('name');
+    });
+
+    it('returns dot-separated for nested properties', () => {
+      const path = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      expect(path.asString()).toBe('address.city');
+    });
+
+    it('returns bracket notation for index', () => {
+      const path = createValuePath([
+        new PropertySegment('items'),
+        new IndexSegment(0),
+      ]);
+      expect(path.asString()).toBe('items[0]');
+    });
+
+    it('returns complex path correctly', () => {
+      const path = createValuePath([
+        new PropertySegment('users'),
+        new IndexSegment(0),
+        new PropertySegment('addresses'),
+        new IndexSegment(1),
+        new PropertySegment('city'),
+      ]);
+      expect(path.asString()).toBe('users[0].addresses[1].city');
+    });
+
+    it('handles standalone index', () => {
+      const path = createValuePath([new IndexSegment(0)]);
+      expect(path.asString()).toBe('[0]');
+    });
+
+    it('handles nested indices', () => {
+      const path = createValuePath([
+        new PropertySegment('matrix'),
+        new IndexSegment(0),
+        new IndexSegment(1),
+      ]);
+      expect(path.asString()).toBe('matrix[0][1]');
+    });
+  });
+
+  describe('parent', () => {
+    it('returns empty path for single segment', () => {
+      const path = createValuePath([new PropertySegment('name')]);
+      expect(path.parent().isEmpty()).toBe(true);
+    });
+
+    it('returns parent path for nested path', () => {
+      const path = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      expect(path.parent().asString()).toBe('address');
+    });
+
+    it('returns parent path for array access', () => {
+      const path = createValuePath([
+        new PropertySegment('items'),
+        new IndexSegment(0),
+      ]);
+      expect(path.parent().asString()).toBe('items');
+    });
+  });
+
+  describe('child', () => {
+    it('creates child from empty path', () => {
+      const child = EMPTY_VALUE_PATH.child('name');
+      expect(child.asString()).toBe('name');
+    });
+
+    it('creates nested child', () => {
+      const path = createValuePath([new PropertySegment('address')]);
+      const child = path.child('city');
+      expect(child.asString()).toBe('address.city');
+    });
+  });
+
+  describe('childIndex', () => {
+    it('creates indexed child', () => {
+      const path = createValuePath([new PropertySegment('items')]);
+      const child = path.childIndex(0);
+      expect(child.asString()).toBe('items[0]');
+    });
+
+    it('creates indexed child from empty path', () => {
+      const child = EMPTY_VALUE_PATH.childIndex(0);
+      expect(child.asString()).toBe('[0]');
+    });
+  });
+
+  describe('equals', () => {
+    it('returns true for equal paths', () => {
+      const a = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      const b = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('returns false for different lengths', () => {
+      const a = createValuePath([new PropertySegment('address')]);
+      const b = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('returns false for different segments', () => {
+      const a = createValuePath([new PropertySegment('name')]);
+      const b = createValuePath([new PropertySegment('age')]);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('empty paths are equal', () => {
+      expect(EMPTY_VALUE_PATH.equals(createValuePath([]))).toBe(true);
+    });
+  });
+
+  describe('isChildOf', () => {
+    it('returns true when path is child of parent', () => {
+      const parent = createValuePath([new PropertySegment('address')]);
+      const child = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      expect(child.isChildOf(parent)).toBe(true);
+    });
+
+    it('returns false when path is not child', () => {
+      const a = createValuePath([new PropertySegment('name')]);
+      const b = createValuePath([new PropertySegment('age')]);
+      expect(a.isChildOf(b)).toBe(false);
+    });
+
+    it('returns false when path equals parent', () => {
+      const path = createValuePath([new PropertySegment('address')]);
+      expect(path.isChildOf(path)).toBe(false);
+    });
+
+    it('returns false when path is shorter than parent', () => {
+      const parent = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      const child = createValuePath([new PropertySegment('address')]);
+      expect(child.isChildOf(parent)).toBe(false);
+    });
+
+    it('returns true for deeply nested child', () => {
+      const parent = createValuePath([new PropertySegment('a')]);
+      const child = createValuePath([
+        new PropertySegment('a'),
+        new PropertySegment('b'),
+        new PropertySegment('c'),
+      ]);
+      expect(child.isChildOf(parent)).toBe(true);
+    });
+  });
+});

--- a/src/core/value-path/__tests__/ValuePathParser.spec.ts
+++ b/src/core/value-path/__tests__/ValuePathParser.spec.ts
@@ -89,6 +89,36 @@ describe('ValuePathParser', () => {
       expect(segments[0]?.isIndex()).toBe(true);
       expect(segments[0]?.indexValue()).toBe(0);
     });
+
+    it('throws for missing closing bracket', () => {
+      expect(() => parseValuePath('items[0')).toThrow(
+        'Invalid path: missing closing bracket in "items[0"',
+      );
+    });
+
+    it('throws for empty index', () => {
+      expect(() => parseValuePath('items[]')).toThrow(
+        'Invalid path: index must be a non-negative integer, got "" in "items[]"',
+      );
+    });
+
+    it('throws for non-numeric index', () => {
+      expect(() => parseValuePath('items[abc]')).toThrow(
+        'Invalid path: index must be a non-negative integer, got "abc" in "items[abc]"',
+      );
+    });
+
+    it('throws for negative index', () => {
+      expect(() => parseValuePath('items[-1]')).toThrow(
+        'Invalid path: index must be a non-negative integer, got "-1" in "items[-1]"',
+      );
+    });
+
+    it('throws for floating point index', () => {
+      expect(() => parseValuePath('items[1.5]')).toThrow(
+        'Invalid path: index must be a non-negative integer, got "1.5" in "items[1.5]"',
+      );
+    });
   });
 
   describe('stringToValuePath', () => {

--- a/src/core/value-path/__tests__/ValuePathParser.spec.ts
+++ b/src/core/value-path/__tests__/ValuePathParser.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseValuePath, stringToValuePath } from '../ValuePathParser.js';
+
+describe('ValuePathParser', () => {
+  describe('parseValuePath', () => {
+    it('returns empty array for empty string', () => {
+      expect(parseValuePath('')).toEqual([]);
+    });
+
+    it('parses single property', () => {
+      const segments = parseValuePath('name');
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.isProperty()).toBe(true);
+      expect(segments[0]?.propertyName()).toBe('name');
+    });
+
+    it('parses dot-separated properties', () => {
+      const segments = parseValuePath('address.city');
+      expect(segments).toHaveLength(2);
+      expect(segments[0]?.propertyName()).toBe('address');
+      expect(segments[1]?.propertyName()).toBe('city');
+    });
+
+    it('parses deeply nested properties', () => {
+      const segments = parseValuePath('a.b.c.d');
+      expect(segments).toHaveLength(4);
+      expect(segments[0]?.propertyName()).toBe('a');
+      expect(segments[1]?.propertyName()).toBe('b');
+      expect(segments[2]?.propertyName()).toBe('c');
+      expect(segments[3]?.propertyName()).toBe('d');
+    });
+
+    it('parses array index', () => {
+      const segments = parseValuePath('items[0]');
+      expect(segments).toHaveLength(2);
+      expect(segments[0]?.propertyName()).toBe('items');
+      expect(segments[1]?.isIndex()).toBe(true);
+      expect(segments[1]?.indexValue()).toBe(0);
+    });
+
+    it('parses array index with larger number', () => {
+      const segments = parseValuePath('items[42]');
+      expect(segments).toHaveLength(2);
+      expect(segments[1]?.indexValue()).toBe(42);
+    });
+
+    it('parses property after array index', () => {
+      const segments = parseValuePath('items[0].name');
+      expect(segments).toHaveLength(3);
+      expect(segments[0]?.propertyName()).toBe('items');
+      expect(segments[1]?.indexValue()).toBe(0);
+      expect(segments[2]?.propertyName()).toBe('name');
+    });
+
+    it('parses nested arrays', () => {
+      const segments = parseValuePath('matrix[0][1]');
+      expect(segments).toHaveLength(3);
+      expect(segments[0]?.propertyName()).toBe('matrix');
+      expect(segments[1]?.indexValue()).toBe(0);
+      expect(segments[2]?.indexValue()).toBe(1);
+    });
+
+    it('parses complex path', () => {
+      const segments = parseValuePath('users[0].addresses[1].city');
+      expect(segments).toHaveLength(5);
+      expect(segments[0]?.propertyName()).toBe('users');
+      expect(segments[1]?.indexValue()).toBe(0);
+      expect(segments[2]?.propertyName()).toBe('addresses');
+      expect(segments[3]?.indexValue()).toBe(1);
+      expect(segments[4]?.propertyName()).toBe('city');
+    });
+
+    it('handles leading dot gracefully', () => {
+      const segments = parseValuePath('.name');
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.propertyName()).toBe('name');
+    });
+
+    it('handles consecutive dots gracefully', () => {
+      const segments = parseValuePath('a..b');
+      expect(segments).toHaveLength(2);
+      expect(segments[0]?.propertyName()).toBe('a');
+      expect(segments[1]?.propertyName()).toBe('b');
+    });
+
+    it('parses standalone index', () => {
+      const segments = parseValuePath('[0]');
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.isIndex()).toBe(true);
+      expect(segments[0]?.indexValue()).toBe(0);
+    });
+  });
+
+  describe('stringToValuePath', () => {
+    it('creates ValuePath from string', () => {
+      const path = stringToValuePath('address.city');
+      expect(path.asString()).toBe('address.city');
+    });
+
+    it('creates empty path from empty string', () => {
+      const path = stringToValuePath('');
+      expect(path.isEmpty()).toBe(true);
+    });
+
+    it('roundtrips complex path', () => {
+      const original = 'users[0].addresses[1].city';
+      const path = stringToValuePath(original);
+      expect(path.asString()).toBe(original);
+    });
+  });
+});

--- a/src/core/value-path/__tests__/ValuePathSegment.spec.ts
+++ b/src/core/value-path/__tests__/ValuePathSegment.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from '@jest/globals';
+import { PropertySegment, IndexSegment } from '../ValuePathSegment.js';
+
+describe('ValuePathSegment', () => {
+  describe('PropertySegment', () => {
+    it('isProperty returns true', () => {
+      const segment = new PropertySegment('name');
+      expect(segment.isProperty()).toBe(true);
+    });
+
+    it('isIndex returns false', () => {
+      const segment = new PropertySegment('name');
+      expect(segment.isIndex()).toBe(false);
+    });
+
+    it('propertyName returns the name', () => {
+      const segment = new PropertySegment('name');
+      expect(segment.propertyName()).toBe('name');
+    });
+
+    it('indexValue throws error', () => {
+      const segment = new PropertySegment('name');
+      expect(() => segment.indexValue()).toThrow('Property segment has no index value');
+    });
+
+    it('equals returns true for same property', () => {
+      const a = new PropertySegment('name');
+      const b = new PropertySegment('name');
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('equals returns false for different property', () => {
+      const a = new PropertySegment('name');
+      const b = new PropertySegment('age');
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('equals returns false for index segment', () => {
+      const a = new PropertySegment('name');
+      const b = new IndexSegment(0);
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe('IndexSegment', () => {
+    it('isProperty returns false', () => {
+      const segment = new IndexSegment(0);
+      expect(segment.isProperty()).toBe(false);
+    });
+
+    it('isIndex returns true', () => {
+      const segment = new IndexSegment(0);
+      expect(segment.isIndex()).toBe(true);
+    });
+
+    it('indexValue returns the index', () => {
+      const segment = new IndexSegment(42);
+      expect(segment.indexValue()).toBe(42);
+    });
+
+    it('propertyName throws error', () => {
+      const segment = new IndexSegment(0);
+      expect(() => segment.propertyName()).toThrow('Index segment has no property name');
+    });
+
+    it('equals returns true for same index', () => {
+      const a = new IndexSegment(5);
+      const b = new IndexSegment(5);
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it('equals returns false for different index', () => {
+      const a = new IndexSegment(5);
+      const b = new IndexSegment(10);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('equals returns false for property segment', () => {
+      const a = new IndexSegment(0);
+      const b = new PropertySegment('name');
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+});

--- a/src/core/value-path/index.ts
+++ b/src/core/value-path/index.ts
@@ -1,0 +1,4 @@
+export type { ValuePath, ValuePathSegment } from './types.js';
+export { EMPTY_VALUE_PATH, createValuePath } from './ValuePath.js';
+export { PropertySegment, IndexSegment } from './ValuePathSegment.js';
+export { parseValuePath, stringToValuePath } from './ValuePathParser.js';

--- a/src/core/value-path/types.ts
+++ b/src/core/value-path/types.ts
@@ -1,0 +1,19 @@
+export interface ValuePathSegment {
+  isProperty(): boolean;
+  isIndex(): boolean;
+  propertyName(): string;
+  indexValue(): number;
+  equals(other: ValuePathSegment): boolean;
+}
+
+export interface ValuePath {
+  segments(): readonly ValuePathSegment[];
+  asString(): string;
+  parent(): ValuePath;
+  child(name: string): ValuePath;
+  childIndex(index: number): ValuePath;
+  equals(other: ValuePath): boolean;
+  isEmpty(): boolean;
+  length(): number;
+  isChildOf(parent: ValuePath): boolean;
+}

--- a/src/core/value-path/types.ts
+++ b/src/core/value-path/types.ts
@@ -1,4 +1,6 @@
-export interface ValuePathSegment {
+import type { BasePath, BasePathSegment } from '../base-path/types.js';
+
+export interface ValuePathSegment extends BasePathSegment {
   isProperty(): boolean;
   isIndex(): boolean;
   propertyName(): string;
@@ -6,14 +8,8 @@ export interface ValuePathSegment {
   equals(other: ValuePathSegment): boolean;
 }
 
-export interface ValuePath {
-  segments(): readonly ValuePathSegment[];
+export interface ValuePath extends BasePath<ValuePathSegment, ValuePath> {
   asString(): string;
-  parent(): ValuePath;
   child(name: string): ValuePath;
   childIndex(index: number): ValuePath;
-  equals(other: ValuePath): boolean;
-  isEmpty(): boolean;
-  length(): number;
-  isChildOf(parent: ValuePath): boolean;
 }

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -1,0 +1,166 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { AnnotationsMap } from '../../core/types/index.js';
+import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
+import { createSchemaModel } from '../schema-model/SchemaModelImpl.js';
+import type { SchemaModel } from '../schema-model/types.js';
+import { createNodeFactory } from '../value-node/NodeFactory.js';
+import { ValueTree } from '../value-tree/ValueTree.js';
+import { RowModelImpl } from './row/RowModelImpl.js';
+import type { RowModel } from './row/types.js';
+import type { TableModel, TableModelOptions } from './types.js';
+
+export class TableModelImpl implements TableModel {
+  private _tableId: string;
+  private _baseTableId: string;
+  private readonly _schema: SchemaModel;
+  private readonly _rows: RowModel[];
+  private readonly _jsonSchema: JsonObjectSchema;
+  private readonly _reactivity: ReactivityAdapter | undefined;
+
+  constructor(options: TableModelOptions, reactivity?: ReactivityAdapter) {
+    this._tableId = options.tableId;
+    this._baseTableId = options.tableId;
+    this._jsonSchema = options.schema;
+    this._schema = createSchemaModel(options.schema, { reactivity });
+    this._reactivity = reactivity;
+    this._rows = reactivity?.observableArray() ?? [];
+
+    if (options.rows) {
+      for (const row of options.rows) {
+        this._rows.push(this.createRowModel(row.rowId, row.data));
+      }
+    }
+
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    this._reactivity?.makeObservable(this, {
+      _tableId: 'observable',
+      _baseTableId: 'observable',
+      tableId: 'computed',
+      baseTableId: 'computed',
+      isRenamed: 'computed',
+      rows: 'computed',
+      rowCount: 'computed',
+      isDirty: 'computed',
+      rename: 'action',
+      addRow: 'action',
+      removeRow: 'action',
+      commit: 'action',
+      revert: 'action',
+    } as AnnotationsMap<this>);
+  }
+
+  get tableId(): string {
+    return this._tableId;
+  }
+
+  get baseTableId(): string {
+    return this._baseTableId;
+  }
+
+  get isRenamed(): boolean {
+    return this._tableId !== this._baseTableId;
+  }
+
+  get schema(): SchemaModel {
+    return this._schema;
+  }
+
+  get rows(): readonly RowModel[] {
+    return this._rows;
+  }
+
+  get rowCount(): number {
+    return this._rows.length;
+  }
+
+  rename(newTableId: string): void {
+    this._tableId = newTableId;
+  }
+
+  addRow(rowId: string, data?: unknown): RowModel {
+    const rowModel = this.createRowModel(rowId, data);
+    this._rows.push(rowModel);
+    return rowModel;
+  }
+
+  removeRow(rowId: string): void {
+    const index = this._rows.findIndex((row) => row.rowId === rowId);
+    if (index !== -1) {
+      const row = this._rows[index];
+      if (row instanceof RowModelImpl) {
+        row.setTableModel(null);
+      }
+      this._rows.splice(index, 1);
+    }
+  }
+
+  getRow(rowId: string): RowModel | undefined {
+    return this._rows.find((row) => row.rowId === rowId);
+  }
+
+  getRowIndex(rowId: string): number {
+    return this._rows.findIndex((row) => row.rowId === rowId);
+  }
+
+  getRowAt(index: number): RowModel | undefined {
+    return this._rows[index];
+  }
+
+  get isDirty(): boolean {
+    if (this.isRenamed) {
+      return true;
+    }
+
+    if (this._schema.isDirty()) {
+      return true;
+    }
+
+    for (const row of this._rows) {
+      if (row.isDirty) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  commit(): void {
+    this._baseTableId = this._tableId;
+    this._schema.markAsSaved();
+
+    for (const row of this._rows) {
+      row.commit();
+    }
+  }
+
+  revert(): void {
+    this._tableId = this._baseTableId;
+    this._schema.revert();
+
+    for (const row of this._rows) {
+      row.revert();
+    }
+  }
+
+  private createRowModel(rowId: string, data?: unknown): RowModel {
+    const factory = createNodeFactory({ reactivity: this._reactivity });
+    const rootNode = factory.createTree(
+      this._jsonSchema as JsonSchema,
+      data ?? {},
+    );
+    const valueTree = new ValueTree(rootNode, this._reactivity);
+    const rowModel = new RowModelImpl(rowId, valueTree, this._reactivity);
+    rowModel.setTableModel(this);
+    return rowModel;
+  }
+}
+
+export function createTableModel(
+  options: TableModelOptions,
+  reactivity?: ReactivityAdapter,
+): TableModel {
+  return new TableModelImpl(options, reactivity);
+}

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -81,6 +81,9 @@ export class TableModelImpl implements TableModel {
   }
 
   addRow(rowId: string, data?: unknown): RowModel {
+    if (this.getRow(rowId)) {
+      throw new Error(`Row with id already exists: ${rowId}`);
+    }
     const rowModel = this.createRowModel(rowId, data);
     this._rows.push(rowModel);
     return rowModel;

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -144,6 +144,17 @@ describe('TableModel', () => {
       expect(row.getPlainValue()).toEqual({ name: 'John', age: 30 });
     });
 
+    it('addRow throws for duplicate rowId', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      table.addRow('user-1');
+
+      expect(() => table.addRow('user-1')).toThrow('Row with id already exists: user-1');
+    });
+
     it('removeRow removes row by id', () => {
       const table = createTableModel({
         tableId: 'users',

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import type { ReactivityAdapter } from '../../../core/reactivity/types.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { createTableModel } from '../TableModelImpl.js';
+
+const createSimpleSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'age'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    age: { type: JsonSchemaTypeName.Number, default: 0 },
+  },
+});
+
+const createNestedSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'address'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    address: {
+      type: JsonSchemaTypeName.Object,
+      additionalProperties: false,
+      required: ['city'],
+      properties: {
+        city: { type: JsonSchemaTypeName.String, default: '' },
+      },
+    },
+  },
+});
+
+describe('TableModel', () => {
+  describe('construction', () => {
+    it('creates table with tableId and schema', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      expect(table.tableId).toBe('users');
+      expect(table.baseTableId).toBe('users');
+      expect(table.schema).toBeDefined();
+    });
+
+    it('creates table with initial rows', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [
+          { rowId: 'user-1', data: { name: 'John', age: 30 } },
+          { rowId: 'user-2', data: { name: 'Jane', age: 25 } },
+        ],
+      });
+
+      expect(table.rows).toHaveLength(2);
+      expect(table.getRow('user-1')).toBeDefined();
+      expect(table.getRow('user-2')).toBeDefined();
+    });
+
+    it('creates empty table when no rows provided', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      expect(table.rows).toHaveLength(0);
+    });
+
+    it('uses single SchemaModel for table', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      const row1 = table.addRow('user-1');
+      const row2 = table.addRow('user-2');
+
+      expect(table.schema).toBeDefined();
+      expect(row1.tree).not.toBe(row2.tree);
+    });
+  });
+
+  describe('rename', () => {
+    it('rename changes tableId', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      table.rename('customers');
+
+      expect(table.tableId).toBe('customers');
+    });
+
+    it('isRenamed returns true after rename', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      expect(table.isRenamed).toBe(false);
+
+      table.rename('customers');
+
+      expect(table.isRenamed).toBe(true);
+    });
+
+    it('baseTableId preserves original name', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      table.rename('customers');
+
+      expect(table.baseTableId).toBe('users');
+      expect(table.tableId).toBe('customers');
+    });
+  });
+
+  describe('rows', () => {
+    it('addRow creates new RowModel', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      const row = table.addRow('user-1');
+
+      expect(row).toBeDefined();
+      expect(row.rowId).toBe('user-1');
+      expect(table.rows).toHaveLength(1);
+    });
+
+    it('addRow with data initializes values', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      const row = table.addRow('user-1', { name: 'John', age: 30 });
+
+      expect(row.getPlainValue()).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('removeRow removes row by id', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [{ rowId: 'user-1', data: { name: 'John', age: 30 } }],
+      });
+
+      table.removeRow('user-1');
+
+      expect(table.rows).toHaveLength(0);
+      expect(table.getRow('user-1')).toBeUndefined();
+    });
+
+    it('removeRow does nothing for non-existent id', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [{ rowId: 'user-1', data: { name: 'John', age: 30 } }],
+      });
+
+      table.removeRow('user-999');
+
+      expect(table.rows).toHaveLength(1);
+    });
+
+    it('getRow returns row or undefined', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [{ rowId: 'user-1', data: { name: 'John', age: 30 } }],
+      });
+
+      expect(table.getRow('user-1')).toBeDefined();
+      expect(table.getRow('user-999')).toBeUndefined();
+    });
+
+    it('getRowIndex returns correct index', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [
+          { rowId: 'user-1', data: { name: 'John', age: 30 } },
+          { rowId: 'user-2', data: { name: 'Jane', age: 25 } },
+        ],
+      });
+
+      expect(table.getRowIndex('user-1')).toBe(0);
+      expect(table.getRowIndex('user-2')).toBe(1);
+      expect(table.getRowIndex('user-999')).toBe(-1);
+    });
+
+    it('getRowAt returns row by index', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [
+          { rowId: 'user-1', data: { name: 'John', age: 30 } },
+          { rowId: 'user-2', data: { name: 'Jane', age: 25 } },
+        ],
+      });
+
+      expect(table.getRowAt(0)?.rowId).toBe('user-1');
+      expect(table.getRowAt(1)?.rowId).toBe('user-2');
+      expect(table.getRowAt(2)).toBeUndefined();
+    });
+
+    it('rowCount returns number of rows', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [
+          { rowId: 'user-1', data: { name: 'John', age: 30 } },
+          { rowId: 'user-2', data: { name: 'Jane', age: 25 } },
+        ],
+      });
+
+      expect(table.rowCount).toBe(2);
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty false initially', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      expect(table.isDirty).toBe(false);
+    });
+
+    it('isDirty true after rename', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      table.rename('customers');
+
+      expect(table.isDirty).toBe(true);
+    });
+
+    it('isDirty true if schema dirty', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      table.schema.addField(table.schema.root().id(), 'newField', 'string');
+
+      expect(table.isDirty).toBe(true);
+    });
+
+    it('isDirty true if any row dirty', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [{ rowId: 'user-1', data: { name: 'John', age: 30 } }],
+      });
+
+      const row = table.getRow('user-1');
+      expect(row).toBeDefined();
+      row!.setValue('name', 'Jane');
+
+      expect(table.isDirty).toBe(true);
+    });
+
+    it('commit resets dirty for all', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [{ rowId: 'user-1', data: { name: 'John', age: 30 } }],
+      });
+
+      table.rename('customers');
+      const row = table.getRow('user-1');
+      row!.setValue('name', 'Jane');
+
+      table.commit();
+
+      expect(table.isDirty).toBe(false);
+      expect(table.isRenamed).toBe(false);
+      expect(table.tableId).toBe('customers');
+      expect(table.baseTableId).toBe('customers');
+    });
+
+    it('revert reverts all changes', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+        rows: [{ rowId: 'user-1', data: { name: 'John', age: 30 } }],
+      });
+
+      table.rename('customers');
+      const row = table.getRow('user-1');
+      row!.setValue('name', 'Jane');
+
+      table.revert();
+
+      expect(table.isDirty).toBe(false);
+      expect(table.isRenamed).toBe(false);
+      expect(table.tableId).toBe('users');
+      expect(row!.getValue('name')).toBe('John');
+    });
+  });
+
+  describe('row navigation', () => {
+    it('rows have navigation after adding to table', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      const row1 = table.addRow('user-1');
+      const row2 = table.addRow('user-2');
+      const row3 = table.addRow('user-3');
+
+      expect(row1.index).toBe(0);
+      expect(row2.index).toBe(1);
+      expect(row3.index).toBe(2);
+
+      expect(row1.prev).toBeNull();
+      expect(row1.next).toBe(row2);
+
+      expect(row2.prev).toBe(row1);
+      expect(row2.next).toBe(row3);
+
+      expect(row3.prev).toBe(row2);
+      expect(row3.next).toBeNull();
+    });
+
+    it('rows lose navigation after removal', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      const row = table.addRow('user-1');
+      expect(row.index).toBe(0);
+
+      table.removeRow('user-1');
+      expect(row.index).toBe(-1);
+    });
+  });
+
+  describe('nested schema support', () => {
+    it('supports nested schema', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createNestedSchema(),
+      });
+      const row = table.addRow('user-1', {
+        name: 'John',
+        address: { city: 'NYC' },
+      });
+
+      expect(row.getValue('address.city')).toBe('NYC');
+    });
+  });
+
+  describe('reactivity', () => {
+    it('calls makeObservable when adapter provided', () => {
+      const makeObservableMock = jest.fn();
+      const mockAdapter: ReactivityAdapter = {
+        makeObservable: makeObservableMock,
+        observableArray: <T>() => [] as T[],
+        observableMap: <K, V>() => new Map<K, V>(),
+        reaction: () => () => {},
+        runInAction: <T>(fn: () => T) => fn(),
+      };
+
+      createTableModel(
+        {
+          tableId: 'users',
+          schema: createSimpleSchema(),
+        },
+        mockAdapter,
+      );
+
+      expect(makeObservableMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/model/table/index.ts
+++ b/src/model/table/index.ts
@@ -1,1 +1,3 @@
 export * from './row/index.js';
+export type { TableModel, TableModelOptions, RowData } from './types.js';
+export { TableModelImpl, createTableModel } from './TableModelImpl.js';

--- a/src/model/table/row/types.ts
+++ b/src/model/table/row/types.ts
@@ -1,20 +1,9 @@
 import type { Diagnostic } from '../../../core/validation/types.js';
 import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
 import type { ValueNode } from '../../value-node/types.js';
+import type { ValueTreeLike } from '../../value-tree/types.js';
 
-export interface ValueTreeLike {
-  readonly root: ValueNode;
-  get(path: string): ValueNode | undefined;
-  getValue(path: string): unknown;
-  setValue(path: string, value: unknown): void;
-  getPlainValue(): unknown;
-  readonly isDirty: boolean;
-  readonly isValid: boolean;
-  readonly errors: readonly Diagnostic[];
-  getPatches(): readonly JsonValuePatch[];
-  commit(): void;
-  revert(): void;
-}
+export type { ValueTreeLike };
 
 export interface TableModelLike {
   getRowIndex(rowId: string): number;

--- a/src/model/table/types.ts
+++ b/src/model/table/types.ts
@@ -1,0 +1,36 @@
+import type { SchemaModel } from '../schema-model/types.js';
+import type { JsonObjectSchema } from '../../types/schema.types.js';
+import type { RowModel } from './row/types.js';
+
+export interface RowData {
+  rowId: string;
+  data: unknown;
+}
+
+export interface TableModelOptions {
+  tableId: string;
+  schema: JsonObjectSchema;
+  rows?: RowData[];
+}
+
+export interface TableModel {
+  readonly tableId: string;
+  readonly baseTableId: string;
+  readonly isRenamed: boolean;
+
+  rename(newTableId: string): void;
+
+  readonly schema: SchemaModel;
+
+  readonly rows: readonly RowModel[];
+  readonly rowCount: number;
+  addRow(rowId: string, data?: unknown): RowModel;
+  removeRow(rowId: string): void;
+  getRow(rowId: string): RowModel | undefined;
+  getRowIndex(rowId: string): number;
+  getRowAt(index: number): RowModel | undefined;
+
+  readonly isDirty: boolean;
+  commit(): void;
+  revert(): void;
+}

--- a/src/model/value-node/index.ts
+++ b/src/model/value-node/index.ts
@@ -37,3 +37,4 @@ export {
   createDefaultRegistry,
 } from './NodeFactory.js';
 export type { NodeFactoryFn, NodeFactoryOptions, RefSchemas } from './NodeFactory.js';
+

--- a/src/model/value-tree/README.md
+++ b/src/model/value-tree/README.md
@@ -1,0 +1,168 @@
+# Value Tree
+
+Wrapper over ValueNode tree with path-based access and dirty tracking.
+
+## Overview
+
+ValueTree provides a convenient API for navigating and manipulating a tree of ValueNodes using string paths (e.g., `address.city`, `items[0].name`). It delegates path parsing to `core/value-path` and dirty tracking to the underlying nodes.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ValueTree                                                      │
+│    - get(path): ValueNode                                       │
+│    - getValue(path): unknown                                    │
+│    - setValue(path, value): void                                │
+│    - isDirty, commit(), revert()                                │
+└────────────────────────┬────────────────────────────────────────┘
+                         │ uses
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  core/value-path                                                │
+│    - parseValuePath("items[0].name")                            │
+│    - PropertySegment, IndexSegment                              │
+└─────────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  value-node                                                     │
+│    - ObjectValueNode.child(name)                                │
+│    - ArrayValueNode.at(index)                                   │
+│    - PrimitiveValueNode.setValue(value)                         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## API
+
+### ValueTreeLike
+
+```typescript
+interface ValueTreeLike {
+  readonly root: ValueNode;
+
+  // Path-based access
+  get(path: string): ValueNode | undefined;
+  getValue(path: string): unknown;
+  setValue(path: string, value: unknown): void;
+  getPlainValue(): unknown;
+
+  // Dirty tracking
+  readonly isDirty: boolean;
+  commit(): void;
+  revert(): void;
+
+  // Validation
+  readonly isValid: boolean;
+  readonly errors: readonly Diagnostic[];
+
+  // Patches (not yet implemented)
+  getPatches(): readonly JsonValuePatch[];
+}
+```
+
+## Path Syntax
+
+```
+name                    # Property access
+address.city            # Nested property
+items[0]                # Array index
+items[0].name           # Property after index
+users[0].addresses[1]   # Multiple indices
+```
+
+## Usage Examples
+
+### Creating a ValueTree
+
+```typescript
+import { createNodeFactory } from '@revisium/schema-toolkit';
+import { ValueTree } from '@revisium/schema-toolkit';
+
+const factory = createNodeFactory();
+const rootNode = factory.createTree(schema, data);
+const tree = new ValueTree(rootNode);
+```
+
+### Path-based access
+
+```typescript
+// Get node at path
+const node = tree.get('address.city');
+
+// Get value at path
+const city = tree.getValue('address.city'); // 'NYC'
+
+// Set value at path
+tree.setValue('address.city', 'LA');
+
+// Get full tree as plain object
+const data = tree.getPlainValue();
+```
+
+### Dirty tracking
+
+```typescript
+console.log(tree.isDirty); // false
+
+tree.setValue('name', 'Jane');
+console.log(tree.isDirty); // true
+
+// Save changes
+tree.commit();
+console.log(tree.isDirty); // false
+
+// Or discard changes
+tree.setValue('name', 'Bob');
+tree.revert();
+console.log(tree.getValue('name')); // 'Jane' (reverted to committed state)
+```
+
+### With Reactivity
+
+```typescript
+import { ValueTree } from '@revisium/schema-toolkit';
+import { mobxAdapter } from '@revisium/schema-toolkit-ui';
+
+const tree = new ValueTree(rootNode, mobxAdapter);
+
+// Now isDirty, isValid, errors are observable
+// React components wrapped with observer() will auto-update
+```
+
+## Error Handling
+
+```typescript
+// Non-existent path
+tree.get('missing.path'); // returns undefined
+tree.getValue('missing'); // returns undefined
+tree.setValue('missing', 'value'); // throws Error: Path not found: missing
+
+// Setting value on non-primitive
+tree.setValue('address', {}); // throws Error: Cannot set value on non-primitive node: address
+```
+
+## Dependencies
+
+### Internal Dependencies
+
+- `core/value-path` - Path parsing (parseValuePath)
+- `core/validation` - Diagnostic types
+- `core/reactivity` - ReactivityAdapter for MobX integration
+- `model/value-node` - ValueNode, DirtyTrackable interfaces
+
+### External Dependencies
+
+None
+
+## Design Decisions
+
+1. **Delegation to value-path**: Path parsing is handled by `core/value-path` module, keeping ValueTree focused on tree navigation and state management.
+
+2. **Delegation to nodes**: Dirty tracking (isDirty, commit, revert) is delegated to the root node which implements DirtyTrackable. ValueTree just exposes the interface.
+
+3. **Path returns undefined**: `get()` and `getValue()` return undefined for invalid paths rather than throwing. This allows safe chaining with optional access.
+
+4. **setValue throws**: Unlike get operations, `setValue()` throws for invalid paths or non-primitive nodes. This prevents silent failures when writing data.
+
+5. **Reactivity-aware**: Accepts optional ReactivityAdapter for MobX integration. Without it, works as plain JavaScript object.

--- a/src/model/value-tree/ValueTree.ts
+++ b/src/model/value-tree/ValueTree.ts
@@ -1,0 +1,109 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { AnnotationsMap } from '../../core/types/index.js';
+import type { Diagnostic } from '../../core/validation/types.js';
+import { parseValuePath } from '../../core/value-path/ValuePathParser.js';
+import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
+import type { DirtyTrackable, ValueNode } from '../value-node/types.js';
+import type { ValueTreeLike } from './types.js';
+
+export class ValueTree implements ValueTreeLike {
+  constructor(
+    private readonly _root: ValueNode,
+    private readonly _reactivity?: ReactivityAdapter,
+  ) {
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    this._reactivity?.makeObservable(this, {
+      isDirty: 'computed',
+      isValid: 'computed',
+      errors: 'computed',
+      commit: 'action',
+      revert: 'action',
+    } as AnnotationsMap<this>);
+  }
+
+  get root(): ValueNode {
+    return this._root;
+  }
+
+  get(path: string): ValueNode | undefined {
+    const segments = parseValuePath(path);
+    if (segments.length === 0) {
+      return this._root;
+    }
+
+    let current: ValueNode | undefined = this._root;
+
+    for (const segment of segments) {
+      if (!current) {
+        return undefined;
+      }
+
+      if (segment.isProperty() && current.isObject()) {
+        current = current.child(segment.propertyName());
+      } else if (segment.isIndex() && current.isArray()) {
+        current = current.at(segment.indexValue());
+      } else {
+        return undefined;
+      }
+    }
+
+    return current;
+  }
+
+  getValue(path: string): unknown {
+    const node = this.get(path);
+    return node?.getPlainValue();
+  }
+
+  setValue(path: string, value: unknown): void {
+    const node = this.get(path);
+    if (!node) {
+      throw new Error(`Path not found: ${path}`);
+    }
+    if (!node.isPrimitive()) {
+      throw new Error(`Cannot set value on non-primitive node: ${path}`);
+    }
+    node.setValue(value);
+  }
+
+  getPlainValue(): unknown {
+    return this._root.getPlainValue();
+  }
+
+  get isDirty(): boolean {
+    const root = this._root as unknown as DirtyTrackable;
+    if ('isDirty' in root) {
+      return root.isDirty;
+    }
+    return false;
+  }
+
+  get isValid(): boolean {
+    return this.errors.length === 0;
+  }
+
+  get errors(): readonly Diagnostic[] {
+    return this._root.errors;
+  }
+
+  getPatches(): readonly JsonValuePatch[] {
+    return [];
+  }
+
+  commit(): void {
+    const root = this._root as unknown as DirtyTrackable;
+    if ('commit' in root && typeof root.commit === 'function') {
+      root.commit();
+    }
+  }
+
+  revert(): void {
+    const root = this._root as unknown as DirtyTrackable;
+    if ('revert' in root && typeof root.revert === 'function') {
+      root.revert();
+    }
+  }
+}

--- a/src/model/value-tree/__tests__/ValueTree.spec.ts
+++ b/src/model/value-tree/__tests__/ValueTree.spec.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import type { ReactivityAdapter } from '../../../core/reactivity/types.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { createNodeFactory } from '../../value-node/NodeFactory.js';
+import { ValueTree } from '../ValueTree.js';
+
+const createSimpleSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'age'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    age: { type: JsonSchemaTypeName.Number, default: 0 },
+  },
+});
+
+const createNestedSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'address'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    address: {
+      type: JsonSchemaTypeName.Object,
+      additionalProperties: false,
+      required: ['city'],
+      properties: {
+        city: { type: JsonSchemaTypeName.String, default: '' },
+      },
+    },
+  },
+});
+
+const createArraySchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['items'],
+  properties: {
+    items: {
+      type: JsonSchemaTypeName.Array,
+      items: {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['name'],
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+        },
+      },
+    },
+  },
+});
+
+function createTree(schema: unknown, data: unknown): ValueTree {
+  const factory = createNodeFactory();
+  const root = factory.createTree(schema as Parameters<typeof factory.createTree>[0], data);
+  return new ValueTree(root);
+}
+
+describe('ValueTree', () => {
+  describe('construction', () => {
+    it('creates tree with root node', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.root).toBeDefined();
+      expect(tree.root.isObject()).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    it('returns root for empty path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.get('')).toBe(tree.root);
+    });
+
+    it('returns child by property path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      const node = tree.get('name');
+
+      expect(node).toBeDefined();
+      expect(node?.getPlainValue()).toBe('John');
+    });
+
+    it('returns nested node', () => {
+      const tree = createTree(createNestedSchema(), {
+        name: 'John',
+        address: { city: 'NYC' },
+      });
+
+      const node = tree.get('address.city');
+
+      expect(node).toBeDefined();
+      expect(node?.getPlainValue()).toBe('NYC');
+    });
+
+    it('returns array item by index', () => {
+      const tree = createTree(createArraySchema(), {
+        items: [{ name: 'Item 1' }, { name: 'Item 2' }],
+      });
+
+      const node = tree.get('items[0]');
+
+      expect(node).toBeDefined();
+      expect(node?.isObject()).toBe(true);
+    });
+
+    it('returns array item property', () => {
+      const tree = createTree(createArraySchema(), {
+        items: [{ name: 'Item 1' }, { name: 'Item 2' }],
+      });
+
+      const node = tree.get('items[0].name');
+
+      expect(node?.getPlainValue()).toBe('Item 1');
+    });
+
+    it('returns undefined for non-existent path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.get('missing')).toBeUndefined();
+    });
+
+    it('returns undefined for invalid nested path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.get('name.invalid')).toBeUndefined();
+    });
+
+    it('returns undefined for out of bounds index', () => {
+      const tree = createTree(createArraySchema(), {
+        items: [{ name: 'Item 1' }],
+      });
+
+      expect(tree.get('items[10]')).toBeUndefined();
+    });
+
+    it('returns undefined for index on non-array', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.get('name[0]')).toBeUndefined();
+    });
+
+    it('returns undefined for property on non-object', () => {
+      const tree = createTree(createArraySchema(), {
+        items: [{ name: 'Item 1' }],
+      });
+
+      expect(tree.get('items.invalid')).toBeUndefined();
+    });
+  });
+
+  describe('getValue', () => {
+    it('returns value at path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.getValue('name')).toBe('John');
+      expect(tree.getValue('age')).toBe(30);
+    });
+
+    it('returns undefined for non-existent path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.getValue('missing')).toBeUndefined();
+    });
+  });
+
+  describe('setValue', () => {
+    it('sets value at path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      tree.setValue('name', 'Jane');
+
+      expect(tree.getValue('name')).toBe('Jane');
+    });
+
+    it('throws for non-existent path', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(() => tree.setValue('missing', 'value')).toThrow('Path not found: missing');
+    });
+
+    it('throws for non-primitive node', () => {
+      const tree = createTree(createNestedSchema(), {
+        name: 'John',
+        address: { city: 'NYC' },
+      });
+
+      expect(() => tree.setValue('address', {})).toThrow(
+        'Cannot set value on non-primitive node: address',
+      );
+    });
+  });
+
+  describe('getPlainValue', () => {
+    it('returns full tree as plain object', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.getPlainValue()).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('returns nested structure', () => {
+      const tree = createTree(createNestedSchema(), {
+        name: 'John',
+        address: { city: 'NYC' },
+      });
+
+      expect(tree.getPlainValue()).toEqual({
+        name: 'John',
+        address: { city: 'NYC' },
+      });
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty is false initially', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.isDirty).toBe(false);
+    });
+
+    it('isDirty is true after setValue', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      tree.setValue('name', 'Jane');
+
+      expect(tree.isDirty).toBe(true);
+    });
+
+    it('commit resets isDirty', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      tree.setValue('name', 'Jane');
+
+      tree.commit();
+
+      expect(tree.isDirty).toBe(false);
+    });
+
+    it('commit preserves new values', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      tree.setValue('name', 'Jane');
+
+      tree.commit();
+
+      expect(tree.getValue('name')).toBe('Jane');
+    });
+
+    it('revert restores original values', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      tree.setValue('name', 'Jane');
+
+      tree.revert();
+
+      expect(tree.getValue('name')).toBe('John');
+      expect(tree.isDirty).toBe(false);
+    });
+  });
+
+  describe('validation', () => {
+    it('isValid is true when no errors', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.isValid).toBe(true);
+    });
+
+    it('errors returns empty array by default', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.errors).toEqual([]);
+    });
+  });
+
+  describe('getPatches', () => {
+    it('returns empty array (patches not implemented)', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      tree.setValue('name', 'Jane');
+
+      expect(tree.getPatches()).toEqual([]);
+    });
+  });
+
+  describe('reactivity', () => {
+    it('calls makeObservable when adapter provided', () => {
+      const makeObservableMock = jest.fn();
+      const mockAdapter: ReactivityAdapter = {
+        makeObservable: makeObservableMock,
+        observableArray: <T>() => [] as T[],
+        observableMap: <K, V>() => new Map<K, V>(),
+        reaction: () => () => {},
+        runInAction: <T>(fn: () => T) => fn(),
+      };
+
+      const factory = createNodeFactory({ reactivity: mockAdapter });
+      const root = factory.createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      new ValueTree(root, mockAdapter);
+
+      expect(makeObservableMock).toHaveBeenCalled();
+    });
+
+    it('works without adapter', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+
+      expect(tree.isDirty).toBe(false);
+    });
+  });
+});

--- a/src/model/value-tree/index.ts
+++ b/src/model/value-tree/index.ts
@@ -1,0 +1,2 @@
+export type { ValueTreeLike } from './types.js';
+export { ValueTree } from './ValueTree.js';

--- a/src/model/value-tree/types.ts
+++ b/src/model/value-tree/types.ts
@@ -1,0 +1,17 @@
+import type { Diagnostic } from '../../core/validation/types.js';
+import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
+import type { ValueNode } from '../value-node/types.js';
+
+export interface ValueTreeLike {
+  readonly root: ValueNode;
+  get(path: string): ValueNode | undefined;
+  getValue(path: string): unknown;
+  setValue(path: string, value: unknown): void;
+  getPlainValue(): unknown;
+  readonly isDirty: boolean;
+  readonly isValid: boolean;
+  readonly errors: readonly Diagnostic[];
+  getPatches(): readonly JsonValuePatch[];
+  commit(): void;
+  revert(): void;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a TableModel for managing schema-backed rows with rename and dirty tracking. Also introduces ValueTree and a value-path API for simple path-based read/write (e.g., address.city, items[0].name).

- **New Features**
  - TableModel: add/remove/get rows, rowCount, row navigation (index/prev/next), rename via tableId/baseTableId, composite isDirty, commit/revert, createTableModel factory, optional reactivity adapter.
  - ValueTree: path-based get/getValue/setValue, undefined on missing paths, throws on invalid writes or non-primitive targets, isDirty/isValid/errors, commit/revert.
  - Value Path: ValuePath/segments (property/index) and parser utilities (parseValuePath, stringToValuePath) used by ValueTree and exposed for reuse.
  - Docs & Tests: new/updated READMEs for table, value-tree, value-path; comprehensive unit tests.

<sup>Written for commit 29f3abf01c4a48d2280933547b8c4077394f0d92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

