### PR TITLE
feat: data model

### DIFF
--- a/src/model/data-model/DataModel.ts
+++ b/src/model/data-model/DataModel.ts
@@ -1,0 +1,21 @@
+import type { JsonObjectSchema } from '../../types/schema.types.js';
+import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
+import type { RowData, TableModel } from '../table/types.js';
+
+export interface DataModel {
+  readonly fk: ForeignKeyResolver;
+
+  addTable(tableId: string, schema: JsonObjectSchema, rows?: RowData[]): TableModel;
+  getTable(tableId: string): TableModel | undefined;
+  removeTable(tableId: string): void;
+  hasTable(tableId: string): boolean;
+
+  readonly tables: readonly TableModel[];
+  readonly tableIds: readonly string[];
+
+  readonly isDirty: boolean;
+
+  commit(): void;
+  revert(): void;
+  dispose(): void;
+}

--- a/src/model/data-model/DataModelImpl.ts
+++ b/src/model/data-model/DataModelImpl.ts
@@ -1,0 +1,121 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { AnnotationsMap } from '../../core/types/index.js';
+import type { JsonObjectSchema } from '../../types/schema.types.js';
+import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
+import { createForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolverImpl.js';
+import { createTableModel } from '../table/TableModelImpl.js';
+import type { RowData, TableModel } from '../table/types.js';
+import type { DataModel } from './DataModel.js';
+import type { DataModelOptions } from './types.js';
+
+export class DataModelImpl implements DataModel {
+  private readonly _tables: Map<string, TableModel>;
+  private readonly _fk: ForeignKeyResolver;
+  private readonly _ownsFkResolver: boolean;
+  private readonly _reactivity: ReactivityAdapter | undefined;
+
+  constructor(options?: DataModelOptions) {
+    this._reactivity = options?.reactivity;
+    this._tables = this._reactivity?.observableMap() ?? new Map();
+
+    if (options?.fkResolver) {
+      this._fk = options.fkResolver;
+      this._ownsFkResolver = false;
+    } else {
+      this._fk = createForeignKeyResolver({ reactivity: this._reactivity });
+      this._ownsFkResolver = true;
+    }
+
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    this._reactivity?.makeObservable(this, {
+      _tables: 'observable',
+      tables: 'computed',
+      tableIds: 'computed',
+      isDirty: 'computed',
+      addTable: 'action',
+      removeTable: 'action',
+      commit: 'action',
+      revert: 'action',
+    } as AnnotationsMap<this>);
+  }
+
+  get fk(): ForeignKeyResolver {
+    return this._fk;
+  }
+
+  get tables(): readonly TableModel[] {
+    return Array.from(this._tables.values());
+  }
+
+  get tableIds(): readonly string[] {
+    return Array.from(this._tables.keys());
+  }
+
+  get isDirty(): boolean {
+    for (const table of this._tables.values()) {
+      if (table.isDirty) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  hasTable(tableId: string): boolean {
+    return this._tables.has(tableId);
+  }
+
+  getTable(tableId: string): TableModel | undefined {
+    return this._tables.get(tableId);
+  }
+
+  addTable(tableId: string, schema: JsonObjectSchema, rows?: RowData[]): TableModel {
+    const tableModel = createTableModel(
+      {
+        tableId,
+        schema,
+        rows,
+        fkResolver: this._fk,
+      },
+      this._reactivity,
+    );
+
+    this._tables.set(tableId, tableModel);
+
+    this._fk.addSchema(tableId, schema);
+    if (rows && rows.length > 0) {
+      this._fk.addTable(tableId, schema, rows);
+    }
+
+    return tableModel;
+  }
+
+  removeTable(tableId: string): void {
+    this._tables.delete(tableId);
+  }
+
+  commit(): void {
+    for (const table of this._tables.values()) {
+      table.commit();
+    }
+  }
+
+  revert(): void {
+    for (const table of this._tables.values()) {
+      table.revert();
+    }
+  }
+
+  dispose(): void {
+    this._tables.clear();
+    if (this._ownsFkResolver) {
+      this._fk.dispose();
+    }
+  }
+}
+
+export function createDataModel(options?: DataModelOptions): DataModel {
+  return new DataModelImpl(options);
+}

--- a/src/model/data-model/README.md
+++ b/src/model/data-model/README.md
@@ -1,0 +1,131 @@
+# DataModel
+
+A container for managing multiple tables with integrated foreign key resolution.
+
+## Installation
+
+```typescript
+import { createDataModel } from 'schema-toolkit/model';
+```
+
+## Overview
+
+DataModel provides:
+- **Table management** - Add, get, remove tables
+- **FK integration** - Automatic schema/row caching in ForeignKeyResolver
+- **Dirty tracking** - Track changes across all tables
+- **Commit/revert** - Batch save/discard changes
+
+## Usage
+
+### Basic Usage
+
+```typescript
+const dataModel = createDataModel();
+
+// Add tables
+const usersTable = dataModel.addTable('users', userSchema);
+const productsTable = dataModel.addTable('products', productSchema, initialRows);
+
+// Access tables
+const table = dataModel.getTable('users');
+dataModel.hasTable('users'); // true
+
+// List all tables
+dataModel.tables; // TableModel[]
+dataModel.tableIds; // string[]
+
+// Remove table (keeps FK cache)
+dataModel.removeTable('users');
+```
+
+### With External FK Resolver
+
+```typescript
+const fkResolver = createForeignKeyResolver({
+  loader: { ... },
+  prefetch: true,
+});
+
+const dataModel = createDataModel({ fkResolver });
+
+// Tables will use the shared resolver
+const table = dataModel.addTable('products', productSchema);
+table.fk === fkResolver; // true
+```
+
+### Dirty Tracking
+
+```typescript
+const dataModel = createDataModel();
+const table = dataModel.addTable('users', schema);
+const row = table.addRow('user-1', { name: 'John' });
+
+row.setValue('name', 'Jane');
+dataModel.isDirty; // true
+
+// Commit all changes
+dataModel.commit();
+dataModel.isDirty; // false
+
+// Or revert all changes
+dataModel.revert();
+```
+
+### Cleanup
+
+```typescript
+const dataModel = createDataModel();
+// ... use dataModel ...
+
+// Dispose clears tables and internal FK resolver
+dataModel.dispose();
+```
+
+## API
+
+### Factory
+
+```typescript
+function createDataModel(options?: DataModelOptions): DataModel
+```
+
+### DataModelOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `reactivity` | `ReactivityAdapter` | - | MobX adapter for observability |
+| `fkResolver` | `ForeignKeyResolver` | - | External resolver (creates internal if not provided) |
+
+### DataModel Interface
+
+```typescript
+interface DataModel {
+  readonly fk: ForeignKeyResolver;
+
+  // Table management
+  addTable(tableId: string, schema: JsonObjectSchema, rows?: RowData[]): TableModel;
+  getTable(tableId: string): TableModel | undefined;
+  removeTable(tableId: string): void;
+  hasTable(tableId: string): boolean;
+
+  readonly tables: readonly TableModel[];
+  readonly tableIds: readonly string[];
+
+  // State
+  readonly isDirty: boolean;
+
+  // Batch operations
+  commit(): void;
+  revert(): void;
+  dispose(): void;
+}
+```
+
+## Behavior Notes
+
+- **addTable** automatically adds schema to FK resolver
+- **addTable with rows** also adds rows to FK resolver
+- **removeTable** removes from DataModel but keeps FK cache (for cross-table references)
+- **dispose** clears tables and disposes internal FK resolver (but not external)
+- **TableModels** created via addTable have access to the shared FK resolver via `table.fk`

--- a/src/model/data-model/__tests__/DataModel.spec.ts
+++ b/src/model/data-model/__tests__/DataModel.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from '@jest/globals';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { createForeignKeyResolver } from '../../foreign-key-resolver/ForeignKeyResolverImpl.js';
+import { createDataModel } from '../DataModelImpl.js';
+
+const createSimpleSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+  },
+});
+
+const createSchemaWithFK = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'categoryId'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
+  },
+});
+
+describe('DataModel', () => {
+  describe('table management', () => {
+    it('addTable creates TableModel', () => {
+      const dataModel = createDataModel();
+
+      const table = dataModel.addTable('users', createSimpleSchema());
+
+      expect(table).toBeDefined();
+      expect(table.tableId).toBe('users');
+      expect(dataModel.hasTable('users')).toBe(true);
+    });
+
+    it('addTable adds schema to fk resolver', () => {
+      const dataModel = createDataModel();
+
+      dataModel.addTable('users', createSimpleSchema());
+
+      expect(dataModel.fk.hasSchema('users')).toBe(true);
+    });
+
+    it('addTable with rows adds rows to fk resolver', () => {
+      const dataModel = createDataModel();
+
+      dataModel.addTable('users', createSimpleSchema(), [
+        { rowId: 'user-1', data: { name: 'John' } },
+      ]);
+
+      expect(dataModel.fk.hasRow('users', 'user-1')).toBe(true);
+    });
+
+    it('getTable returns TableModel or undefined', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      expect(dataModel.getTable('users')).toBeDefined();
+      expect(dataModel.getTable('unknown')).toBeUndefined();
+    });
+
+    it('hasTable checks table existence', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      expect(dataModel.hasTable('users')).toBe(true);
+      expect(dataModel.hasTable('unknown')).toBe(false);
+    });
+
+    it('removeTable removes TableModel but not from fk cache', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema(), [
+        { rowId: 'user-1', data: { name: 'John' } },
+      ]);
+
+      dataModel.removeTable('users');
+
+      expect(dataModel.hasTable('users')).toBe(false);
+      expect(dataModel.fk.hasSchema('users')).toBe(true);
+      expect(dataModel.fk.hasRow('users', 'user-1')).toBe(true);
+    });
+
+    it('tables returns all TableModels', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+      dataModel.addTable('products', createSimpleSchema());
+
+      expect(dataModel.tables).toHaveLength(2);
+    });
+
+    it('tableIds returns all table ids', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+      dataModel.addTable('products', createSimpleSchema());
+
+      expect(dataModel.tableIds).toContain('users');
+      expect(dataModel.tableIds).toContain('products');
+    });
+  });
+
+  describe('fk integration', () => {
+    it('created TableModels have fk resolver', () => {
+      const dataModel = createDataModel();
+      const table = dataModel.addTable('users', createSimpleSchema());
+
+      expect(table.fk).toBe(dataModel.fk);
+    });
+
+    it('uses provided fkResolver', () => {
+      const fkResolver = createForeignKeyResolver();
+      const dataModel = createDataModel({ fkResolver });
+
+      expect(dataModel.fk).toBe(fkResolver);
+    });
+
+    it('creates internal fkResolver when not provided', () => {
+      const dataModel = createDataModel();
+
+      expect(dataModel.fk).toBeDefined();
+    });
+  });
+
+  describe('dirty tracking', () => {
+    it('isDirty false initially', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      expect(dataModel.isDirty).toBe(false);
+    });
+
+    it('isDirty true if any table dirty', () => {
+      const dataModel = createDataModel();
+      const table = dataModel.addTable('users', createSimpleSchema());
+      const row = table.addRow('user-1', { name: 'John' });
+
+      row.setValue('name', 'Jane');
+
+      expect(dataModel.isDirty).toBe(true);
+    });
+
+    it('commit commits all tables', () => {
+      const dataModel = createDataModel();
+      const table = dataModel.addTable('users', createSimpleSchema());
+      const row = table.addRow('user-1', { name: 'John' });
+
+      row.setValue('name', 'Jane');
+      dataModel.commit();
+
+      expect(dataModel.isDirty).toBe(false);
+      expect(row.getValue('name')).toBe('Jane');
+    });
+
+    it('revert reverts all tables', () => {
+      const dataModel = createDataModel();
+      const table = dataModel.addTable('users', createSimpleSchema());
+      const row = table.addRow('user-1', { name: 'John' });
+
+      row.setValue('name', 'Jane');
+      dataModel.revert();
+
+      expect(dataModel.isDirty).toBe(false);
+      expect(row.getValue('name')).toBe('John');
+    });
+  });
+
+  describe('dispose', () => {
+    it('dispose clears tables', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+      dataModel.addTable('products', createSimpleSchema());
+
+      dataModel.dispose();
+
+      expect(dataModel.hasTable('users')).toBe(false);
+      expect(dataModel.hasTable('products')).toBe(false);
+    });
+
+    it('dispose disposes internal fk resolver', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      dataModel.dispose();
+
+      expect(dataModel.fk.hasSchema('users')).toBe(false);
+    });
+
+    it('dispose does not dispose external fk resolver', () => {
+      const fkResolver = createForeignKeyResolver();
+      fkResolver.addSchema('external', createSimpleSchema());
+
+      const dataModel = createDataModel({ fkResolver });
+      dataModel.addTable('users', createSimpleSchema());
+
+      dataModel.dispose();
+
+      expect(fkResolver.hasSchema('external')).toBe(true);
+    });
+  });
+
+  describe('FK value node integration', () => {
+    it('creates ForeignKeyValueNode for FK fields', () => {
+      const dataModel = createDataModel();
+      const table = dataModel.addTable('products', createSchemaWithFK());
+      const row = table.addRow('prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+
+      const categoryNode = row.get('categoryId');
+      expect(categoryNode).toBeDefined();
+      expect('foreignKey' in categoryNode!).toBe(true);
+    });
+  });
+});

