### PR TITLE
feat: default value

### DIFF
--- a/src/model/default-value/README.md
+++ b/src/model/default-value/README.md
@@ -1,0 +1,90 @@
+# default-value
+
+Generates plain JSON values from JSON Schema using default values.
+
+## API
+
+```typescript
+function generateDefaultValue(
+  schema: JsonSchema | null | undefined,
+  options?: GenerateDefaultValueOptions
+): unknown;
+
+interface GenerateDefaultValueOptions {
+  arrayItemCount?: number;  // default: 0
+  refSchemas?: Record<string, JsonSchema>;
+}
+```
+
+## Usage
+
+### Basic Types
+
+```typescript
+generateDefaultValue({ type: 'string', default: '' });       // ''
+generateDefaultValue({ type: 'string', default: 'hello' });  // 'hello'
+generateDefaultValue({ type: 'number', default: 0 });        // 0
+generateDefaultValue({ type: 'number', default: 42 });       // 42
+generateDefaultValue({ type: 'boolean', default: false });   // false
+generateDefaultValue({ type: 'boolean', default: true });    // true
+```
+
+### Objects
+
+```typescript
+generateDefaultValue({
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'age'],
+  properties: {
+    name: { type: 'string', default: 'Unknown' },
+    age: { type: 'number', default: 0 }
+  }
+});
+// { name: 'Unknown', age: 0 }
+```
+
+### Arrays
+
+```typescript
+generateDefaultValue(
+  { type: 'array', items: { type: 'string', default: 'item' } },
+  { arrayItemCount: 3 }
+);
+// ['item', 'item', 'item']
+```
+
+### $ref Resolution
+
+```typescript
+generateDefaultValue(
+  { $ref: 'File' },
+  {
+    refSchemas: {
+      File: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['fileId', 'url'],
+        properties: {
+          fileId: { type: 'string', default: '' },
+          url: { type: 'string', default: '' }
+        }
+      }
+    }
+  }
+);
+// { fileId: '', url: '' }
+```
+
+## Default Values by Type
+
+| Type    | Default Value                          |
+|---------|----------------------------------------|
+| string  | `schema.default` or `''`               |
+| number  | `schema.default` or `0`                |
+| boolean | `schema.default` or `false`            |
+| object  | recursively generate from properties   |
+| array   | `arrayItemCount` items with defaults   |
+| $ref    | resolve via `refSchemas`, then recurse |
+
+Priority: `schema.default` > generated value

