### PR TITLE
fix: data model

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,16 @@
         "types": "./dist/formula/index.d.cts",
         "default": "./dist/formula/index.cjs"
       }
+    },
+    "./core": {
+      "import": {
+        "types": "./dist/core/index.d.ts",
+        "default": "./dist/core/index.js"
+      },
+      "require": {
+        "types": "./dist/core/index.d.cts",
+        "default": "./dist/core/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",
@@ -135,6 +145,9 @@
       ],
       "formula": [
         "./dist/formula/index.d.ts"
+      ],
+      "core": [
+        "./dist/core/index.d.ts"
       ]
     }
   },

--- a/src/model/data-model/DataModel.ts
+++ b/src/model/data-model/DataModel.ts
@@ -8,6 +8,7 @@ export interface DataModel {
   addTable(tableId: string, schema: JsonObjectSchema, rows?: RowData[]): TableModel;
   getTable(tableId: string): TableModel | undefined;
   removeTable(tableId: string): void;
+  renameTable(oldTableId: string, newTableId: string): void;
   hasTable(tableId: string): boolean;
 
   readonly tables: readonly TableModel[];

--- a/src/model/data-model/DataModelImpl.ts
+++ b/src/model/data-model/DataModelImpl.ts
@@ -37,6 +37,7 @@ export class DataModelImpl implements DataModel {
       isDirty: 'computed',
       addTable: 'action',
       removeTable: 'action',
+      renameTable: 'action',
       commit: 'action',
       revert: 'action',
     } as AnnotationsMap<this>);

--- a/src/model/data-model/DataModelImpl.ts
+++ b/src/model/data-model/DataModelImpl.ts
@@ -96,6 +96,17 @@ export class DataModelImpl implements DataModel {
     this._tables.delete(tableId);
   }
 