--- a/src/model/data-model/index.ts
+++ b/src/model/data-model/index.ts
@@ -1,0 +1,3 @@
+export type { DataModel } from './DataModel.js';
+export { DataModelImpl, createDataModel } from './DataModelImpl.js';
+export type { DataModelOptions } from './types.js';

--- a/src/model/data-model/types.ts
+++ b/src/model/data-model/types.ts
@@ -1,0 +1,7 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
+
+export interface DataModelOptions {
+  reactivity?: ReactivityAdapter;
+  fkResolver?: ForeignKeyResolver;
+}

--- a/src/model/foreign-key-resolver/ForeignKeyResolver.ts
+++ b/src/model/foreign-key-resolver/ForeignKeyResolver.ts
@@ -1,0 +1,23 @@
+import type { JsonObjectSchema } from '../../types/schema.types.js';
+import type { RowData } from './types.js';
+
+export interface ForeignKeyResolver {
+  addSchema(tableId: string, schema: JsonObjectSchema): void;
+  addTable(tableId: string, schema: JsonObjectSchema, rows: RowData[]): void;
+  addRow(tableId: string, rowId: string, data: unknown): void;
+
+  getSchema(tableId: string): Promise<JsonObjectSchema>;
+  getRowData(tableId: string, rowId: string): Promise<RowData>;
+
+  isLoading(tableId: string): boolean;
+  isLoadingRow(tableId: string, rowId: string): boolean;
+
+  hasSchema(tableId: string): boolean;
+  hasTable(tableId: string): boolean;
+  hasRow(tableId: string, rowId: string): boolean;
+
+  setPrefetch(enabled: boolean): void;
+  readonly isPrefetchEnabled: boolean;
+
+  dispose(): void;
+}

--- a/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
+++ b/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
@@ -1,0 +1,371 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { AnnotationsMap } from '../../core/types/index.js';
+import {
+  JsonSchemaTypeName,
+  type JsonObjectSchema,
+  type JsonSchema,
+} from '../../types/schema.types.js';
+import {
+  ForeignKeyNotFoundError,
+  ForeignKeyResolverNotConfiguredError,
+} from './errors.js';
+import type { ForeignKeyResolver } from './ForeignKeyResolver.js';
+import type {
+  ForeignKeyLoader,
+  ForeignKeyResolverOptions,
+  ForeignKeyTableCache,
+  RowData,
+} from './types.js';
+
+export class ForeignKeyResolverImpl implements ForeignKeyResolver {
+  private readonly _schemaCache: Map<string, JsonObjectSchema>;
+  private readonly _tableCache: Map<string, ForeignKeyTableCache>;
+  private readonly _loadingTables: Set<string>;
+  private readonly _loadingRows: Map<string, Set<string>>;
+  private readonly _pendingTableLoads: Map<string, Promise<JsonObjectSchema>>;
+  private readonly _pendingRowLoads: Map<string, Promise<RowData>>;
+  private _prefetchEnabled: boolean;
+  private _disposed = false;
+
+  private readonly loader: ForeignKeyLoader | undefined;
+  private readonly reactivity: ReactivityAdapter | undefined;
+
+  constructor(options?: ForeignKeyResolverOptions) {
+    this.loader = options?.loader;
+    this.reactivity = options?.reactivity;
+    this._prefetchEnabled = options?.prefetch ?? false;
+
+    this._schemaCache = this.reactivity?.observableMap() ?? new Map();
+    this._tableCache = this.reactivity?.observableMap() ?? new Map();
+    this._loadingTables = new Set();
+    this._loadingRows = new Map();
+    this._pendingTableLoads = new Map();
+    this._pendingRowLoads = new Map();
+
+    this.initObservable();
+  }
+
+  private initObservable(): void {
+    this.reactivity?.makeObservable(this, {
+      _schemaCache: 'observable',
+      _tableCache: 'observable',
+      _prefetchEnabled: 'observable',
+      isPrefetchEnabled: 'computed',
+      addSchema: 'action',
+      addTable: 'action',
+      addRow: 'action',
+      setPrefetch: 'action',
+    } as AnnotationsMap<this>);
+  }
+
+  get isPrefetchEnabled(): boolean {
+    return this._prefetchEnabled;
+  }
+
+  setPrefetch(enabled: boolean): void {
+    this._prefetchEnabled = enabled;
+  }
+
+  hasSchema(tableId: string): boolean {
+    return this._schemaCache.has(tableId) || this._tableCache.has(tableId);
+  }
+
+  hasTable(tableId: string): boolean {
+    return this._tableCache.has(tableId);
+  }
+
+  hasRow(tableId: string, rowId: string): boolean {
+    const table = this._tableCache.get(tableId);
+    return table?.rows.has(rowId) ?? false;
+  }
+
+  isLoading(tableId: string): boolean {
+    return this._loadingTables.has(tableId);
+  }
+
+  isLoadingRow(tableId: string, rowId: string): boolean {
+    const rowSet = this._loadingRows.get(tableId);
+    return rowSet?.has(rowId) ?? false;
+  }
+
+  addSchema(tableId: string, schema: JsonObjectSchema): void {
+    if (this._disposed) {
+      return;
+    }
+    if (this.reactivity) {
+      this.reactivity.runInAction(() => {
+        this._schemaCache.set(tableId, schema);
+      });
+    } else {
+      this._schemaCache.set(tableId, schema);
+    }
+  }
+
+  addTable(tableId: string, schema: JsonObjectSchema, rows: RowData[]): void {
+    if (this._disposed) {
+      return;
+    }
+
+    const rowMap: Map<string, RowData> =
+      this.reactivity?.observableMap() ?? new Map();
+    for (const row of rows) {
+      rowMap.set(row.rowId, row);
+    }
+
+    const cache: ForeignKeyTableCache = { schema, rows: rowMap };
+
+    if (this.reactivity) {
+      this.reactivity.runInAction(() => {
+        this._tableCache.set(tableId, cache);
+        this._schemaCache.set(tableId, schema);
+      });
+    } else {
+      this._tableCache.set(tableId, cache);
+      this._schemaCache.set(tableId, schema);
+    }
+
+    if (this._prefetchEnabled) {
+      this.prefetchForeignKeysFromTable(tableId, schema, rows);
+    }
+  }
+
+  addRow(tableId: string, rowId: string, data: unknown): void {
+    if (this._disposed) {
+      return;
+    }
+
+    const table = this._tableCache.get(tableId);
+    if (table) {
+      const rowData: RowData = { rowId, data };
+      if (this.reactivity) {
+        this.reactivity.runInAction(() => {
+          table.rows.set(rowId, rowData);
+        });
+      } else {
+        table.rows.set(rowId, rowData);
+      }
+
+      if (this._prefetchEnabled) {
+        this.prefetchForeignKeysFromRow(tableId, table.schema, data);
+      }
+    }
+  }
+
+  async getSchema(tableId: string): Promise<JsonObjectSchema> {
+    const cachedSchema = this._schemaCache.get(tableId);
+    if (cachedSchema) {
+      return cachedSchema;
+    }
+
+    const cachedTable = this._tableCache.get(tableId);
+    if (cachedTable) {
+      return cachedTable.schema;
+    }
+
+    if (!this.loader) {
+      throw new ForeignKeyNotFoundError(tableId);
+    }
+
+    const pending = this._pendingTableLoads.get(tableId);
+    if (pending) {
+      return pending;
+    }
+
+    const loadPromise = this.loadSchemaInternal(tableId);
+    this._pendingTableLoads.set(tableId, loadPromise);
+
+    try {
+      return await loadPromise;
+    } finally {
+      this._pendingTableLoads.delete(tableId);
+    }
+  }
+
+  async getRowData(tableId: string, rowId: string): Promise<RowData> {
+    const table = this._tableCache.get(tableId);
+    if (table) {
+      const row = table.rows.get(rowId);
+      if (row) {
+        return row;
+      }
+    }
+
+    if (!this.loader) {
+      throw new ForeignKeyNotFoundError(tableId, rowId);
+    }
+
+    const pendingKey = `${tableId}:${rowId}`;
+    const pending = this._pendingRowLoads.get(pendingKey);
+    if (pending) {
+      return pending;
+    }
+
+    const loadPromise = this.loadRowInternal(tableId, rowId);
+    this._pendingRowLoads.set(pendingKey, loadPromise);
+
+    try {
+      return await loadPromise;
+    } finally {
+      this._pendingRowLoads.delete(pendingKey);
+    }
+  }
+
+  dispose(): void {
+    this._disposed = true;
+    this._schemaCache.clear();
+    this._tableCache.clear();
+    this._loadingTables.clear();
+    this._loadingRows.clear();
+    this._pendingTableLoads.clear();
+    this._pendingRowLoads.clear();
+  }
+
+  private async loadSchemaInternal(tableId: string): Promise<JsonObjectSchema> {
+    if (!this.loader) {
+      throw new ForeignKeyResolverNotConfiguredError();
+    }
+
+    this._loadingTables.add(tableId);
+
+    try {
+      const schema = await this.loader.loadSchema(tableId);
+      if (!this._disposed) {
+        this.addSchema(tableId, schema);
+      }
+      return schema;
+    } finally {
+      this._loadingTables.delete(tableId);
+    }
+  }
+
+  private async loadRowInternal(
+    tableId: string,
+    rowId: string,
+  ): Promise<RowData> {
+    if (!this.loader) {
+      throw new ForeignKeyResolverNotConfiguredError();
+    }
+
+    this.setRowLoading(tableId, rowId, true);
+
+    try {
+      const result = await this.loader.loadRow(tableId, rowId);
+      if (!this._disposed) {
+        this.addSchema(tableId, result.schema);
+        this.ensureTableCache(tableId, result.schema);
+        this.addRow(tableId, rowId, result.row.data);
+      }
+      return result.row;
+    } finally {
+      this.setRowLoading(tableId, rowId, false);
+    }
+  }
+
+  private ensureTableCache(tableId: string, schema: JsonObjectSchema): void {
+    if (!this._tableCache.has(tableId)) {
+      const rowMap: Map<string, RowData> =
+        this.reactivity?.observableMap() ?? new Map();
+      const cache: ForeignKeyTableCache = { schema, rows: rowMap };
+
+      if (this.reactivity) {
+        this.reactivity.runInAction(() => {
+          this._tableCache.set(tableId, cache);
+        });
+      } else {
+        this._tableCache.set(tableId, cache);
+      }
+    }
+  }
+
+  private setRowLoading(
+    tableId: string,
+    rowId: string,
+    loading: boolean,
+  ): void {
+    if (loading) {
+      let rowSet = this._loadingRows.get(tableId);
+      if (!rowSet) {
+        rowSet = new Set();
+        this._loadingRows.set(tableId, rowSet);
+      }
+      rowSet.add(rowId);
+    } else {
+      const rowSet = this._loadingRows.get(tableId);
+      if (rowSet) {
+        rowSet.delete(rowId);
+        if (rowSet.size === 0) {
+          this._loadingRows.delete(tableId);
+        }
+      }
+    }
+  }
+
+  private prefetchForeignKeysFromTable(
+    sourceTableId: string,
+    schema: JsonObjectSchema,
+    rows: RowData[],
+  ): void {
+    for (const row of rows) {
+      this.prefetchForeignKeysFromRow(sourceTableId, schema, row.data);
+    }
+  }
+
+  private prefetchForeignKeysFromRow(
+    _sourceTableId: string,
+    schema: JsonObjectSchema,
+    data: unknown,
+  ): void {
+    const foreignKeys = this.extractForeignKeys(schema);
+    if (foreignKeys.length === 0) {
+      return;
+    }
+
+    const dataObj = data as Record<string, unknown>;
+    const properties = schema.properties;
+
+    for (const [fieldName, fieldSchema] of Object.entries(properties)) {
+      const fk = this.getForeignKeyFromSchema(fieldSchema);
+      if (fk && dataObj[fieldName]) {
+        const rowId = String(dataObj[fieldName]);
+        if (!this.hasRow(fk, rowId) && !this.isLoadingRow(fk, rowId)) {
+          this.prefetchRow(fk, rowId);
+        }
+      }
+    }
+  }
+
+  private prefetchRow(tableId: string, rowId: string): void {
+    if (!this.loader) {
+      return;
+    }
+
+    const prefetchPromise = this.getRowData(tableId, rowId);
+    prefetchPromise.catch(() => {
+      // Prefetch errors are silently ignored
+    });
+  }
+
+  private extractForeignKeys(schema: JsonObjectSchema): string[] {
+    const foreignKeys: string[] = [];
+    for (const fieldSchema of Object.values(schema.properties)) {
+      const fk = this.getForeignKeyFromSchema(fieldSchema);
+      if (fk) {
+        foreignKeys.push(fk);
+      }
+    }
+    return foreignKeys;
+  }
+
+  private getForeignKeyFromSchema(schema: JsonSchema): string | undefined {
+    if ('type' in schema && schema.type === JsonSchemaTypeName.String) {
+      return schema.foreignKey;
+    }
+    return undefined;
+  }
+}
+
+export function createForeignKeyResolver(
+  options?: ForeignKeyResolverOptions,
+): ForeignKeyResolver {
+  return new ForeignKeyResolverImpl(options);
+}