--- a/src/model/default-value/__tests__/generateDefaultValue.spec.ts
+++ b/src/model/default-value/__tests__/generateDefaultValue.spec.ts
@@ -1,0 +1,476 @@
+import { describe, it, expect } from '@jest/globals';
+import { JsonSchemaTypeName, type JsonSchema } from '../../../types/schema.types.js';
+import { generateDefaultValue } from '../generateDefaultValue.js';
+
+describe('generateDefaultValue', () => {
+  describe('primitives', () => {
+    describe('string', () => {
+      it('returns empty string without default', () => {
+        const schema: JsonSchema = {
+          type: JsonSchemaTypeName.String,
+          default: '',
+        };
+
+        const result = generateDefaultValue(schema);
+
+        expect(result).toBe('');
+      });
+
+      it('returns schema default when provided', () => {
+        const schema: JsonSchema = {
+          type: JsonSchemaTypeName.String,
+          default: 'hello',
+        };
+
+        const result = generateDefaultValue(schema);
+
+        expect(result).toBe('hello');
+      });
+    });
+
+    describe('number', () => {
+      it('returns 0 without default', () => {
+        const schema: JsonSchema = {
+          type: JsonSchemaTypeName.Number,
+          default: 0,
+        };
+
+        const result = generateDefaultValue(schema);
+
+        expect(result).toBe(0);
+      });
+
+      it('returns schema default when provided', () => {
+        const schema: JsonSchema = {
+          type: JsonSchemaTypeName.Number,
+          default: 42,
+        };
+
+        const result = generateDefaultValue(schema);
+
+        expect(result).toBe(42);
+      });
+    });
+
+    describe('boolean', () => {
+      it('returns false without default', () => {
+        const schema: JsonSchema = {
+          type: JsonSchemaTypeName.Boolean,
+          default: false,
+        };
+
+        const result = generateDefaultValue(schema);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns schema default when provided', () => {
+        const schema: JsonSchema = {
+          type: JsonSchemaTypeName.Boolean,
+          default: true,
+        };
+
+        const result = generateDefaultValue(schema);
+
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('object', () => {
+    it('returns empty object for empty schema', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: [],
+        properties: {},
+      };
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual({});
+    });
+
+    it('generates defaults for properties', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['name', 'age'],
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+          age: { type: JsonSchemaTypeName.Number, default: 0 },
+        },
+      };
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual({ name: '', age: 0 });
+    });
+
+    it('uses property defaults', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['name', 'age'],
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: 'Unknown' },
+          age: { type: JsonSchemaTypeName.Number, default: 18 },
+        },
+      };
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual({ name: 'Unknown', age: 18 });
+    });
+
+    it('handles nested objects recursively', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['address'],
+        properties: {
+          address: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['city', 'zip'],
+            properties: {
+              city: { type: JsonSchemaTypeName.String, default: 'NYC' },
+              zip: { type: JsonSchemaTypeName.String, default: '' },
+            },
+          },
+        },
+      };
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual({
+        address: { city: 'NYC', zip: '' },
+      });
+    });
+  });
+
+  describe('array', () => {
+    it('returns empty array without arrayItemCount', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array with arrayItemCount 0', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 0 });
+
+      expect(result).toEqual([]);
+    });
+
+    it('generates one element with arrayItemCount 1', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: '' },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 1 });
+
+      expect(result).toEqual(['']);
+    });
+
+    it('generates multiple elements with arrayItemCount', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { type: JsonSchemaTypeName.String, default: 'item' },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 3 });
+
+      expect(result).toEqual(['item', 'item', 'item']);
+    });
+
+    it('generates object items with defaults', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Object,
+          additionalProperties: false,
+          required: ['id'],
+          properties: {
+            id: { type: JsonSchemaTypeName.String, default: '' },
+          },
+        },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 2 });
+
+      expect(result).toEqual([{ id: '' }, { id: '' }]);
+    });
+
+    it('creates independent object instances', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: {
+          type: JsonSchemaTypeName.Object,
+          additionalProperties: false,
+          required: ['id'],
+          properties: {
+            id: { type: JsonSchemaTypeName.String, default: '' },
+          },
+        },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 2 }) as object[];
+
+      expect(result[0]).not.toBe(result[1]);
+    });
+
+    it('applies arrayItemCount to nested arrays', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['matrix'],
+        properties: {
+          matrix: {
+            type: JsonSchemaTypeName.Array,
+            items: {
+              type: JsonSchemaTypeName.Array,
+              items: { type: JsonSchemaTypeName.Number, default: 0 },
+            },
+          },
+        },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 2 });
+
+      expect(result).toEqual({
+        matrix: [
+          [0, 0],
+          [0, 0],
+        ],
+      });
+    });
+  });
+
+  describe('$ref', () => {
+    it('resolves ref and generates default', () => {
+      const schema: JsonSchema = { $ref: 'File' };
+
+      const result = generateDefaultValue(schema, {
+        refSchemas: {
+          File: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['fileId', 'url'],
+            properties: {
+              fileId: { type: JsonSchemaTypeName.String, default: '' },
+              url: { type: JsonSchemaTypeName.String, default: '' },
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({ fileId: '', url: '' });
+    });
+
+    it('returns empty object without refSchemas', () => {
+      const schema: JsonSchema = { $ref: 'File' };
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty object for unknown ref', () => {
+      const schema: JsonSchema = { $ref: 'Unknown' };
+
+      const result = generateDefaultValue(schema, {
+        refSchemas: {
+          File: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: [],
+            properties: {},
+          },
+        },
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it('handles nested refs', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['image'],
+        properties: {
+          image: { $ref: 'File' },
+        },
+      };
+
+      const result = generateDefaultValue(schema, {
+        refSchemas: {
+          File: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['url'],
+            properties: {
+              url: { type: JsonSchemaTypeName.String, default: '' },
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        image: { url: '' },
+      });
+    });
+
+    it('handles array of refs', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Array,
+        items: { $ref: 'Tag' },
+      };
+
+      const result = generateDefaultValue(schema, {
+        arrayItemCount: 2,
+        refSchemas: {
+          Tag: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['name'],
+            properties: {
+              name: { type: JsonSchemaTypeName.String, default: '' },
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual([{ name: '' }, { name: '' }]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty object for null schema', () => {
+      const result = generateDefaultValue(null);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty object for undefined schema', () => {
+      const result = generateDefaultValue(undefined);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty string for string without default in schema', () => {
+      const schema = { type: JsonSchemaTypeName.String } as JsonSchema;
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toBe('');
+    });
+
+    it('returns 0 for number without default in schema', () => {
+      const schema = { type: JsonSchemaTypeName.Number } as JsonSchema;
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toBe(0);
+    });
+
+    it('returns false for boolean without default in schema', () => {
+      const schema = { type: JsonSchemaTypeName.Boolean } as JsonSchema;
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns undefined for schema without type', () => {
+      const schema = {} as JsonSchema;
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns empty object for object without properties', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: [],
+      } as unknown as JsonSchema;
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns undefined for unknown type', () => {
+      const schema = { type: 'unknown' } as unknown as JsonSchema;
+
+      const result = generateDefaultValue(schema);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('handles complex nested structure', () => {
+      const schema: JsonSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['user', 'tags', 'metadata'],
+        properties: {
+          user: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['name', 'contacts'],
+            properties: {
+              name: { type: JsonSchemaTypeName.String, default: '' },
+              contacts: {
+                type: JsonSchemaTypeName.Array,
+                items: {
+                  type: JsonSchemaTypeName.Object,
+                  additionalProperties: false,
+                  required: ['type', 'value'],
+                  properties: {
+                    type: { type: JsonSchemaTypeName.String, default: 'email' },
+                    value: { type: JsonSchemaTypeName.String, default: '' },
+                  },
+                },
+              },
+            },
+          },
+          tags: {
+            type: JsonSchemaTypeName.Array,
+            items: { type: JsonSchemaTypeName.String, default: '' },
+          },
+          metadata: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['active'],
+            properties: {
+              active: { type: JsonSchemaTypeName.Boolean, default: true },
+            },
+          },
+        },
+      };
+
+      const result = generateDefaultValue(schema, { arrayItemCount: 1 });
+
+      expect(result).toEqual({
+        user: {
+          name: '',
+          contacts: [{ type: 'email', value: '' }],
+        },
+        tags: [''],
+        metadata: { active: true },
+      });
+    });
+  });
+});

--- a/src/model/default-value/generateDefaultValue.ts
+++ b/src/model/default-value/generateDefaultValue.ts
@@ -1,0 +1,133 @@
+import {
+  JsonSchemaTypeName,
+  type JsonArraySchema,
+  type JsonObjectSchema,
+  type JsonSchema,
+} from '../../types/schema.types.js';
+import type { GenerateDefaultValueOptions } from './types.js';
+
+const DEFAULT_STRING = '';
+const DEFAULT_NUMBER = 0;
+const DEFAULT_BOOLEAN = false;
+
+function isRefSchema(schema: JsonSchema): schema is { $ref: string } {
+  return '$ref' in schema;
+}
+
+function isObjectSchema(schema: JsonSchema): schema is JsonObjectSchema {
+  return 'type' in schema && schema.type === JsonSchemaTypeName.Object;
+}
+
+function isArraySchema(schema: JsonSchema): schema is JsonArraySchema {
+  return 'type' in schema && schema.type === JsonSchemaTypeName.Array;
+}
+
+function hasDefaultValue(schema: JsonSchema): boolean {
+  return 'default' in schema && schema.default !== undefined;
+}
+
+function generatePrimitiveDefault(schema: JsonSchema): unknown {
+  if (!('type' in schema)) {
+    return undefined;
+  }
+
+  switch (schema.type) {
+    case JsonSchemaTypeName.String:
+      return DEFAULT_STRING;
+    case JsonSchemaTypeName.Number:
+      return DEFAULT_NUMBER;
+    case JsonSchemaTypeName.Boolean:
+      return DEFAULT_BOOLEAN;
+    default:
+      return undefined;
+  }
+}
+
+function generateObjectDefault(
+  schema: JsonObjectSchema,
+  options: GenerateDefaultValueOptions,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  if (!schema.properties) {
+    return result;
+  }
+
+  for (const [key, propertySchema] of Object.entries(schema.properties)) {
+    result[key] = generateDefaultValueInternal(propertySchema, options);
+  }
+
+  return result;
+}
+
+function generateArrayDefault(
+  schema: JsonArraySchema,
+  options: GenerateDefaultValueOptions,
+): unknown[] {
+  const itemCount = options.arrayItemCount ?? 0;
+
+  if (itemCount === 0 || !schema.items) {
+    return [];
+  }
+
+  const itemDefault = generateDefaultValueInternal(schema.items, options);
+  return Array.from({ length: itemCount }, () => {
+    if (typeof itemDefault === 'object' && itemDefault !== null) {
+      return generateDefaultValueInternal(schema.items, options);
+    }
+    return itemDefault;
+  });
+}
+
+function generateRefDefault(
+  schema: { $ref: string },
+  options: GenerateDefaultValueOptions,
+): unknown {
+  const refSchemas = options.refSchemas;
+
+  if (!refSchemas) {
+    return {};
+  }
+
+  const refSchema = refSchemas[schema.$ref];
+
+  if (!refSchema) {
+    return {};
+  }
+
+  return generateDefaultValueInternal(refSchema, options);
+}
+
+function generateDefaultValueInternal(
+  schema: JsonSchema,
+  options: GenerateDefaultValueOptions,
+): unknown {
+  if (hasDefaultValue(schema)) {
+    return (schema as { default: unknown }).default;
+  }
+
+  if (isRefSchema(schema)) {
+    return generateRefDefault(schema, options);
+  }
+
+  if (isObjectSchema(schema)) {
+    return generateObjectDefault(schema, options);
+  }
+
+  if (isArraySchema(schema)) {
+    return generateArrayDefault(schema, options);
+  }
+
+  return generatePrimitiveDefault(schema);
+}
+
+export function generateDefaultValue(
+  schema: JsonSchema | null | undefined,
+  options: GenerateDefaultValueOptions = {},
+): unknown {
+  if (!schema) {
+    return {};
+  }
+
+  return generateDefaultValueInternal(schema, options);
+}

--- a/src/model/default-value/index.ts
+++ b/src/model/default-value/index.ts
@@ -1,0 +1,2 @@
+export { generateDefaultValue } from './generateDefaultValue.js';
+export type { GenerateDefaultValueOptions } from './types.js';

--- a/src/model/default-value/types.ts
+++ b/src/model/default-value/types.ts
@@ -1,0 +1,6 @@
+import type { JsonSchema } from '../../types/schema.types.js';
+
+export interface GenerateDefaultValueOptions {
+  arrayItemCount?: number;
+  refSchemas?: Record<string, JsonSchema>;
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -2,3 +2,4 @@ export * from './schema/index.js';
 export * from './value/index.js';
 export * from './schema-model/index.js';
 export * from './table/index.js';
+export * from './default-value/index.js';

--- a/src/model/schema-model/README.md
+++ b/src/model/schema-model/README.md
@@ -96,6 +96,13 @@ model.revert();
 
 // Get serialized schema
 const plainSchema = model.getPlainSchema();
+
+// Generate default values from schema
+const defaults = model.generateDefaultValue();
+// { name: '', age: 0 }
+
+// Generate with array items
+const defaultsWithArrays = model.generateDefaultValue({ arrayItemCount: 2 });
 ```
 
 ### With Reactivity (MobX)

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -11,6 +11,7 @@ import type { SchemaModel, ReactivityOptions, FieldType } from './types.js';
 import { SchemaParser } from './SchemaParser.js';
 import { NodeFactory } from './NodeFactory.js';
 import { ParsedFormula, FormulaDependencyIndex } from '../schema-formula/index.js';
+import { generateDefaultValue as generateDefaultValueFn } from '../default-value/index.js';
 
 export class SchemaModelImpl implements SchemaModel {
   private _baseTree: SchemaTree;
@@ -178,6 +179,10 @@ export class SchemaModelImpl implements SchemaModel {
 
   getPlainSchema(): JsonObjectSchema {
     return this._serializer.serializeTree(this._currentTree);
+  }
+
+  generateDefaultValue(options?: { arrayItemCount?: number }): unknown {
+    return generateDefaultValueFn(this.getPlainSchema(), options);
   }
 
   private _buildFormulaIndex(): void {

--- a/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
@@ -4,6 +4,7 @@ import {
   emptySchema,
   simpleSchema,
   nestedSchema,
+  arraySchema,
   schemaWithMetadata,
   schemaWithFormula,
   schemaWithForeignKey,
@@ -164,6 +165,46 @@ describe('SchemaModel state management', () => {
       model.addField(rootId, 'newField', 'string');
 
       expect(model.getPlainSchema()).toMatchSnapshot();
+    });
+  });
+
+  describe('generateDefaultValue', () => {
+    it('returns defaults for current schema', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const result = model.generateDefaultValue();
+
+      expect(result).toEqual({ name: '', age: 0 });
+    });
+
+    it('applies arrayItemCount option', () => {
+      const model = createSchemaModel(arraySchema());
+
+      const result = model.generateDefaultValue({ arrayItemCount: 2 });
+
+      expect(result).toEqual({ items: ['', ''] });
+    });
+
+    it('reflects schema changes', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+
+      model.addField(rootId, 'name', 'string');
+      model.addField(rootId, 'active', 'boolean');
+
+      const result = model.generateDefaultValue();
+
+      expect(result).toEqual({ name: '', active: false });
+    });
+
+    it('returns defaults for nested schema', () => {
+      const model = createSchemaModel(nestedSchema());
+
+      const result = model.generateDefaultValue();
+
+      expect(result).toEqual({
+        user: { firstName: '', lastName: '' },
+      });
     });
   });
 });

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -39,4 +39,6 @@ export interface SchemaModel {
   revert(): void;
 
   getPlainSchema(): JsonObjectSchema;
+
+  generateDefaultValue(options?: { arrayItemCount?: number }): unknown;
 }

--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -64,7 +64,7 @@ interface TableModel {
   // Row management
   readonly rows: readonly RowModel[];
   readonly rowCount: number;
-  addRow(rowId: string, data?: unknown): RowModel;
+  addRow(rowId: string, data?: unknown): RowModel;  // data defaults to schema defaults if not provided
   removeRow(rowId: string): void;
   getRow(rowId: string): RowModel | undefined;
   getRowIndex(rowId: string): number;
@@ -168,8 +168,12 @@ const table = createTableModel({
 const row = table.getRow('user-1');
 console.log(row?.getValue('name')); // 'John'
 
-// Add new row
+// Add new row with data
 const newRow = table.addRow('user-3', { name: 'Bob', age: 35 });
+
+// Add row with default values from schema
+const rowWithDefaults = table.addRow('user-4');
+console.log(rowWithDefaults.getPlainValue()); // { name: '', age: 0 }
 
 // Remove row
 table.removeRow('user-2');
@@ -297,6 +301,7 @@ const table = createTableModel(
 - `types/json-value-patch.types` - JsonValuePatch type for change tracking
 - `model/value-node` - ValueNode, ValueTree interfaces
 - `model/schema-model` - SchemaModel for schema management
+- `model/default-value` - generateDefaultValue for auto-generating row data
 
 ### External Dependencies
 
@@ -324,3 +329,5 @@ None
 8. **Reactivity-aware**: Accepts optional ReactivityAdapter for MobX integration. Without it, works as plain JavaScript object (suitable for backend).
 
 9. **Factory Function**: `createTableModel()` provides a clean API and hides implementation details. Follows the same pattern as `createSchemaModel()`.
+
+10. **Auto-generated Defaults**: When `addRow()` is called without data, `generateDefaultValue()` automatically creates row data with schema defaults. This ensures rows always have valid initial values.

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -1,6 +1,7 @@
 import type { ReactivityAdapter } from '../../core/reactivity/types.js';
 import type { AnnotationsMap } from '../../core/types/index.js';
 import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
+import { generateDefaultValue } from '../default-value/index.js';
 import { createSchemaModel } from '../schema-model/SchemaModelImpl.js';
 import type { SchemaModel } from '../schema-model/types.js';
 import { createNodeFactory } from '../value-node/NodeFactory.js';
@@ -150,10 +151,8 @@ export class TableModelImpl implements TableModel {
 
   private createRowModel(rowId: string, data?: unknown): RowModel {
     const factory = createNodeFactory({ reactivity: this._reactivity });
-    const rootNode = factory.createTree(
-      this._jsonSchema as JsonSchema,
-      data ?? {},
-    );
+    const rowData = data ?? generateDefaultValue(this._jsonSchema);
+    const rootNode = factory.createTree(this._jsonSchema as JsonSchema, rowData);
     const valueTree = new ValueTree(rootNode, this._reactivity);
     const rowModel = new RowModelImpl(rowId, valueTree, this._reactivity);
     rowModel.setTableModel(this);

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -155,6 +155,36 @@ describe('TableModel', () => {
       expect(() => table.addRow('user-1')).toThrow('Row with id already exists: user-1');
     });
 
+    it('addRow without data generates defaults from schema', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      const row = table.addRow('user-1');
+
+      expect(row.getPlainValue()).toEqual({ name: '', age: 0 });
+    });
+
+    it('addRow without data uses schema defaults', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: {
+          type: JsonSchemaTypeName.Object,
+          additionalProperties: false,
+          required: ['name', 'status'],
+          properties: {
+            name: { type: JsonSchemaTypeName.String, default: 'Unknown' },
+            status: { type: JsonSchemaTypeName.String, default: 'active' },
+          },
+        },
+      });
+
+      const row = table.addRow('user-1');
+
+      expect(row.getPlainValue()).toEqual({ name: 'Unknown', status: 'active' });
+    });
+
     it('removeRow removes row by id', () => {
       const table = createTableModel({
         tableId: 'users',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a default value generator for JSON Schema and integrate it into SchemaModel and TableModel to auto-create initial row data when none is provided. This improves DX and ensures consistent defaults, including $ref resolution and array items.

- **New Features**
  - New generateDefaultValue(schema, { arrayItemCount, refSchemas }) to produce plain JSON defaults.
  - Supports $ref via refSchemas and nested structures.
  - Arrays can prefill items with arrayItemCount (default 0).
  - SchemaModel.generateDefaultValue(options) exposes defaults for the current schema.
  - TableModel.addRow() now uses schema defaults when data is omitted.
  - Added tests and docs for default-value, SchemaModel, and TableModel.

<sup>Written for commit ebaa6e5db05c88a915de22975d53e7200719f196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