+  renameTable(oldTableId: string, newTableId: string): void {
+    const table = this._tables.get(oldTableId);
+    if (!table) {
+      return;
+    }
+
+    table.rename(newTableId);
+    this._tables.delete(oldTableId);
+    this._tables.set(newTableId, table);
+  }
+
   commit(): void {
     for (const table of this._tables.values()) {
       table.commit();

--- a/src/model/data-model/DataModelImpl.ts
+++ b/src/model/data-model/DataModelImpl.ts
@@ -102,9 +102,15 @@ export class DataModelImpl implements DataModel {
       return;
     }
 
+    if (this._tables.has(newTableId)) {
+      throw new Error(`Table with id '${newTableId}' already exists`);
+    }
+
     table.rename(newTableId);
     this._tables.delete(oldTableId);
     this._tables.set(newTableId, table);
+
+    this._fk.renameTable(oldTableId, newTableId);
   }
 
   commit(): void {

--- a/src/model/data-model/README.md
+++ b/src/model/data-model/README.md
@@ -131,6 +131,6 @@ interface DataModel {
 - **addTable** automatically adds schema to FK resolver
 - **addTable with rows** also adds rows to FK resolver
 - **removeTable** removes from DataModel but keeps FK cache (for cross-table references)
-- **renameTable** renames table and updates internal map key (use this instead of `table.rename()` directly)
+- **renameTable** renames table, updates internal map key, and updates FK resolver cache (use this instead of `table.rename()` directly); throws if target tableId already exists
 - **dispose** clears tables and disposes internal FK resolver (but not external)
 - **TableModels** created via addTable have access to the shared FK resolver via `table.fk`

--- a/src/model/data-model/README.md
+++ b/src/model/data-model/README.md
@@ -37,6 +37,9 @@ dataModel.tableIds; // string[]
 
 // Remove table (keeps FK cache)
 dataModel.removeTable('users');
+
+// Rename table
+dataModel.renameTable('products', 'items');
 ```
 
 ### With External FK Resolver
@@ -107,6 +110,7 @@ interface DataModel {
   addTable(tableId: string, schema: JsonObjectSchema, rows?: RowData[]): TableModel;
   getTable(tableId: string): TableModel | undefined;
   removeTable(tableId: string): void;
+  renameTable(oldTableId: string, newTableId: string): void;
   hasTable(tableId: string): boolean;
 
   readonly tables: readonly TableModel[];
@@ -127,5 +131,6 @@ interface DataModel {
 - **addTable** automatically adds schema to FK resolver
 - **addTable with rows** also adds rows to FK resolver
 - **removeTable** removes from DataModel but keeps FK cache (for cross-table references)
+- **renameTable** renames table and updates internal map key (use this instead of `table.rename()` directly)
 - **dispose** clears tables and disposes internal FK resolver (but not external)
 - **TableModels** created via addTable have access to the shared FK resolver via `table.fk`

--- a/src/model/data-model/__tests__/DataModel.spec.ts
+++ b/src/model/data-model/__tests__/DataModel.spec.ts
@@ -97,6 +97,37 @@ describe('DataModel', () => {
       expect(dataModel.tableIds).toContain('users');
       expect(dataModel.tableIds).toContain('products');
     });
+
+    it('renameTable updates internal map key', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      dataModel.renameTable('users', 'customers');
+
+      expect(dataModel.hasTable('users')).toBe(false);
+      expect(dataModel.hasTable('customers')).toBe(true);
+      expect(dataModel.getTable('customers')?.tableId).toBe('customers');
+    });
+
+    it('renameTable updates tableIds', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      dataModel.renameTable('users', 'customers');
+
+      expect(dataModel.tableIds).not.toContain('users');
+      expect(dataModel.tableIds).toContain('customers');
+    });
+
+    it('renameTable does nothing for non-existent table', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+
+      dataModel.renameTable('unknown', 'customers');
+
+      expect(dataModel.tableIds).toContain('users');
+      expect(dataModel.tableIds).not.toContain('customers');
+    });
   });
 
   describe('fk integration', () => {

--- a/src/model/data-model/__tests__/DataModel.spec.ts
+++ b/src/model/data-model/__tests__/DataModel.spec.ts
@@ -128,6 +128,30 @@ describe('DataModel', () => {
       expect(dataModel.tableIds).toContain('users');
       expect(dataModel.tableIds).not.toContain('customers');
     });
+
+    it('renameTable throws if target table exists', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema());
+      dataModel.addTable('customers', createSimpleSchema());
+
+      expect(() => dataModel.renameTable('users', 'customers')).toThrow(
+        "Table with id 'customers' already exists",
+      );
+    });
+
+    it('renameTable updates FK resolver cache', () => {
+      const dataModel = createDataModel();
+      dataModel.addTable('users', createSimpleSchema(), [
+        { rowId: 'user-1', data: { name: 'John' } },
+      ]);
+
+      dataModel.renameTable('users', 'customers');
+
+      expect(dataModel.fk.hasSchema('users')).toBe(false);
+      expect(dataModel.fk.hasSchema('customers')).toBe(true);
+      expect(dataModel.fk.hasRow('users', 'user-1')).toBe(false);
+      expect(dataModel.fk.hasRow('customers', 'user-1')).toBe(true);
+    });
   });
 
   describe('fk integration', () => {

--- a/src/model/foreign-key-resolver/ForeignKeyResolver.ts
+++ b/src/model/foreign-key-resolver/ForeignKeyResolver.ts
@@ -5,6 +5,7 @@ export interface ForeignKeyResolver {
   addSchema(tableId: string, schema: JsonObjectSchema): void;
   addTable(tableId: string, schema: JsonObjectSchema, rows: RowData[]): void;
   addRow(tableId: string, rowId: string, data: unknown): void;
+  renameTable(oldTableId: string, newTableId: string): void;
 
   getSchema(tableId: string): Promise<JsonObjectSchema>;
   getRowData(tableId: string, rowId: string): Promise<RowData>;

--- a/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
+++ b/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
@@ -151,6 +151,37 @@ export class ForeignKeyResolverImpl implements ForeignKeyResolver {
     }
   }
 
+  renameTable(oldTableId: string, newTableId: string): void {
+    if (this._disposed) {
+      return;
+    }
+
+    const schema = this._schemaCache.get(oldTableId);
+    const tableCache = this._tableCache.get(oldTableId);
+
+    if (this.reactivity) {
+      this.reactivity.runInAction(() => {
+        if (schema) {
+          this._schemaCache.delete(oldTableId);
+          this._schemaCache.set(newTableId, schema);
+        }
+        if (tableCache) {
+          this._tableCache.delete(oldTableId);
+          this._tableCache.set(newTableId, tableCache);
+        }
+      });
+    } else {
+      if (schema) {
+        this._schemaCache.delete(oldTableId);
+        this._schemaCache.set(newTableId, schema);
+      }
+      if (tableCache) {
+        this._tableCache.delete(oldTableId);
+        this._tableCache.set(newTableId, tableCache);
+      }
+    }
+  }
+
   async getSchema(tableId: string): Promise<JsonObjectSchema> {
     const cachedSchema = this._schemaCache.get(tableId);
     if (cachedSchema) {

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
@@ -305,8 +305,8 @@ describe('ForeignKeyResolver prefetch', () => {
       expect(mockLoader.loadRowCallCount).toBe(0);
     });
 
-    it('prefetch skips non-string FK fields', async () => {
-      const schemaWithNumberField: JsonObjectSchema = {
+    it('prefetch skips schema without FK fields', async () => {
+      const schemaWithoutFK: JsonObjectSchema = {
         type: JsonSchemaTypeName.Object,
         additionalProperties: false,
         required: ['name', 'count'],
@@ -321,7 +321,7 @@ describe('ForeignKeyResolver prefetch', () => {
         prefetch: true,
       });
 
-      resolver.addTable('products', schemaWithNumberField, [
+      resolver.addTable('products', schemaWithoutFK, [
         { rowId: 'prod-1', data: { name: 'iPhone', count: 5 } },
       ]);
 

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
@@ -304,6 +304,45 @@ describe('ForeignKeyResolver prefetch', () => {
 
       expect(mockLoader.loadRowCallCount).toBe(0);
     });
+
+    it('prefetch skips non-string FK fields', async () => {
+      const schemaWithNumberField: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['name', 'count'],
+        properties: {
+          name: { type: JsonSchemaTypeName.String, default: '' },
+          count: { type: JsonSchemaTypeName.Number, default: 0 },
+        },
+      };
+
+      const resolver = createForeignKeyResolver({
+        loader: mockLoader,
+        prefetch: true,
+      });
+
+      resolver.addTable('products', schemaWithNumberField, [
+        { rowId: 'prod-1', data: { name: 'iPhone', count: 5 } },
+      ]);
+
+      await flushMicrotasks();
+
+      expect(mockLoader.loadRowCallCount).toBe(0);
+    });
+
+    it('prefetch does nothing without loader', async () => {
+      const resolver = createForeignKeyResolver({
+        prefetch: true,
+      });
+
+      resolver.addTable('products', productSchema, [
+        { rowId: 'prod-1', data: { name: 'iPhone', categoryId: 'cat-1' } },
+      ]);
+
+      await flushMicrotasks();
+
+      expect(resolver.hasRow('categories', 'cat-1')).toBe(false);
+    });
   });
 
   describe('setPrefetch runtime control', () => {

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
@@ -71,6 +71,17 @@ describe('ForeignKeyResolver', () => {
       expect(result).toBe(schema);
     });
 
+    it('getSchema returns schema from tableCache when not in schemaCache', async () => {
+      const resolver = createForeignKeyResolver();
+      const schema = createSimpleSchema();
+
+      resolver.addTable('users', schema, []);
+      (resolver as unknown as { _schemaCache: Map<string, unknown> })._schemaCache.delete('users');
+
+      const result = await resolver.getSchema('users');
+      expect(result).toBe(schema);
+    });
+
     it('addTable stores table with schema and rows', () => {
       const resolver = createForeignKeyResolver();
       const schema = createSimpleSchema();
@@ -397,6 +408,25 @@ describe('ForeignKeyResolver', () => {
       resolver.addSchema('users', createSimpleSchema());
 
       expect(resolver.hasSchema('users')).toBe(false);
+    });
+
+    it('dispose prevents addTable', () => {
+      const resolver = createForeignKeyResolver();
+
+      resolver.dispose();
+      resolver.addTable('users', createSimpleSchema(), [{ rowId: 'u-1', data: {} }]);
+
+      expect(resolver.hasTable('users')).toBe(false);
+    });
+
+    it('dispose prevents addRow', () => {
+      const resolver = createForeignKeyResolver();
+      resolver.addTable('users', createSimpleSchema(), []);
+
+      resolver.dispose();
+      resolver.addRow('users', 'u-1', { name: 'John' });
+
+      expect(resolver.hasRow('users', 'u-1')).toBe(false);
     });
   });
 

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
@@ -429,4 +429,51 @@ describe('ForeignKeyResolver', () => {
       expect(resolver.isPrefetchEnabled).toBe(false);
     });
   });
+
+  describe('renameTable', () => {
+    it('renames schema in cache', () => {
+      const resolver = createForeignKeyResolver();
+      resolver.addSchema('users', createSimpleSchema());
+
+      resolver.renameTable('users', 'customers');
+
+      expect(resolver.hasSchema('users')).toBe(false);
+      expect(resolver.hasSchema('customers')).toBe(true);
+    });
+
+    it('renames table with rows in cache', () => {
+      const resolver = createForeignKeyResolver();
+      resolver.addTable('users', createSimpleSchema(), [
+        { rowId: 'user-1', data: { name: 'John' } },
+      ]);
+
+      resolver.renameTable('users', 'customers');
+
+      expect(resolver.hasTable('users')).toBe(false);
+      expect(resolver.hasTable('customers')).toBe(true);
+      expect(resolver.hasRow('users', 'user-1')).toBe(false);
+      expect(resolver.hasRow('customers', 'user-1')).toBe(true);
+    });
+
+    it('does nothing for non-existent table', () => {
+      const resolver = createForeignKeyResolver();
+      resolver.addSchema('users', createSimpleSchema());
+
+      resolver.renameTable('unknown', 'customers');
+
+      expect(resolver.hasSchema('users')).toBe(true);
+      expect(resolver.hasSchema('customers')).toBe(false);
+    });
+
+    it('does nothing after dispose', () => {
+      const resolver = createForeignKeyResolver();
+      resolver.addSchema('users', createSimpleSchema());
+
+      resolver.dispose();
+      resolver.renameTable('users', 'customers');
+
+      expect(resolver.hasSchema('users')).toBe(false);
+      expect(resolver.hasSchema('customers')).toBe(false);
+    });
+  });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'lib/index': 'src/lib/index.ts',
     'validation-schemas/index': 'src/validation-schemas/index.ts',
     'formula/index': 'src/formula/index.ts',
+    'core/index': 'src/core/index.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add DataModel.renameTable to safely rename tables and keep DataModel and FK resolver state consistent.

- **New Features**
  - Added renameTable(oldTableId, newTableId) that updates the internal map, calls table.rename, and moves FK resolver cache (schema and rows).
  - Throws if newTableId already exists; no-op if oldTableId is missing.
  - Updated README and tests for tableIds sync, FK cache move, and edge cases.
  - Exposed ./core export and build target.

- **Migration**
  - Use dataModel.renameTable(...) instead of calling table.rename() directly.

<sup>Written for commit 25bee3ba64bb2efc88942b84a239de9e4b1726b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