--- a/src/model/foreign-key-resolver/README.md
+++ b/src/model/foreign-key-resolver/README.md
@@ -188,16 +188,15 @@ try {
 }
 ```
 
-### ForeignKeyResolverNotConfiguredError
+### ForeignKeyNotFoundError
 
-Thrown when attempting to load data without a configured loader:
+Thrown when data is not in cache and no loader is configured:
 
 ```typescript
 const resolver = createForeignKeyResolver(); // no loader
-await resolver.getSchema('users'); // throws ForeignKeyNotFoundError (no cached data, no loader)
+await resolver.getSchema('users'); // throws ForeignKeyNotFoundError
+await resolver.getRowData('users', 'user-1'); // throws ForeignKeyNotFoundError
 ```
-
-Note: When no loader is configured and data is not in cache, `ForeignKeyNotFoundError` is thrown. `ForeignKeyResolverNotConfiguredError` is thrown internally when loader methods are called without a loader.
 
 ## Prefetch Behavior
 

--- a/src/model/foreign-key-resolver/README.md
+++ b/src/model/foreign-key-resolver/README.md
@@ -1,0 +1,256 @@
+# ForeignKeyResolver
+
+Manages resolution of foreign key references between tables with support for caching, lazy loading, and automatic prefetching.
+
+## Installation
+
+```typescript
+import { createForeignKeyResolver } from 'schema-toolkit/model';
+```
+
+## Overview
+
+ForeignKeyResolver provides:
+- **Schema caching** - Store and retrieve table schemas
+- **Row caching** - Store and retrieve individual rows
+- **Lazy loading** - Load data on demand via configurable loader
+- **Prefetch** - Automatically load referenced data in the background
+- **Loading state** - Track which tables/rows are currently loading
+- **Reactivity support** - Integration with MobX or similar
+
+## Usage
+
+### Basic Cache-Only Usage
+
+```typescript
+const resolver = createForeignKeyResolver();
+
+// Add schema to cache
+resolver.addSchema('categories', categorySchema);
+
+// Add full table with rows
+resolver.addTable('products', productSchema, [
+  { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+]);
+
+// Check cache
+resolver.hasSchema('categories'); // true
+resolver.hasRow('products', 'prod-1'); // true
+
+// Get from cache (returns Promise for consistency)
+const schema = await resolver.getSchema('categories');
+const row = await resolver.getRowData('products', 'prod-1');
+```
+
+### With Lazy Loading
+
+```typescript
+const resolver = createForeignKeyResolver({
+  loader: {
+    loadSchema: async (tableId) => api.getTableSchema(tableId),
+    loadTable: async (tableId) => api.getTable(tableId),
+    loadRow: async (tableId, rowId) => api.getRow(tableId, rowId),
+  },
+});
+
+// Will load from API if not cached
+const schema = await resolver.getSchema('categories');
+const row = await resolver.getRowData('categories', 'cat-1');
+
+// Subsequent calls return from cache
+const cachedRow = await resolver.getRowData('categories', 'cat-1');
+```
+
+### With Automatic Prefetch
+
+```typescript
+const resolver = createForeignKeyResolver({
+  prefetch: true,
+  loader: { ... },
+});
+
+// Adding a row with FK will trigger background loading of referenced data
+resolver.addTable('products', productSchema, []);
+resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+// ^ Background: loads categories/cat-1
+
+// Later, data is likely in cache
+const categoryRow = await resolver.getRowData('categories', 'cat-1');
+```
+
+### Runtime Prefetch Control
+
+```typescript
+const resolver = createForeignKeyResolver({ prefetch: false });
+
+// Enable prefetch later
+resolver.setPrefetch(true);
+
+// Check current state
+resolver.isPrefetchEnabled; // true
+```
+
+### Loading State
+
+```typescript
+// Check if loading
+resolver.isLoading('categories'); // true if schema being loaded
+resolver.isLoadingRow('categories', 'cat-1'); // true if row being loaded
+```
+
+### With Reactivity (MobX)
+
+```typescript
+import { mobxAdapter } from 'your-mobx-adapter';
+
+const resolver = createForeignKeyResolver({
+  reactivity: mobxAdapter,
+  loader: { ... },
+});
+
+// Observable properties:
+// - isPrefetchEnabled
+// - Cache maps for UI reactivity
+```
+
+## API
+
+### Factory
+
+```typescript
+function createForeignKeyResolver(options?: ForeignKeyResolverOptions): ForeignKeyResolver
+```
+
+### ForeignKeyResolverOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `loader` | `ForeignKeyLoader` | - | Async loader for fetching data |
+| `prefetch` | `boolean` | `false` | Enable automatic FK prefetching |
+| `prefetchDepth` | `1` | `1` | How deep to prefetch (currently only 1) |
+| `reactivity` | `ReactivityAdapter` | - | MobX adapter for observability |
+
+### ForeignKeyLoader Interface
+
+```typescript
+interface ForeignKeyLoader {
+  loadSchema(tableId: string): Promise<JsonObjectSchema>;
+  loadTable(tableId: string): Promise<ForeignKeyLoaderResult>;
+  loadRow(tableId: string, rowId: string): Promise<ForeignKeyRowLoaderResult>;
+}
+```
+
+### ForeignKeyResolver Interface
+
+```typescript
+interface ForeignKeyResolver {
+  // Cache management
+  addSchema(tableId: string, schema: JsonObjectSchema): void;
+  addTable(tableId: string, schema: JsonObjectSchema, rows: RowData[]): void;
+  addRow(tableId: string, rowId: string, data: unknown): void;
+
+  // Data retrieval (async, uses cache or loader)
+  getSchema(tableId: string): Promise<JsonObjectSchema>;
+  getRowData(tableId: string, rowId: string): Promise<RowData>;
+
+  // Loading state
+  isLoading(tableId: string): boolean;
+  isLoadingRow(tableId: string, rowId: string): boolean;
+
+  // Cache checks (sync)
+  hasSchema(tableId: string): boolean;
+  hasTable(tableId: string): boolean;
+  hasRow(tableId: string, rowId: string): boolean;
+
+  // Prefetch control
+  setPrefetch(enabled: boolean): void;
+  readonly isPrefetchEnabled: boolean;
+
+  // Cleanup
+  dispose(): void;
+}
+```
+
+## Error Handling
+
+### ForeignKeyNotFoundError
+
+Thrown when data is not cached and no loader is configured:
+
+```typescript
+try {
+  await resolver.getSchema('unknown');
+} catch (error) {
+  if (error instanceof ForeignKeyNotFoundError) {
+    console.log(error.tableId); // 'unknown'
+    console.log(error.rowId);   // undefined for schema errors
+  }
+}
+```
+
+### ForeignKeyResolverNotConfiguredError
+
+Thrown when attempting to load data without a configured loader:
+
+```typescript
+const resolver = createForeignKeyResolver(); // no loader
+await resolver.getSchema('users'); // throws ForeignKeyNotFoundError
+```
+
+## Prefetch Behavior
+
+When prefetch is enabled:
+
+1. **On addRow**: Scans the row's data for FK fields, triggers background loading
+2. **On addTable**: Scans all rows for FK fields, triggers background loading
+3. **Depth limit**: Only first-level FKs are loaded (no recursive prefetch)
+4. **Error handling**: Prefetch errors are silently ignored
+5. **Non-blocking**: addRow/addTable return immediately, loading happens in background
+
+## Flow Diagrams
+
+### getSchema Flow
+
+```
+getSchema('categories')
+    │
+    ├─→ hasSchema? → return cached
+    │
+    ├─→ hasTable? → return table.schema
+    │
+    └─→ loader.loadSchema('categories')
+            │
+            ├─→ addSchema (cache)
+            │
+            └─→ return schema
+```
+
+### getRowData Flow
+
+```
+getRowData('categories', 'cat-1')
+    │
+    ├─→ hasRow? → return cached
+    │
+    └─→ loader.loadRow('categories', 'cat-1')
+            │
+            ├─→ addSchema (from response)
+            ├─→ ensureTableCache
+            ├─→ addRow (cache)
+            │
+            └─→ return row
+```
+
+### Prefetch Flow
+
+```
+prefetch: true
+
+addRow('products', 'prod-1', { categoryId: 'cat-1' })
+    │
+    ├─→ scan FK fields in schema
+    │       categoryId → foreignKey: 'categories'
+    │
+    └─→ background: getRowData('categories', 'cat-1')
+            └─→ loads, does NOT recursively prefetch
+```

--- a/src/model/foreign-key-resolver/README.md
+++ b/src/model/foreign-key-resolver/README.md
@@ -194,8 +194,10 @@ Thrown when attempting to load data without a configured loader:
 
 ```typescript
 const resolver = createForeignKeyResolver(); // no loader
-await resolver.getSchema('users'); // throws ForeignKeyNotFoundError
+await resolver.getSchema('users'); // throws ForeignKeyNotFoundError (no cached data, no loader)
 ```
+
+Note: When no loader is configured and data is not in cache, `ForeignKeyNotFoundError` is thrown. `ForeignKeyResolverNotConfiguredError` is thrown internally when loader methods are called without a loader.
 
 ## Prefetch Behavior
 
@@ -211,7 +213,7 @@ When prefetch is enabled:
 
 ### getSchema Flow
 
-```
+```text
 getSchema('categories')
     │
     ├─→ hasSchema? → return cached
@@ -227,7 +229,7 @@ getSchema('categories')
 
 ### getRowData Flow
 
-```
+```text
 getRowData('categories', 'cat-1')
     │
     ├─→ hasRow? → return cached
@@ -243,7 +245,7 @@ getRowData('categories', 'cat-1')
 
 ### Prefetch Flow
 
-```
+```text
 prefetch: true
 
 addRow('products', 'prod-1', { categoryId: 'cat-1' })

--- a/src/model/foreign-key-resolver/README.md
+++ b/src/model/foreign-key-resolver/README.md
@@ -175,9 +175,11 @@ interface ForeignKeyResolver {
 
 ### ForeignKeyNotFoundError
 
-Thrown when data is not cached and no loader is configured:
+Thrown when data is not in cache and no loader is configured:
 
 ```typescript
+const resolver = createForeignKeyResolver(); // no loader
+
 try {
   await resolver.getSchema('unknown');
 } catch (error) {
@@ -186,16 +188,19 @@ try {
     console.log(error.rowId);   // undefined for schema errors
   }
 }
+
+// Also thrown for row lookups
+await resolver.getRowData('users', 'user-1'); // throws ForeignKeyNotFoundError
 ```
 
-### ForeignKeyNotFoundError
+### ForeignKeyResolverNotConfiguredError
 
-Thrown when data is not in cache and no loader is configured:
+Thrown internally when loader methods are called without a configured loader. This is an internal error that should not normally be seen by consumers - if you see it, there's likely a bug in the resolver implementation.
 
 ```typescript
-const resolver = createForeignKeyResolver(); // no loader
-await resolver.getSchema('users'); // throws ForeignKeyNotFoundError
-await resolver.getRowData('users', 'user-1'); // throws ForeignKeyNotFoundError
+import { ForeignKeyResolverNotConfiguredError } from 'schema-toolkit/model';
+
+// This error indicates internal misconfiguration
 ```
 
 ## Prefetch Behavior

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { createForeignKeyResolver } from '../ForeignKeyResolverImpl.js';
+import type { ForeignKeyLoader, RowData } from '../types.js';
+
+const createCategorySchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+  },
+});
+
+const createProductSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'categoryId'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
+  },
+});
+
+const createProductWithMultipleFKSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name', 'categoryId', 'brandId'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
+    brandId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'brands' },
+  },
+});
+
+function createMockLoader(
+  rowHandler?: (tableId: string, rowId: string) => Promise<{ schema: JsonObjectSchema; row: RowData }>,
+): ForeignKeyLoader & {
+  loadRowCalls: Array<{ tableId: string; rowId: string }>;
+  loadRowCallCount: number;
+} {
+  const loader = {
+    loadRowCalls: [] as Array<{ tableId: string; rowId: string }>,
+    loadRowCallCount: 0,
+    loadSchema: async () => {
+      throw new Error('loadSchema not implemented');
+    },
+    loadTable: async () => {
+      throw new Error('loadTable not implemented');
+    },
+    loadRow: async (tableId: string, rowId: string) => {
+      loader.loadRowCalls.push({ tableId, rowId });
+      loader.loadRowCallCount++;
+      if (rowHandler) {
+        return rowHandler(tableId, rowId);
+      }
+      throw new Error('loadRow not implemented');
+    },
+  };
+  return loader;
+}
+
+describe('ForeignKeyResolver prefetch', () => {
+  let mockLoader: ReturnType<typeof createMockLoader>;
+  const categorySchema = createCategorySchema();
+  const productSchema = createProductSchema();
+
+  beforeEach(() => {
+    mockLoader = createMockLoader();
+  });
+
+  describe('prefetch disabled', () => {
+    it('addRow does not trigger FK loading', () => {
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: false,
+      });
+      resolver.addTable('products', productSchema, []);
+
+      resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+
+    it('addTable does not trigger FK loading', () => {
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: false,
+      });
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+      ]);
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+  });
+
+  describe('prefetch enabled', () => {
+    it('addRow triggers background FK loading', async () => {
+      const categoryRow: RowData = { rowId: 'cat-1', data: { name: 'Electronics' } };
+      mockLoader = createMockLoader(async () => ({ schema: categorySchema, row: categoryRow }));
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+      resolver.addTable('products', productSchema, []);
+
+      resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-1' });
+    });
+
+    it('addTable triggers background FK loading for all rows', async () => {
+      const categoryRow1: RowData = { rowId: 'cat-1', data: { name: 'Electronics' } };
+      const categoryRow2: RowData = { rowId: 'cat-2', data: { name: 'Clothing' } };
+      mockLoader = createMockLoader(async (_tableId, rowId) => {
+        if (rowId === 'cat-1') return { schema: categorySchema, row: categoryRow1 };
+        return { schema: categorySchema, row: categoryRow2 };
+      });
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+        { rowId: 'prod-2', data: { name: 'Shirt', categoryId: 'cat-2' } },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-1' });
+      expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-2' });
+    });
+
+    it('prefetch does not duplicate requests for same FK value', async () => {
+      const categoryRow: RowData = { rowId: 'cat-1', data: { name: 'Electronics' } };
+      mockLoader = createMockLoader(async () => ({ schema: categorySchema, row: categoryRow }));
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+        { rowId: 'prod-2', data: { name: 'iPad', categoryId: 'cat-1' } },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCallCount).toBe(1);
+    });
+
+    it('prefetch skips already cached rows', async () => {
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+      resolver.addTable('categories', categorySchema, [
+        { rowId: 'cat-1', data: { name: 'Electronics' } },
+      ]);
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+
+    it('prefetch handles multiple FK fields', async () => {
+      const brandSchema = createCategorySchema();
+      const categoryRow: RowData = { rowId: 'cat-1', data: { name: 'Electronics' } };
+      const brandRow: RowData = { rowId: 'brand-1', data: { name: 'Apple' } };
+
+      mockLoader = createMockLoader(async (tableId) => {
+        if (tableId === 'categories') {
+          return { schema: categorySchema, row: categoryRow };
+        }
+        return { schema: brandSchema, row: brandRow };
+      });
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      resolver.addTable('products', createProductWithMultipleFKSchema(), [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1', brandId: 'brand-1' } },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-1' });
+      expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'brands', rowId: 'brand-1' });
+    });
+
+    it('prefetch errors are silently ignored', async () => {
+      mockLoader = createMockLoader(async () => {
+        throw new Error('Network error');
+      });
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+      resolver.addTable('products', productSchema, []);
+
+      expect(() => {
+        resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+      }).not.toThrow();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    it('prefetch does not block addRow', () => {
+      let resolvePromise: (result: { schema: JsonObjectSchema; row: RowData }) => void;
+      mockLoader = createMockLoader(
+        () =>
+          new Promise((resolve) => {
+            resolvePromise = resolve;
+          }),
+      );
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+      resolver.addTable('products', productSchema, []);
+
+      const start = Date.now();
+      resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+      const duration = Date.now() - start;
+
+      expect(duration).toBeLessThan(50);
+      expect(resolver.hasRow('products', 'prod-1')).toBe(true);
+
+      resolvePromise!({
+        schema: categorySchema,
+        row: { rowId: 'cat-1', data: { name: 'Electronics' } },
+      });
+    });
+
+    it('prefetch does not block addTable', () => {
+      let resolvePromise: (result: { schema: JsonObjectSchema; row: RowData }) => void;
+      mockLoader = createMockLoader(
+        () =>
+          new Promise((resolve) => {
+            resolvePromise = resolve;
+          }),
+      );
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      const start = Date.now();
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+      ]);
+      const duration = Date.now() - start;
+
+      expect(duration).toBeLessThan(50);
+      expect(resolver.hasTable('products')).toBe(true);
+
+      resolvePromise!({
+        schema: categorySchema,
+        row: { rowId: 'cat-1', data: { name: 'Electronics' } },
+      });
+    });
+
+    it('prefetch skips empty FK values', async () => {
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: '' } },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+
+    it('prefetch skips null FK values', async () => {
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: null } },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+  });
+
+  describe('setPrefetch runtime control', () => {
+    it('enabling prefetch at runtime triggers on next addRow', async () => {
+      const categoryRow: RowData = { rowId: 'cat-1', data: { name: 'Electronics' } };
+      mockLoader = createMockLoader(async () => ({ schema: categorySchema, row: categoryRow }));
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: false,
+      });
+      resolver.addTable('products', productSchema, []);
+
+      resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(mockLoader.loadRowCallCount).toBe(0);
+
+      resolver.setPrefetch(true);
+      resolver.addRow('products', 'prod-2', { name: 'iPad', categoryId: 'cat-2' });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-2' });
+    });
+
+    it('disabling prefetch stops automatic loading', async () => {
+      const categoryRow: RowData = { rowId: 'cat-1', data: { name: 'Electronics' } };
+      mockLoader = createMockLoader(async () => ({ schema: categorySchema, row: categoryRow }));
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+      resolver.addTable('products', productSchema, []);
+
+      resolver.setPrefetch(false);
+      resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+  });
+});

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
@@ -60,6 +60,10 @@ function createMockLoader(
   return loader;
 }
 
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 describe('ForeignKeyResolver prefetch', () => {
   let mockLoader: ReturnType<typeof createMockLoader>;
   const categorySchema = createCategorySchema();
@@ -109,7 +113,7 @@ describe('ForeignKeyResolver prefetch', () => {
 
       resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-1' });
     });
@@ -132,7 +136,7 @@ describe('ForeignKeyResolver prefetch', () => {
         { rowId: 'prod-2', data: { name: 'Shirt', categoryId: 'cat-2' } },
       ]);
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-1' });
       expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-2' });
@@ -152,7 +156,7 @@ describe('ForeignKeyResolver prefetch', () => {
         { rowId: 'prod-2', data: { name: 'iPad', categoryId: 'cat-1' } },
       ]);
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCallCount).toBe(1);
     });
@@ -170,7 +174,7 @@ describe('ForeignKeyResolver prefetch', () => {
         { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
       ]);
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCallCount).toBe(0);
     });
@@ -196,7 +200,7 @@ describe('ForeignKeyResolver prefetch', () => {
         { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1', brandId: 'brand-1' } },
       ]);
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-1' });
       expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'brands', rowId: 'brand-1' });
@@ -217,7 +221,7 @@ describe('ForeignKeyResolver prefetch', () => {
         resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
       }).not.toThrow();
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
     });
 
     it('prefetch does not block addRow', () => {
@@ -235,11 +239,8 @@ describe('ForeignKeyResolver prefetch', () => {
       });
       resolver.addTable('products', productSchema, []);
 
-      const start = Date.now();
       resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
-      const duration = Date.now() - start;
 
-      expect(duration).toBeLessThan(50);
       expect(resolver.hasRow('products', 'prod-1')).toBe(true);
 
       resolvePromise!({
@@ -262,13 +263,10 @@ describe('ForeignKeyResolver prefetch', () => {
         prefetch: true,
       });
 
-      const start = Date.now();
       resolver.addTable('products', productSchema, [
         { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
       ]);
-      const duration = Date.now() - start;
 
-      expect(duration).toBeLessThan(50);
       expect(resolver.hasTable('products')).toBe(true);
 
       resolvePromise!({
@@ -287,7 +285,7 @@ describe('ForeignKeyResolver prefetch', () => {
         { rowId: 'prod-1', data: { name: 'iPhone', categoryId: '' } },
       ]);
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCallCount).toBe(0);
     });
@@ -302,7 +300,7 @@ describe('ForeignKeyResolver prefetch', () => {
         { rowId: 'prod-1', data: { name: 'iPhone', categoryId: null } },
       ]);
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCallCount).toBe(0);
     });
@@ -320,12 +318,12 @@ describe('ForeignKeyResolver prefetch', () => {
       resolver.addTable('products', productSchema, []);
 
       resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
       expect(mockLoader.loadRowCallCount).toBe(0);
 
       resolver.setPrefetch(true);
       resolver.addRow('products', 'prod-2', { name: 'iPad', categoryId: 'cat-2' });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCalls).toContainEqual({ tableId: 'categories', rowId: 'cat-2' });
     });
@@ -343,7 +341,7 @@ describe('ForeignKeyResolver prefetch', () => {
       resolver.setPrefetch(false);
       resolver.addRow('products', 'prod-1', { name: 'iPhone', categoryId: 'cat-1' });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       expect(mockLoader.loadRowCallCount).toBe(0);
     });

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect } from '@jest/globals';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { createForeignKeyResolver } from '../ForeignKeyResolverImpl.js';
+import { ForeignKeyNotFoundError } from '../errors.js';
+import type { ForeignKeyLoader, RowData } from '../types.js';
+
+const createSimpleSchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+  },
+});
+
+function createMockLoader(overrides: Partial<ForeignKeyLoader> = {}): ForeignKeyLoader & {
+  loadSchemaCallCount: number;
+  loadTableCallCount: number;
+  loadRowCallCount: number;
+  loadRowCalls: Array<{ tableId: string; rowId: string }>;
+} {
+  const loader = {
+    loadSchemaCallCount: 0,
+    loadTableCallCount: 0,
+    loadRowCallCount: 0,
+    loadRowCalls: [] as Array<{ tableId: string; rowId: string }>,
+    loadSchema: async (tableId: string) => {
+      loader.loadSchemaCallCount++;
+      if (overrides.loadSchema) {
+        return overrides.loadSchema(tableId);
+      }
+      throw new Error('loadSchema not implemented');
+    },
+    loadTable: async (tableId: string) => {
+      loader.loadTableCallCount++;
+      if (overrides.loadTable) {
+        return overrides.loadTable(tableId);
+      }
+      throw new Error('loadTable not implemented');
+    },
+    loadRow: async (tableId: string, rowId: string) => {
+      loader.loadRowCallCount++;
+      loader.loadRowCalls.push({ tableId, rowId });
+      if (overrides.loadRow) {
+        return overrides.loadRow(tableId, rowId);
+      }
+      throw new Error('loadRow not implemented');
+    },
+  };
+  return loader;
+}
+
+describe('ForeignKeyResolver', () => {
+  describe('without loader (cache only)', () => {
+    it('addSchema stores schema in cache', () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+
+      resolver.addSchema('users', schema);
+
+      expect(resolver.hasSchema('users')).toBe(true);
+    });
+
+    it('getSchema returns cached schema', async () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+
+      resolver.addSchema('users', schema);
+
+      const result = await resolver.getSchema('users');
+      expect(result).toBe(schema);
+    });
+
+    it('addTable stores table with schema and rows', () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+      const rows: RowData[] = [
+        { rowId: 'row-1', data: { name: 'John' } },
+        { rowId: 'row-2', data: { name: 'Jane' } },
+      ];
+
+      resolver.addTable('users', schema, rows);
+
+      expect(resolver.hasTable('users')).toBe(true);
+      expect(resolver.hasSchema('users')).toBe(true);
+      expect(resolver.hasRow('users', 'row-1')).toBe(true);
+      expect(resolver.hasRow('users', 'row-2')).toBe(true);
+    });
+
+    it('addRow adds row to existing table', () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+
+      resolver.addTable('users', schema, []);
+      resolver.addRow('users', 'row-1', { name: 'John' });
+
+      expect(resolver.hasRow('users', 'row-1')).toBe(true);
+    });
+
+    it('addRow does nothing if table not cached', () => {
+      const resolver = createForeignKeyResolver();
+
+      resolver.addRow('users', 'row-1', { name: 'John' });
+
+      expect(resolver.hasRow('users', 'row-1')).toBe(false);
+    });
+
+    it('getSchema throws ForeignKeyNotFoundError when not cached', async () => {
+      const resolver = createForeignKeyResolver();
+
+      await expect(resolver.getSchema('unknown')).rejects.toThrow(ForeignKeyNotFoundError);
+      await expect(resolver.getSchema('unknown')).rejects.toThrow(
+        'Foreign key table not found: unknown',
+      );
+    });
+
+    it('getRowData throws ForeignKeyNotFoundError when not cached', async () => {
+      const resolver = createForeignKeyResolver();
+
+      await expect(resolver.getRowData('unknown', 'row-1')).rejects.toThrow(ForeignKeyNotFoundError);
+      await expect(resolver.getRowData('unknown', 'row-1')).rejects.toThrow(
+        'Foreign key row not found: unknown/row-1',
+      );
+    });
+
+    it('getRowData returns cached row', async () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+
+      resolver.addTable('users', schema, [{ rowId: 'row-1', data: { name: 'John' } }]);
+
+      const result = await resolver.getRowData('users', 'row-1');
+      expect(result.rowId).toBe('row-1');
+      expect(result.data).toEqual({ name: 'John' });
+    });
+
+    it('hasSchema returns false for unknown table', () => {
+      const resolver = createForeignKeyResolver();
+
+      expect(resolver.hasSchema('unknown')).toBe(false);
+    });
+
+    it('hasTable returns false for unknown table', () => {
+      const resolver = createForeignKeyResolver();
+
+      expect(resolver.hasTable('unknown')).toBe(false);
+    });
+
+    it('hasRow returns false for unknown table', () => {
+      const resolver = createForeignKeyResolver();
+
+      expect(resolver.hasRow('unknown', 'row-1')).toBe(false);
+    });
+
+    it('hasRow returns false for unknown row in known table', () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+
+      resolver.addTable('users', schema, []);
+
+      expect(resolver.hasRow('users', 'row-1')).toBe(false);
+    });
+  });
+
+  describe('with loader', () => {
+    const usersSchema = createSimpleSchema();
+
+    it('getSchema loads via loader when not cached', async () => {
+      const mockLoader = createMockLoader({
+        loadSchema: async () => usersSchema,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      const result = await resolver.getSchema('users');
+
+      expect(mockLoader.loadSchemaCallCount).toBe(1);
+      expect(result).toBe(usersSchema);
+    });
+
+    it('getSchema caches loaded schema', async () => {
+      const mockLoader = createMockLoader({
+        loadSchema: async () => usersSchema,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      await resolver.getSchema('users');
+      await resolver.getSchema('users');
+
+      expect(mockLoader.loadSchemaCallCount).toBe(1);
+    });
+
+    it('getSchema returns cached schema without calling loader', async () => {
+      const mockLoader = createMockLoader({
+        loadSchema: async () => usersSchema,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+      resolver.addSchema('users', usersSchema);
+
+      const result = await resolver.getSchema('users');
+
+      expect(mockLoader.loadSchemaCallCount).toBe(0);
+      expect(result).toBe(usersSchema);
+    });
+
+    it('getRowData loads via loader when not cached', async () => {
+      const rowData: RowData = { rowId: 'row-1', data: { name: 'John' } };
+      const mockLoader = createMockLoader({
+        loadRow: async () => ({ schema: usersSchema, row: rowData }),
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      const result = await resolver.getRowData('users', 'row-1');
+
+      expect(mockLoader.loadRowCallCount).toBe(1);
+      expect(mockLoader.loadRowCalls[0]).toEqual({ tableId: 'users', rowId: 'row-1' });
+      expect(result).toEqual(rowData);
+    });
+
+    it('getRowData caches loaded row', async () => {
+      const rowData: RowData = { rowId: 'row-1', data: { name: 'John' } };
+      const mockLoader = createMockLoader({
+        loadRow: async () => ({ schema: usersSchema, row: rowData }),
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      await resolver.getRowData('users', 'row-1');
+      await resolver.getRowData('users', 'row-1');
+
+      expect(mockLoader.loadRowCallCount).toBe(1);
+    });
+
+    it('loadRow automatically adds schema to cache', async () => {
+      const rowData: RowData = { rowId: 'row-1', data: { name: 'John' } };
+      const mockLoader = createMockLoader({
+        loadRow: async () => ({ schema: usersSchema, row: rowData }),
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      await resolver.getRowData('users', 'row-1');
+
+      expect(resolver.hasSchema('users')).toBe(true);
+    });
+
+    it('concurrent getSchema calls share same promise', async () => {
+      let resolvePromise: (schema: JsonObjectSchema) => void;
+      const loadPromise = new Promise<JsonObjectSchema>((resolve) => {
+        resolvePromise = resolve;
+      });
+      const mockLoader = createMockLoader({
+        loadSchema: () => loadPromise,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      const promise1 = resolver.getSchema('users');
+      const promise2 = resolver.getSchema('users');
+
+      resolvePromise!(usersSchema);
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      expect(mockLoader.loadSchemaCallCount).toBe(1);
+      expect(result1).toBe(result2);
+    });
+
+    it('concurrent getRowData calls share same promise', async () => {
+      const rowData: RowData = { rowId: 'row-1', data: { name: 'John' } };
+      let resolvePromise: (result: { schema: JsonObjectSchema; row: RowData }) => void;
+      const loadPromise = new Promise<{ schema: JsonObjectSchema; row: RowData }>((resolve) => {
+        resolvePromise = resolve;
+      });
+      const mockLoader = createMockLoader({
+        loadRow: () => loadPromise,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      const promise1 = resolver.getRowData('users', 'row-1');
+      const promise2 = resolver.getRowData('users', 'row-1');
+
+      resolvePromise!({ schema: usersSchema, row: rowData });
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      expect(mockLoader.loadRowCallCount).toBe(1);
+      expect(result1).toEqual(result2);
+    });
+  });
+
+  describe('loading state', () => {
+    it('isLoading false initially', () => {
+      const resolver = createForeignKeyResolver();
+
+      expect(resolver.isLoading('users')).toBe(false);
+    });
+
+    it('isLoading true during table load', async () => {
+      let resolvePromise: (schema: JsonObjectSchema) => void;
+      const loadPromise = new Promise<JsonObjectSchema>((resolve) => {
+        resolvePromise = resolve;
+      });
+      const mockLoader = createMockLoader({
+        loadSchema: () => loadPromise,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+      const schemaPromise = resolver.getSchema('users');
+
+      expect(resolver.isLoading('users')).toBe(true);
+
+      resolvePromise!(createSimpleSchema());
+      await schemaPromise;
+
+      expect(resolver.isLoading('users')).toBe(false);
+    });
+
+    it('isLoadingRow false initially', () => {
+      const resolver = createForeignKeyResolver();
+
+      expect(resolver.isLoadingRow('users', 'row-1')).toBe(false);
+    });
+
+    it('isLoadingRow true during row load', async () => {
+      let resolvePromise: (result: { schema: JsonObjectSchema; row: RowData }) => void;
+      const loadPromise = new Promise<{ schema: JsonObjectSchema; row: RowData }>((resolve) => {
+        resolvePromise = resolve;
+      });
+      const mockLoader = createMockLoader({
+        loadRow: () => loadPromise,
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+      const rowPromise = resolver.getRowData('users', 'row-1');
+
+      expect(resolver.isLoadingRow('users', 'row-1')).toBe(true);
+
+      resolvePromise!({
+        schema: createSimpleSchema(),
+        row: { rowId: 'row-1', data: { name: 'John' } },
+      });
+      await rowPromise;
+
+      expect(resolver.isLoadingRow('users', 'row-1')).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('loader error propagates from getSchema', async () => {
+      const mockLoader = createMockLoader({
+        loadSchema: async () => {
+          throw new Error('Network error');
+        },
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      await expect(resolver.getSchema('users')).rejects.toThrow('Network error');
+    });
+
+    it('loader error propagates from getRowData', async () => {
+      const mockLoader = createMockLoader({
+        loadRow: async () => {
+          throw new Error('Network error');
+        },
+      });
+      const resolver = createForeignKeyResolver({ loader: mockLoader });
+
+      await expect(resolver.getRowData('users', 'row-1')).rejects.toThrow('Network error');
+    });
+
+    it('ForeignKeyNotFoundError contains tableId', () => {
+      const error = new ForeignKeyNotFoundError('users');
+
+      expect(error.tableId).toBe('users');
+      expect(error.rowId).toBeUndefined();
+    });
+
+    it('ForeignKeyNotFoundError contains tableId and rowId', () => {
+      const error = new ForeignKeyNotFoundError('users', 'row-1');
+
+      expect(error.tableId).toBe('users');
+      expect(error.rowId).toBe('row-1');
+    });
+  });
+
+  describe('dispose', () => {
+    it('dispose clears cache', () => {
+      const resolver = createForeignKeyResolver();
+      resolver.addSchema('users', createSimpleSchema());
+      resolver.addTable('products', createSimpleSchema(), [{ rowId: 'p-1', data: {} }]);
+
+      resolver.dispose();
+
+      expect(resolver.hasSchema('users')).toBe(false);
+      expect(resolver.hasTable('products')).toBe(false);
+    });
+
+    it('dispose prevents new additions', () => {
+      const resolver = createForeignKeyResolver();
+
+      resolver.dispose();
+      resolver.addSchema('users', createSimpleSchema());
+
+      expect(resolver.hasSchema('users')).toBe(false);
+    });
+  });
+
+  describe('prefetch control', () => {
+    it('prefetch disabled by default', () => {
+      const resolver = createForeignKeyResolver();
+
+      expect(resolver.isPrefetchEnabled).toBe(false);
+    });
+
+    it('prefetch can be enabled via options', () => {
+      const resolver = createForeignKeyResolver({ prefetch: true });
+
+      expect(resolver.isPrefetchEnabled).toBe(true);
+    });
+
+    it('setPrefetch enables prefetch at runtime', () => {
+      const resolver = createForeignKeyResolver();
+
+      resolver.setPrefetch(true);
+
+      expect(resolver.isPrefetchEnabled).toBe(true);
+    });
+
+    it('setPrefetch disables prefetch at runtime', () => {
+      const resolver = createForeignKeyResolver({ prefetch: true });
+
+      resolver.setPrefetch(false);
+
+      expect(resolver.isPrefetchEnabled).toBe(false);
+    });
+  });
+});

--- a/src/model/foreign-key-resolver/errors.ts
+++ b/src/model/foreign-key-resolver/errors.ts
@@ -1,0 +1,19 @@
+export class ForeignKeyNotFoundError extends Error {
+  constructor(
+    public readonly tableId: string,
+    public readonly rowId?: string,
+  ) {
+    const message = rowId
+      ? `Foreign key row not found: ${tableId}/${rowId}`
+      : `Foreign key table not found: ${tableId}`;
+    super(message);
+    this.name = 'ForeignKeyNotFoundError';
+  }
+}
+
+export class ForeignKeyResolverNotConfiguredError extends Error {
+  constructor() {
+    super('ForeignKeyResolver is not configured with a loader');
+    this.name = 'ForeignKeyResolverNotConfiguredError';
+  }
+}

--- a/src/model/foreign-key-resolver/index.ts
+++ b/src/model/foreign-key-resolver/index.ts
@@ -1,0 +1,13 @@
+export type { ForeignKeyResolver } from './ForeignKeyResolver.js';
+export { ForeignKeyResolverImpl, createForeignKeyResolver } from './ForeignKeyResolverImpl.js';
+export type {
+  RowData,
+  ForeignKeyLoader,
+  ForeignKeyLoaderResult,
+  ForeignKeyRowLoaderResult,
+  ForeignKeyResolverOptions,
+} from './types.js';
+export {
+  ForeignKeyNotFoundError,
+  ForeignKeyResolverNotConfiguredError,
+} from './errors.js';

--- a/src/model/foreign-key-resolver/types.ts
+++ b/src/model/foreign-key-resolver/types.ts
@@ -1,0 +1,35 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
+import type { RowData } from '../table/types.js';
+
+export type { RowData };
+
+export interface ForeignKeyLoaderResult {
+  schema: JsonObjectSchema;
+  rows: RowData[];
+}
+
+export interface ForeignKeyRowLoaderResult {
+  schema: JsonObjectSchema;
+  row: RowData;
+}
+
+export interface ForeignKeyLoader {
+  loadSchema(tableId: string): Promise<JsonObjectSchema>;
+  loadTable(tableId: string): Promise<ForeignKeyLoaderResult>;
+  loadRow(tableId: string, rowId: string): Promise<ForeignKeyRowLoaderResult>;
+}
+
+export interface ForeignKeyResolverOptions {
+  reactivity?: ReactivityAdapter;
+  loader?: ForeignKeyLoader;
+  prefetch?: boolean;
+  prefetchDepth?: 1;
+}
+
+export interface ForeignKeyTableCache {
+  schema: JsonObjectSchema;
+  rows: Map<string, RowData>;
+}
+
+export type ForeignKeySchemaExtractor = (schema: JsonSchema) => string[];

--- a/src/model/foreign-key-resolver/types.ts
+++ b/src/model/foreign-key-resolver/types.ts
@@ -2,7 +2,7 @@ import type { ReactivityAdapter } from '../../core/reactivity/types.js';
 import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
 import type { RowData } from '../table/types.js';
 
-export type { RowData };
+export type { RowData } from '../table/types.js';
 
 export interface ForeignKeyLoaderResult {
   schema: JsonObjectSchema;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -3,3 +3,42 @@ export * from './value/index.js';
 export * from './schema-model/index.js';
 export * from './table/index.js';
 export * from './default-value/index.js';
+export * from './foreign-key-resolver/index.js';
+export * from './data-model/index.js';
+
+export {
+  ValueType,
+  extractFormulaDefinition,
+  BaseValueNode,
+  generateNodeId,
+  resetNodeIdCounter,
+  BasePrimitiveValueNode,
+  StringValueNode,
+  NumberValueNode,
+  BooleanValueNode,
+  ObjectValueNode,
+  ArrayValueNode,
+  ForeignKeyValueNodeImpl,
+  isForeignKeyValueNode,
+  NodeFactoryRegistry,
+  createNodeFactory,
+  createDefaultRegistry,
+} from './value-node/index.js';
+export type {
+  ValueNode,
+  PrimitiveValueNode,
+  ObjectValueNodeInterface,
+  ArrayValueNodeInterface,
+  DirtyTrackable,
+  FormulaDefinition,
+  FormulaWarning,
+  ValueNodeOptions,
+  PrimitiveNodeOptions,
+  ObjectNodeOptions,
+  ArrayNodeOptions,
+  ForeignKeyValueNode,
+  NodeFactoryFn,
+  NodeFactoryOptions,
+  RefSchemas,
+} from './value-node/index.js';
+export { NodeFactory as ValueNodeFactory } from './value-node/index.js';

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -2,6 +2,7 @@ import type { ReactivityAdapter } from '../../core/reactivity/types.js';
 import type { AnnotationsMap } from '../../core/types/index.js';
 import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
 import { generateDefaultValue } from '../default-value/index.js';
+import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
 import { createSchemaModel } from '../schema-model/SchemaModelImpl.js';
 import type { SchemaModel } from '../schema-model/types.js';
 import { createNodeFactory } from '../value-node/NodeFactory.js';
@@ -17,6 +18,7 @@ export class TableModelImpl implements TableModel {
   private readonly _rows: RowModel[];
   private readonly _jsonSchema: JsonObjectSchema;
   private readonly _reactivity: ReactivityAdapter | undefined;
+  private readonly _fkResolver: ForeignKeyResolver | undefined;
 
   constructor(options: TableModelOptions, reactivity?: ReactivityAdapter) {
     this._tableId = options.tableId;
@@ -24,6 +26,7 @@ export class TableModelImpl implements TableModel {
     this._jsonSchema = options.schema;
     this._schema = createSchemaModel(options.schema, { reactivity });
     this._reactivity = reactivity;
+    this._fkResolver = options.fkResolver;
     this._rows = reactivity?.observableArray() ?? [];
 
     if (options.rows) {
@@ -63,6 +66,10 @@ export class TableModelImpl implements TableModel {
 
   get isRenamed(): boolean {
     return this._tableId !== this._baseTableId;
+  }
+
+  get fk(): ForeignKeyResolver | undefined {
+    return this._fkResolver;
   }
 
   get schema(): SchemaModel {
@@ -150,7 +157,10 @@ export class TableModelImpl implements TableModel {
   }
 
   private createRowModel(rowId: string, data?: unknown): RowModel {
-    const factory = createNodeFactory({ reactivity: this._reactivity });
+    const factory = createNodeFactory({
+      reactivity: this._reactivity,
+      fkResolver: this._fkResolver,
+    });
     const rowData = data ?? generateDefaultValue(this._jsonSchema);
     const rootNode = factory.createTree(this._jsonSchema as JsonSchema, rowData);
     const valueTree = new ValueTree(rootNode, this._reactivity);

--- a/src/model/table/types.ts
+++ b/src/model/table/types.ts
@@ -1,5 +1,6 @@
 import type { SchemaModel } from '../schema-model/types.js';
 import type { JsonObjectSchema } from '../../types/schema.types.js';
+import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
 import type { RowModel } from './row/types.js';
 
 export interface RowData {
@@ -11,9 +12,11 @@ export interface TableModelOptions {
   tableId: string;
   schema: JsonObjectSchema;
   rows?: RowData[];
+  fkResolver?: ForeignKeyResolver;
 }
 
 export interface TableModel {
+  readonly fk: ForeignKeyResolver | undefined;
   readonly tableId: string;
   readonly baseTableId: string;
   readonly isRenamed: boolean;

--- a/src/model/value-node/ForeignKeyValueNode.ts
+++ b/src/model/value-node/ForeignKeyValueNode.ts
@@ -1,0 +1,84 @@
+import type { ReactivityAdapter } from '../../core/reactivity/types.js';
+import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
+import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
+import type { RowData } from '../foreign-key-resolver/types.js';
+import {
+  ForeignKeyNotFoundError,
+  ForeignKeyResolverNotConfiguredError,
+} from '../foreign-key-resolver/errors.js';
+import { StringValueNode } from './StringValueNode.js';
+import type { ValueNode } from './types.js';
+
+export interface ForeignKeyValueNode extends ValueNode {
+  readonly value: string;
+  readonly foreignKey: string;
+
+  getRow(): Promise<RowData>;
+  getSchema(): Promise<JsonObjectSchema>;
+
+  readonly isLoading: boolean;
+}
+
+export function isForeignKeyValueNode(node: ValueNode): node is ForeignKeyValueNode {
+  return (
+    node instanceof ForeignKeyValueNodeImpl ||
+    ('foreignKey' in node && typeof (node as ForeignKeyValueNode).foreignKey === 'string')
+  );
+}
+
+export class ForeignKeyValueNodeImpl extends StringValueNode implements ForeignKeyValueNode {
+  private readonly _foreignKey: string;
+
+  constructor(
+    id: string | undefined,
+    name: string,
+    schema: JsonSchema,
+    value?: string,
+    reactivity?: ReactivityAdapter,
+    private readonly fkResolver?: ForeignKeyResolver,
+  ) {
+    super(id, name, schema, value, reactivity);
+
+    const schemaFk =
+      'foreignKey' in schema && typeof schema.foreignKey === 'string'
+        ? schema.foreignKey
+        : undefined;
+
+    if (!schemaFk) {
+      throw new Error('ForeignKeyValueNode requires a schema with foreignKey property');
+    }
+
+    this._foreignKey = schemaFk;
+  }
+
+  get foreignKey(): string {
+    return this._foreignKey;
+  }
+
+  get isLoading(): boolean {
+    if (!this.fkResolver) {
+      return false;
+    }
+    return this.fkResolver.isLoadingRow(this._foreignKey, this._value);
+  }
+
+  async getRow(): Promise<RowData> {
+    if (!this.fkResolver) {
+      throw new ForeignKeyResolverNotConfiguredError();
+    }
+
+    if (!this._value) {
+      throw new ForeignKeyNotFoundError(this._foreignKey, this._value);
+    }
+
+    return this.fkResolver.getRowData(this._foreignKey, this._value);
+  }
+
+  async getSchema(): Promise<JsonObjectSchema> {
+    if (!this.fkResolver) {
+      throw new ForeignKeyResolverNotConfiguredError();
+    }
+
+    return this.fkResolver.getSchema(this._foreignKey);
+  }
+}

--- a/src/model/value-node/ForeignKeyValueNode.ts
+++ b/src/model/value-node/ForeignKeyValueNode.ts
@@ -56,7 +56,7 @@ export class ForeignKeyValueNodeImpl extends StringValueNode implements ForeignK
   }
 
   get isLoading(): boolean {
-    if (!this.fkResolver) {
+    if (!this.fkResolver || !this._value) {
       return false;
     }
     return this.fkResolver.isLoadingRow(this._foreignKey, this._value);

--- a/src/model/value-node/README.md
+++ b/src/model/value-node/README.md
@@ -366,25 +366,29 @@ const schema = {
 
 const root = factory.createTree(schema, { name: 'iPhone', categoryId: 'cat-1' });
 
-if (root.isObject()) {
-  const categoryNode = root.child('categoryId');
+async function resolveForeignKey() {
+  if (root.isObject()) {
+    const categoryNode = root.child('categoryId');
 
-  // Check if it's a FK node
-  if (categoryNode && isForeignKeyValueNode(categoryNode)) {
-    console.log(categoryNode.foreignKey); // 'categories'
-    console.log(categoryNode.value);      // 'cat-1'
+    // Check if it's a FK node
+    if (categoryNode && isForeignKeyValueNode(categoryNode)) {
+      console.log(categoryNode.foreignKey); // 'categories'
+      console.log(categoryNode.value);      // 'cat-1'
 
-    // Resolve the referenced row
-    const row = await categoryNode.getRow();
-    console.log(row.data); // { name: 'Electronics' }
+      // Resolve the referenced row
+      const row = await categoryNode.getRow();
+      console.log(row.data); // { name: 'Electronics' }
 
-    // Get the target table schema
-    const targetSchema = await categoryNode.getSchema();
+      // Get the target table schema
+      const targetSchema = await categoryNode.getSchema();
 
-    // Check loading state
-    console.log(categoryNode.isLoading); // false (already cached)
+      // Check loading state
+      console.log(categoryNode.isLoading); // false (already cached)
+    }
   }
 }
+
+resolveForeignKey();
 ```
 
 ## Dependencies

--- a/src/model/value-node/README.md
+++ b/src/model/value-node/README.md
@@ -23,6 +23,7 @@ The `value-node` module provides a tree-based representation of JSON values that
 │      │       │                                                  │
 │      │       ├── BasePrimitiveValueNode<T>                      │
 │      │       │       ├── StringValueNode                        │
+│      │       │       │       └── ForeignKeyValueNodeImpl        │
 │      │       │       ├── NumberValueNode                        │
 │      │       │       └── BooleanValueNode                       │
 │      │       │                                                  │
@@ -107,6 +108,23 @@ interface PrimitiveValueNode extends ValueNode, DirtyTrackable {
 }
 ```
 
+### ForeignKeyValueNode
+
+```typescript
+interface ForeignKeyValueNode extends ValueNode {
+  readonly value: string;
+  readonly foreignKey: string;
+
+  getRow(): Promise<RowData>;
+  getSchema(): Promise<JsonObjectSchema>;
+
+  readonly isLoading: boolean;
+}
+
+// Type guard
+function isForeignKeyValueNode(node: ValueNode): node is ForeignKeyValueNode;
+```
+
 ### ObjectValueNode
 
 ```typescript
@@ -148,8 +166,9 @@ interface ArrayValueNode extends ValueNode, DirtyTrackable {
 function createNodeFactory(options?: NodeFactoryOptions): NodeFactory;
 
 interface NodeFactoryOptions {
-  refSchemas?: RefSchemas;     // For resolving $ref schemas
-  reactivity?: ReactivityAdapter;  // For reactive updates
+  refSchemas?: RefSchemas;          // For resolving $ref schemas
+  reactivity?: ReactivityAdapter;   // For reactive updates
+  fkResolver?: ForeignKeyResolver;  // For FK field resolution
 }
 
 class NodeFactory {
@@ -318,6 +337,56 @@ if (root.isArray()) {
 }
 ```
 
+### Foreign Key Fields
+
+```typescript
+import { createNodeFactory, isForeignKeyValueNode } from '@revisium/schema-toolkit/model/value-node';
+import { createForeignKeyResolver } from '@revisium/schema-toolkit/model/foreign-key-resolver';
+import { JsonSchemaTypeName } from '@revisium/schema-toolkit/types';
+
+// Create FK resolver with data
+const fkResolver = createForeignKeyResolver();
+fkResolver.addTable('categories', categorySchema, [
+  { rowId: 'cat-1', data: { name: 'Electronics' } },
+  { rowId: 'cat-2', data: { name: 'Books' } },
+]);
+
+// Create factory with FK resolver
+const factory = createNodeFactory({ fkResolver });
+
+const schema = {
+  type: JsonSchemaTypeName.Object,
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
+  },
+  additionalProperties: false,
+  required: ['name', 'categoryId'],
+};
+
+const root = factory.createTree(schema, { name: 'iPhone', categoryId: 'cat-1' });
+
+if (root.isObject()) {
+  const categoryNode = root.child('categoryId');
+
+  // Check if it's a FK node
+  if (categoryNode && isForeignKeyValueNode(categoryNode)) {
+    console.log(categoryNode.foreignKey); // 'categories'
+    console.log(categoryNode.value);      // 'cat-1'
+
+    // Resolve the referenced row
+    const row = await categoryNode.getRow();
+    console.log(row.data); // { name: 'Electronics' }
+
+    // Get the target table schema
+    const targetSchema = await categoryNode.getSchema();
+
+    // Check loading state
+    console.log(categoryNode.isLoading); // false (already cached)
+  }
+}
+```
+
 ## Dependencies
 
 ### Internal
@@ -339,3 +408,5 @@ npm test -- src/model/value-node
 - `schema-model` - Schema tree operations
 - `schema-formula` - Formula parsing and serialization (for `x-formula` support)
 - `value-formula` (PR 2.9) - Runtime formula evaluation for value trees
+- `foreign-key-resolver` - FK caching and resolution for ForeignKeyValueNode
+- `data-model` - Multi-table container with integrated FK resolver

--- a/src/model/value-node/__tests__/ForeignKeyValueNode.spec.ts
+++ b/src/model/value-node/__tests__/ForeignKeyValueNode.spec.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  JsonSchemaTypeName,
+  type JsonObjectSchema,
+  type JsonStringSchema,
+} from '../../../types/schema.types.js';
+import { createForeignKeyResolver } from '../../foreign-key-resolver/ForeignKeyResolverImpl.js';
+import {
+  ForeignKeyNotFoundError,
+  ForeignKeyResolverNotConfiguredError,
+} from '../../foreign-key-resolver/errors.js';
+import type { ForeignKeyResolver } from '../../foreign-key-resolver/ForeignKeyResolver.js';
+import {
+  ForeignKeyValueNodeImpl,
+  isForeignKeyValueNode,
+  type ForeignKeyValueNode,
+} from '../ForeignKeyValueNode.js';
+import { StringValueNode } from '../StringValueNode.js';
+
+const createFKSchema = (foreignKey: string): JsonStringSchema => ({
+  type: JsonSchemaTypeName.String,
+  default: '',
+  foreignKey,
+});
+
+const createCategorySchema = (): JsonObjectSchema => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: { type: JsonSchemaTypeName.String, default: '' },
+  },
+});
+
+describe('ForeignKeyValueNode', () => {
+  describe('constructor', () => {
+    it('creates node with foreignKey schema', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      expect(node.foreignKey).toBe('categories');
+      expect(node.value).toBe('cat-1');
+    });
+
+    it('throws if schema has no foreignKey property', () => {
+      const schema: JsonStringSchema = { type: JsonSchemaTypeName.String, default: '' };
+
+      expect(() => new ForeignKeyValueNodeImpl(undefined, 'field', schema, 'value')).toThrow(
+        'ForeignKeyValueNode requires a schema with foreignKey property',
+      );
+    });
+
+    it('works without fkResolver', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      expect(node.foreignKey).toBe('categories');
+      expect(node.isLoading).toBe(false);
+    });
+  });
+
+  describe('isForeignKeyValueNode', () => {
+    it('returns true for ForeignKeyValueNodeImpl instance', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      expect(isForeignKeyValueNode(node)).toBe(true);
+    });
+
+    it('returns true for node with foreignKey property', () => {
+      const mockNode = {
+        foreignKey: 'categories',
+        value: 'cat-1',
+      } as unknown as ForeignKeyValueNode;
+
+      expect(isForeignKeyValueNode(mockNode)).toBe(true);
+    });
+
+    it('returns false for StringValueNode without foreignKey', () => {
+      const schema: JsonStringSchema = { type: JsonSchemaTypeName.String, default: '' };
+      const node = new StringValueNode(undefined, 'name', schema, 'value');
+
+      expect(isForeignKeyValueNode(node)).toBe(false);
+    });
+
+    it('returns false for node with non-string foreignKey', () => {
+      const mockNode = {
+        foreignKey: 123,
+        value: 'cat-1',
+      } as unknown as ForeignKeyValueNode;
+
+      expect(isForeignKeyValueNode(mockNode)).toBe(false);
+    });
+  });
+
+  describe('isLoading', () => {
+    let fkResolver: ForeignKeyResolver;
+
+    beforeEach(() => {
+      fkResolver = createForeignKeyResolver();
+    });
+
+    it('returns false when no fkResolver', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      expect(node.isLoading).toBe(false);
+    });
+
+    it('returns false when row is cached', () => {
+      const schema = createCategorySchema();
+      fkResolver.addTable('categories', schema, [{ rowId: 'cat-1', data: { name: 'Electronics' } }]);
+
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        'cat-1',
+        undefined,
+        fkResolver,
+      );
+
+      expect(node.isLoading).toBe(false);
+    });
+
+    it('returns true when row is loading', async () => {
+      let resolveLoad: ((value: unknown) => void) | undefined;
+      const loadPromise = new Promise((resolve) => {
+        resolveLoad = resolve;
+      });
+
+      const fkResolverWithLoader = createForeignKeyResolver({
+        loader: {
+          loadSchema: async () => createCategorySchema(),
+          loadTable: async () => ({ schema: createCategorySchema(), rows: [] }),
+          loadRow: async () => {
+            await loadPromise;
+            return { schema: createCategorySchema(), row: { rowId: 'cat-1', data: { name: 'Test' } } };
+          },
+        },
+      });
+
+      fkResolverWithLoader.addSchema('categories', createCategorySchema());
+
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        'cat-1',
+        undefined,
+        fkResolverWithLoader,
+      );
+
+      const getRowPromise = node.getRow();
+      expect(node.isLoading).toBe(true);
+
+      resolveLoad!(undefined);
+      await getRowPromise;
+      expect(node.isLoading).toBe(false);
+    });
+  });
+
+  describe('getRow', () => {
+    let fkResolver: ForeignKeyResolver;
+
+    beforeEach(() => {
+      fkResolver = createForeignKeyResolver();
+    });
+
+    it('throws ForeignKeyResolverNotConfiguredError when no resolver', async () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      await expect(node.getRow()).rejects.toThrow(ForeignKeyResolverNotConfiguredError);
+    });
+
+    it('throws ForeignKeyNotFoundError when value is empty', async () => {
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        '',
+        undefined,
+        fkResolver,
+      );
+
+      await expect(node.getRow()).rejects.toThrow(ForeignKeyNotFoundError);
+    });
+
+    it('returns row data when cached', async () => {
+      const schema = createCategorySchema();
+      fkResolver.addTable('categories', schema, [{ rowId: 'cat-1', data: { name: 'Electronics' } }]);
+
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        'cat-1',
+        undefined,
+        fkResolver,
+      );
+
+      const row = await node.getRow();
+      expect(row).toEqual({ rowId: 'cat-1', data: { name: 'Electronics' } });
+    });
+
+    it('loads row via loader when not cached', async () => {
+      const schema = createCategorySchema();
+      const fkResolverWithLoader = createForeignKeyResolver({
+        loader: {
+          loadSchema: async () => schema,
+          loadTable: async () => ({ schema, rows: [] }),
+          loadRow: async (_tableId, rowId) => ({
+            schema,
+            row: { rowId, data: { name: 'Loaded Category' } },
+          }),
+        },
+      });
+      fkResolverWithLoader.addSchema('categories', schema);
+
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        'cat-1',
+        undefined,
+        fkResolverWithLoader,
+      );
+
+      const row = await node.getRow();
+      expect(row).toEqual({ rowId: 'cat-1', data: { name: 'Loaded Category' } });
+    });
+  });
+
+  describe('getSchema', () => {
+    let fkResolver: ForeignKeyResolver;
+
+    beforeEach(() => {
+      fkResolver = createForeignKeyResolver();
+    });
+
+    it('throws ForeignKeyResolverNotConfiguredError when no resolver', async () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      await expect(node.getSchema()).rejects.toThrow(ForeignKeyResolverNotConfiguredError);
+    });
+
+    it('returns schema when cached', async () => {
+      const schema = createCategorySchema();
+      fkResolver.addSchema('categories', schema);
+
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        'cat-1',
+        undefined,
+        fkResolver,
+      );
+
+      const result = await node.getSchema();
+      expect(result).toEqual(schema);
+    });
+
+    it('loads schema via loader when not cached', async () => {
+      const schema = createCategorySchema();
+      const fkResolverWithLoader = createForeignKeyResolver({
+        loader: {
+          loadSchema: async () => schema,
+          loadTable: async () => ({ schema, rows: [] }),
+          loadRow: async () => ({ schema, row: { rowId: '', data: {} } }),
+        },
+      });
+
+      const node = new ForeignKeyValueNodeImpl(
+        undefined,
+        'categoryId',
+        createFKSchema('categories'),
+        'cat-1',
+        undefined,
+        fkResolverWithLoader,
+      );
+
+      const result = await node.getSchema();
+      expect(result).toEqual(schema);
+    });
+  });
+
+  describe('inherits StringValueNode behavior', () => {
+    it('supports setValue', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      node.setValue('cat-2');
+      expect(node.value).toBe('cat-2');
+    });
+
+    it('supports dirty tracking', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      expect(node.isDirty).toBe(false);
+
+      node.setValue('cat-2');
+      expect(node.isDirty).toBe(true);
+
+      node.revert();
+      expect(node.value).toBe('cat-1');
+      expect(node.isDirty).toBe(false);
+    });
+
+    it('supports commit', () => {
+      const node = new ForeignKeyValueNodeImpl(undefined, 'categoryId', createFKSchema('categories'), 'cat-1');
+
+      node.setValue('cat-2');
+      node.commit();
+
+      expect(node.isDirty).toBe(false);
+      expect(node.baseValue).toBe('cat-2');
+    });
+  });
+});

--- a/src/model/value-node/index.ts
+++ b/src/model/value-node/index.ts
@@ -28,6 +28,11 @@ export { NumberValueNode } from './NumberValueNode.js';
 export { BooleanValueNode } from './BooleanValueNode.js';
 export { ObjectValueNode } from './ObjectValueNode.js';
 export { ArrayValueNode } from './ArrayValueNode.js';
+export {
+  ForeignKeyValueNodeImpl,
+  isForeignKeyValueNode,
+} from './ForeignKeyValueNode.js';
+export type { ForeignKeyValueNode } from './ForeignKeyValueNode.js';
 
 // Factory
 export {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a DataModel for managing multiple tables and a ForeignKeyResolver for FK caching/lazy loading. Adds ForeignKeyValueNode and wires FK support into TableModel and NodeFactory to resolve referenced rows and schemas.

- **New Features**
  - DataModel: add/get/remove tables, isDirty across tables, commit/revert, dispose; shares a single ForeignKeyResolver (internal or provided).
  - ForeignKeyResolver: caches schemas/rows, async loader support, optional prefetch, loading state, reactive-friendly, dispose.
  - ForeignKeyValueNode: auto-created for string fields with foreignKey; exposes getRow/getSchema and isLoading.
  - Integration: TableModel accepts fkResolver and passes it to NodeFactory; NodeFactory constructs FK nodes when schema has foreignKey.
  - Exports/Docs/Tests: new modules exported via model/index; extensive tests and READMEs.

- **Migration**
  - Optional: use createDataModel() for multi-table management and shared FK resolution.
  - If constructing tables/factories directly, pass fkResolver to:
    - createNodeFactory({ fkResolver }) to enable FK node resolution.
    - createTableModel({ fkResolver, ... }) so rows use the shared resolver.
  - Managing lifecycle: dispose() DataModel to clean internal resolver; if you provide an external resolver, you own its disposal.

<sup>Written for commit 88813596826d72cfa64e3cf2a4c4fe3f563da259. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

