### PR TITLE
feat: schema updates

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.coverage.exclusions=**/__tests__**,**/__mocks__**,**/*.spec.ts
 # ====================
 # Issue Ignore Rules
 # ====================
-sonar.issue.ignore.multicriteria=tech1,tech2,fp1,fp2,fp3,fp4
+sonar.issue.ignore.multicriteria=tech1,tech2,fp1,fp2,fp3,fp4,fp5
 
 # ====================
 # Technical Debt Exclusions
@@ -49,6 +49,10 @@ sonar.issue.ignore.multicriteria.fp3.resourceKey=**/ObjectNode.ts
 # FP: SchemaNode.removeChild is not DOM API (S7762 variant of S6788)
 sonar.issue.ignore.multicriteria.fp4.ruleKey=typescript:S7762
 sonar.issue.ignore.multicriteria.fp4.resourceKey=**/schema-tree/**
+
+# FP: SchemaNode.replaceChild is not DOM API, it's our custom tree method
+sonar.issue.ignore.multicriteria.fp5.ruleKey=typescript:S7768
+sonar.issue.ignore.multicriteria.fp5.resourceKey=**/schema-tree/**
 
 # ====================
 # Duplicate Code Exclusions

--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -99,6 +99,10 @@ export abstract class BaseNode implements SchemaNode {
     return false;
   }
 
+  replaceChild(_name: string, _node: SchemaNode): boolean {
+    return false;
+  }
+
   setItems(_node: SchemaNode): void {
     // No-op by default
   }

--- a/src/core/schema-node/NullNode.ts
+++ b/src/core/schema-node/NullNode.ts
@@ -90,6 +90,10 @@ class NullNodeImpl implements SchemaNode {
     return false;
   }
 
+  replaceChild(_name: string, _node: SchemaNode): boolean {
+    return false;
+  }
+
   setItems(_node: SchemaNode): void {
     // No-op for null
   }

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -53,6 +53,15 @@ export class ObjectNode extends BaseNode {
     this._children.splice(index, 1);
     return true;
   }
+
+  replaceChild(name: string, node: SchemaNode): boolean {
+    const index = this._children.findIndex((child) => child.name() === name);
+    if (index === -1) {
+      return false;
+    }
+    this._children[index] = node;
+    return true;
+  }
 }
 
 export function createObjectNode(

--- a/src/core/schema-node/types.ts
+++ b/src/core/schema-node/types.ts
@@ -47,6 +47,7 @@ export interface SchemaNode {
   setMetadata(metadata: NodeMetadata): void;
   addChild(node: SchemaNode): void;
   removeChild(name: string): boolean;
+  replaceChild(name: string, node: SchemaNode): boolean;
   setItems(node: SchemaNode): void;
   setDefaultValue(value: unknown): void;
   setFormula(formula: Formula | undefined): void;

--- a/src/core/schema-tree/__tests__/SchemaTree.replaceRoot.spec.ts
+++ b/src/core/schema-tree/__tests__/SchemaTree.replaceRoot.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaTree } from '../index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  NULL_NODE,
+} from '../../schema-node/index.js';
+
+describe('SchemaTree.replaceRoot', () => {
+  it('replaces object root with array', () => {
+    const nameNode = createStringNode('name-id', 'name');
+    const root = createObjectNode('root-id', 'root', [nameNode]);
+    const tree = createSchemaTree(root);
+
+    const itemNode = createStringNode('item-id', '');
+    const newRoot = createArrayNode('new-root-id', 'root', itemNode);
+
+    tree.replaceRoot(newRoot);
+
+    expect(tree.root()).toBe(newRoot);
+    expect(tree.root().id()).toBe('new-root-id');
+    expect(tree.root().isArray()).toBe(true);
+  });
+
+  it('replaces array root with object', () => {
+    const itemNode = createStringNode('item-id', '');
+    const root = createArrayNode('root-id', 'root', itemNode);
+    const tree = createSchemaTree(root);
+
+    const nameNode = createStringNode('name-id', 'name');
+    const newRoot = createObjectNode('new-root-id', 'root', [nameNode]);
+
+    tree.replaceRoot(newRoot);
+
+    expect(tree.root()).toBe(newRoot);
+    expect(tree.root().id()).toBe('new-root-id');
+    expect(tree.root().isObject()).toBe(true);
+  });
+
+  it('rebuilds index after replacement', () => {
+    const nameNode = createStringNode('name-id', 'name');
+    const root = createObjectNode('root-id', 'root', [nameNode]);
+    const tree = createSchemaTree(root);
+
+    const cityNode = createStringNode('city-id', 'city');
+    const addressNode = createObjectNode('address-id', 'address', [cityNode]);
+    const newRoot = createObjectNode('new-root-id', 'root', [addressNode]);
+
+    tree.replaceRoot(newRoot);
+
+    expect(tree.nodeById('new-root-id')).toBe(newRoot);
+    expect(tree.nodeById('address-id')).toBe(addressNode);
+    expect(tree.nodeById('city-id')).toBe(cityNode);
+    expect(tree.pathOf('city-id').asJsonPointer()).toBe(
+      '/properties/address/properties/city',
+    );
+  });
+
+  it('old nodes are no longer accessible after replacement', () => {
+    const nameNode = createStringNode('name-id', 'name');
+    const root = createObjectNode('root-id', 'root', [nameNode]);
+    const tree = createSchemaTree(root);
+
+    const itemNode = createStringNode('item-id', '');
+    const newRoot = createArrayNode('new-root-id', 'root', itemNode);
+
+    tree.replaceRoot(newRoot);
+
+    expect(tree.nodeById('root-id')).toBe(NULL_NODE);
+    expect(tree.nodeById('name-id')).toBe(NULL_NODE);
+  });
+
+  it('correctly counts nodes after replacement', () => {
+    const nameNode = createStringNode('name-id', 'name');
+    const ageNode = createNumberNode('age-id', 'age');
+    const root = createObjectNode('root-id', 'root', [nameNode, ageNode]);
+    const tree = createSchemaTree(root);
+
+    expect(tree.countNodes()).toBe(3);
+
+    const itemNode = createStringNode('item-id', '');
+    const newRoot = createArrayNode('new-root-id', 'root', itemNode);
+
+    tree.replaceRoot(newRoot);
+
+    expect(tree.countNodes()).toBe(2);
+  });
+
+  it('nodeIds returns new node ids after replacement', () => {
+    const nameNode = createStringNode('name-id', 'name');
+    const root = createObjectNode('root-id', 'root', [nameNode]);
+    const tree = createSchemaTree(root);
+
+    const cityNode = createStringNode('city-id', 'city');
+    const newRoot = createObjectNode('new-root-id', 'root', [cityNode]);
+
+    tree.replaceRoot(newRoot);
+
+    const ids = [...tree.nodeIds()];
+    expect(ids).toContain('new-root-id');
+    expect(ids).toContain('city-id');
+    expect(ids).not.toContain('root-id');
+    expect(ids).not.toContain('name-id');
+  });
+
+  it('preserves replacements map after root replacement', () => {
+    const root = createObjectNode('root-id', 'root');
+    const tree = createSchemaTree(root);
+    tree.trackReplacement('old-id', 'replaced-id');
+
+    const newRoot = createObjectNode('new-root-id', 'root');
+    tree.replaceRoot(newRoot);
+
+    const replacements = [...tree.replacements()];
+    expect(replacements).toContainEqual(['old-id', 'replaced-id']);
+  });
+});

--- a/src/core/schema-tree/types.ts
+++ b/src/core/schema-tree/types.ts
@@ -17,4 +17,5 @@ export interface SchemaTree {
   renameNode(nodeId: string, newName: string): void;
   moveNode(nodeId: string, newParentId: string): void;
   setNodeAt(path: Path, node: SchemaNode): void;
+  replaceRoot(newRoot: SchemaNode): void;
 }

--- a/src/core/validation/README.md
+++ b/src/core/validation/README.md
@@ -89,3 +89,98 @@ ValidatorResolver    ← resolves which validators apply
        ↓
 ValidationEngine     ← runs validators, collects diagnostics
 ```
+
+---
+
+# Schema Validation
+
+Validation of schema structure itself (field names, duplicates, etc.).
+
+## Schema Validation Types
+
+```typescript
+type SchemaValidationErrorType = 'empty-name' | 'duplicate-name' | 'invalid-name';
+
+interface SchemaValidationError {
+  nodeId: string;
+  type: SchemaValidationErrorType;
+  message: string;
+}
+```
+
+## Field Name Validation
+
+Field names must:
+- Start with a letter or underscore
+- NOT start with `__` (reserved for system)
+- Only contain letters, numbers, hyphens, and underscores
+- Be at most 64 characters
+
+```typescript
+import { isValidFieldName } from '@revisium/schema-toolkit/core';
+
+isValidFieldName('myField');     // true
+isValidFieldName('_private');    // true
+isValidFieldName('123invalid');  // false
+isValidFieldName('__reserved');  // false
+```
+
+## Schema Structure Validation
+
+```typescript
+import { validateSchema } from '@revisium/schema-toolkit/core';
+
+const errors = validateSchema(schemaTree.root());
+// Returns SchemaValidationError[] for:
+// - empty-name: Field with empty name
+// - duplicate-name: Same name used twice in object
+// - invalid-name: Name violates pattern rules
+```
+
+---
+
+# Formula Validation
+
+Validation of formula dependencies in schema.
+
+```typescript
+interface FormulaValidationError {
+  nodeId: string;
+  message: string;
+  fieldPath?: string;
+}
+```
+
+## Usage
+
+```typescript
+import { validateFormulas } from '@revisium/schema-toolkit/core';
+
+const errors = validateFormulas(schemaTree);
+// Returns FormulaValidationError[] for formulas with missing dependencies
+```
+
+---
+
+# Integration with SchemaModel
+
+SchemaModel provides convenient methods for validation:
+
+```typescript
+import { createSchemaModel } from '@revisium/schema-toolkit';
+
+const model = createSchemaModel(schema);
+
+// Get schema validation errors
+const schemaErrors = model.getValidationErrors();
+
+// Get formula validation errors
+const formulaErrors = model.getFormulaErrors();
+
+// Check if schema is fully valid
+const isValid = model.isValid();
+// Returns true only if:
+// - Root is object
+// - No schema validation errors
+// - No formula errors
+```

--- a/src/core/validation/__tests__/FieldNameValidator.spec.ts
+++ b/src/core/validation/__tests__/FieldNameValidator.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from '@jest/globals';
+import { isValidFieldName } from '../schema/FieldNameValidator.js';
+
+describe('FieldNameValidator', () => {
+  describe('isValidFieldName', () => {
+    describe('valid names', () => {
+      it('accepts name starting with letter', () => {
+        expect(isValidFieldName('name')).toBe(true);
+      });
+
+      it('accepts name starting with underscore', () => {
+        expect(isValidFieldName('_name')).toBe(true);
+      });
+
+      it('accepts name with numbers', () => {
+        expect(isValidFieldName('field1')).toBe(true);
+      });
+
+      it('accepts name with hyphens', () => {
+        expect(isValidFieldName('my-field')).toBe(true);
+      });
+
+      it('accepts name with underscores', () => {
+        expect(isValidFieldName('my_field')).toBe(true);
+      });
+
+      it('accepts single character name', () => {
+        expect(isValidFieldName('a')).toBe(true);
+      });
+
+      it('accepts single underscore', () => {
+        expect(isValidFieldName('_')).toBe(true);
+      });
+
+      it('accepts mixed case', () => {
+        expect(isValidFieldName('MyFieldName')).toBe(true);
+      });
+
+      it('accepts name with all allowed characters', () => {
+        expect(isValidFieldName('My_Field-Name123')).toBe(true);
+      });
+    });
+
+    describe('invalid names', () => {
+      it('rejects empty string', () => {
+        expect(isValidFieldName('')).toBe(false);
+      });
+
+      it('rejects name starting with double underscore', () => {
+        expect(isValidFieldName('__name')).toBe(false);
+      });
+
+      it('rejects name starting with number', () => {
+        expect(isValidFieldName('1field')).toBe(false);
+      });
+
+      it('rejects name starting with hyphen', () => {
+        expect(isValidFieldName('-field')).toBe(false);
+      });
+
+      it('rejects name with spaces', () => {
+        expect(isValidFieldName('my field')).toBe(false);
+      });
+
+      it('rejects name with special characters', () => {
+        expect(isValidFieldName('field@name')).toBe(false);
+        expect(isValidFieldName('field.name')).toBe(false);
+        expect(isValidFieldName('field$name')).toBe(false);
+      });
+
+      it('rejects name exceeding max length', () => {
+        const longName = 'a'.repeat(65);
+        expect(isValidFieldName(longName)).toBe(false);
+      });
+
+      it('accepts name at max length', () => {
+        const maxLengthName = 'a'.repeat(64);
+        expect(isValidFieldName(maxLengthName)).toBe(true);
+      });
+
+      it('rejects just double underscore', () => {
+        expect(isValidFieldName('__')).toBe(false);
+      });
+    });
+  });
+});

--- a/src/core/validation/__tests__/FormulaValidator.spec.ts
+++ b/src/core/validation/__tests__/FormulaValidator.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from '@jest/globals';
+import { validateFormulas } from '../formula/FormulaValidator.js';
+import { createSchemaTree } from '../../schema-tree/index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+} from '../../schema-node/index.js';
+import { jsonPointerToPath } from '../../path/index.js';
+import { ParsedFormula } from '../../../model/schema-formula/index.js';
+
+describe('FormulaValidator', () => {
+  describe('validateFormulas', () => {
+    it('returns empty array when no formulas exist', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('name-id', 'name'),
+      ]);
+      const tree = createSchemaTree(root);
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('returns empty array when formula dependencies are valid', () => {
+      const priceNode = createNumberNode('price-id', 'price');
+      const quantityNode = createNumberNode('quantity-id', 'quantity');
+      const totalNode = createNumberNode('total-id', 'total');
+      const root = createObjectNode('root-id', 'root', [
+        priceNode,
+        quantityNode,
+        totalNode,
+      ]);
+      const tree = createSchemaTree(root);
+
+      const formula = new ParsedFormula(tree, 'total-id', 'price * quantity');
+      totalNode.setFormula(formula);
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('detects missing formula dependency after field removal', () => {
+      const priceNode = createNumberNode('price-id', 'price');
+      const totalNode = createNumberNode('total-id', 'total');
+      const root = createObjectNode('root-id', 'root', [priceNode, totalNode]);
+      const tree = createSchemaTree(root);
+
+      const formula = new ParsedFormula(tree, 'total-id', 'price');
+      totalNode.setFormula(formula);
+
+      tree.removeNodeAt(jsonPointerToPath('/properties/price'));
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: 'total-id',
+        message: 'Cannot resolve formula dependency: target node not found',
+        fieldPath: 'total',
+      });
+    });
+
+    it('includes field path for nested fields', () => {
+      const priceNode = createNumberNode('price-id', 'price');
+      const computedNode = createNumberNode('computed-id', 'computed');
+      const nestedObj = createObjectNode('nested-id', 'nested', [computedNode]);
+      const root = createObjectNode('root-id', 'root', [priceNode, nestedObj]);
+      const tree = createSchemaTree(root);
+
+      const formula = new ParsedFormula(tree, 'computed-id', '/price');
+      computedNode.setFormula(formula);
+
+      tree.removeNodeAt(jsonPointerToPath('/properties/price'));
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.fieldPath).toBe('nested.computed');
+    });
+
+    it('includes field path for array items', () => {
+      const priceNode = createNumberNode('price-id', 'price');
+      const computedNode = createNumberNode('computed-id', 'computed');
+      const itemsObj = createObjectNode('items-id', '', [computedNode]);
+      const arrayNode = createArrayNode('array-id', 'items', itemsObj);
+      const root = createObjectNode('root-id', 'root', [priceNode, arrayNode]);
+      const tree = createSchemaTree(root);
+
+      const formula = new ParsedFormula(tree, 'computed-id', '/price');
+      computedNode.setFormula(formula);
+
+      tree.removeNodeAt(jsonPointerToPath('/properties/price'));
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.fieldPath).toBe('items[*].computed');
+    });
+
+    it('collects multiple errors', () => {
+      const priceNode = createNumberNode('price-id', 'price');
+      const field1 = createNumberNode('field1-id', 'field1');
+      const field2 = createNumberNode('field2-id', 'field2');
+      const root = createObjectNode('root-id', 'root', [priceNode, field1, field2]);
+      const tree = createSchemaTree(root);
+
+      field1.setFormula(new ParsedFormula(tree, 'field1-id', 'price'));
+      field2.setFormula(new ParsedFormula(tree, 'field2-id', 'price'));
+
+      tree.removeNodeAt(jsonPointerToPath('/properties/price'));
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(2);
+    });
+
+    it('does not report error for object nodes', () => {
+      const objNode = createObjectNode('obj-id', 'obj', [
+        createStringNode('child-id', 'child'),
+      ]);
+      const root = createObjectNode('root-id', 'root', [objNode]);
+      const tree = createSchemaTree(root);
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('handles deeply nested array structures', () => {
+      const priceNode = createNumberNode('price-id', 'price');
+      const computedNode = createNumberNode('computed-id', 'value');
+      const innerObj = createObjectNode('inner-id', '', [computedNode]);
+      const innerArray = createArrayNode('inner-array-id', 'nested', innerObj);
+      const outerObj = createObjectNode('outer-id', '', [innerArray]);
+      const outerArray = createArrayNode('outer-array-id', 'items', outerObj);
+      const root = createObjectNode('root-id', 'root', [priceNode, outerArray]);
+      const tree = createSchemaTree(root);
+
+      const formula = new ParsedFormula(tree, 'computed-id', '/price');
+      computedNode.setFormula(formula);
+
+      tree.removeNodeAt(jsonPointerToPath('/properties/price'));
+
+      const errors = validateFormulas(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.fieldPath).toBe('items[*].nested[*].value');
+    });
+  });
+});

--- a/src/core/validation/__tests__/SchemaValidator.spec.ts
+++ b/src/core/validation/__tests__/SchemaValidator.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from '@jest/globals';
+import { validateSchema } from '../schema/SchemaValidator.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+} from '../../schema-node/index.js';
+
+describe('SchemaValidator', () => {
+  describe('validateSchema', () => {
+    it('returns empty array for valid schema', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('name-id', 'name'),
+        createStringNode('age-id', 'age'),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('detects empty field name', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('empty-id', ''),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: 'empty-id',
+        type: 'empty-name',
+        message: 'Field name cannot be empty',
+      });
+    });
+
+    it('detects duplicate field names', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('first-id', 'name'),
+        createStringNode('second-id', 'name'),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: 'second-id',
+        type: 'duplicate-name',
+        message: 'Duplicate field name: name',
+      });
+    });
+
+    it('detects invalid field name pattern', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('invalid-id', '123invalid'),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: 'invalid-id',
+        type: 'invalid-name',
+      });
+    });
+
+    it('detects name starting with double underscore', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('reserved-id', '__reserved'),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: 'reserved-id',
+        type: 'invalid-name',
+      });
+    });
+
+    it('validates nested object fields', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createObjectNode('nested-id', 'nested', [
+          createStringNode('empty-id', ''),
+        ]),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.nodeId).toBe('empty-id');
+    });
+
+    it('validates array items schema', () => {
+      const items = createObjectNode('items-id', 'items', [
+        createStringNode('invalid-id', '1invalid'),
+      ]);
+      const root = createObjectNode('root-id', 'root', [
+        createArrayNode('array-id', 'items', items),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.nodeId).toBe('invalid-id');
+    });
+
+    it('collects multiple errors', () => {
+      const root = createObjectNode('root-id', 'root', [
+        createStringNode('empty-id', ''),
+        createStringNode('invalid-id', '123'),
+        createStringNode('reserved-id', '__sys'),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(3);
+    });
+
+    it('handles deeply nested structures', () => {
+      const deepNested = createObjectNode('deep-id', 'deep', [
+        createStringNode('invalid-id', ''),
+      ]);
+      const items = createArrayNode('items-id', 'items', deepNested);
+      const middle = createObjectNode('middle-id', 'middle', [items]);
+      const root = createObjectNode('root-id', 'root', [middle]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.nodeId).toBe('invalid-id');
+    });
+
+    it('does not report error on primitive array items', () => {
+      const items = createStringNode('items-id', '');
+      const root = createObjectNode('root-id', 'root', [
+        createArrayNode('array-id', 'tags', items),
+      ]);
+
+      const errors = validateSchema(root);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/core/validation/formula/FormulaValidator.ts
+++ b/src/core/validation/formula/FormulaValidator.ts
@@ -1,0 +1,47 @@
+import type { SchemaTree } from '../../schema-tree/index.js';
+import type { SchemaNode } from '../../schema-node/index.js';
+import type { FormulaValidationError } from './types.js';
+
+export function validateFormulas(tree: SchemaTree): FormulaValidationError[] {
+  const errors: FormulaValidationError[] = [];
+  collectFormulaErrors(tree.root(), tree, errors, '');
+  return errors;
+}
+
+function collectFormulaErrors(
+  node: SchemaNode,
+  tree: SchemaTree,
+  errors: FormulaValidationError[],
+  fieldPath: string,
+): void {
+  if (node.isNull()) {
+    return;
+  }
+
+  if (node.isPrimitive() && node.hasFormula()) {
+    const formula = node.formula();
+    if (formula) {
+      for (const dep of formula.dependencies()) {
+        const targetId = dep.targetNodeId();
+        const targetNode = tree.nodeById(targetId);
+        if (targetNode.isNull()) {
+          errors.push({
+            nodeId: node.id(),
+            message: 'Cannot resolve formula dependency: target node not found',
+            fieldPath: fieldPath || node.name(),
+          });
+        }
+      }
+    }
+  }
+
+  if (node.isObject()) {
+    for (const child of node.properties()) {
+      const childPath = fieldPath ? `${fieldPath}.${child.name()}` : child.name();
+      collectFormulaErrors(child, tree, errors, childPath);
+    }
+  } else if (node.isArray()) {
+    const itemsPath = fieldPath ? `${fieldPath}[*]` : '[*]';
+    collectFormulaErrors(node.items(), tree, errors, itemsPath);
+  }
+}

--- a/src/core/validation/formula/index.ts
+++ b/src/core/validation/formula/index.ts
@@ -1,0 +1,2 @@
+export type { FormulaValidationError } from './types.js';
+export { validateFormulas } from './FormulaValidator.js';

--- a/src/core/validation/formula/types.ts
+++ b/src/core/validation/formula/types.ts
@@ -1,0 +1,5 @@
+export interface FormulaValidationError {
+  nodeId: string;
+  message: string;
+  fieldPath?: string;
+}

--- a/src/core/validation/index.ts
+++ b/src/core/validation/index.ts
@@ -18,3 +18,12 @@ export {
 
 export * from './validators/index.js';
 export * from './rules/index.js';
+
+export type {
+  SchemaValidationError,
+  SchemaValidationErrorType,
+} from './schema/index.js';
+export { validateSchema, isValidFieldName, FIELD_NAME_ERROR_MESSAGE } from './schema/index.js';
+
+export type { FormulaValidationError } from './formula/index.js';
+export { validateFormulas } from './formula/index.js';

--- a/src/core/validation/schema/FieldNameValidator.ts
+++ b/src/core/validation/schema/FieldNameValidator.ts
@@ -1,0 +1,12 @@
+const FIELD_NAME_PATTERN = /^(?!__)[a-zA-Z_][a-zA-Z0-9-_]*$/;
+const FIELD_NAME_MAX_LENGTH = 64;
+
+export const FIELD_NAME_ERROR_MESSAGE =
+  'Must start with a letter or underscore, cannot start with __, and can only include letters, numbers, hyphens, and underscores (max 64 chars)';
+
+export function isValidFieldName(name: string): boolean {
+  if (name.length === 0 || name.length > FIELD_NAME_MAX_LENGTH) {
+    return false;
+  }
+  return FIELD_NAME_PATTERN.test(name);
+}

--- a/src/core/validation/schema/SchemaValidator.ts
+++ b/src/core/validation/schema/SchemaValidator.ts
@@ -1,0 +1,50 @@
+import type { SchemaNode } from '../../schema-node/index.js';
+import type { SchemaValidationError, SchemaValidationErrorType } from './types.js';
+import { isValidFieldName, FIELD_NAME_ERROR_MESSAGE } from './FieldNameValidator.js';
+
+export function validateSchema(root: SchemaNode): SchemaValidationError[] {
+  const errors: SchemaValidationError[] = [];
+  collectValidationErrors(root, errors);
+  return errors;
+}
+
+function collectValidationErrors(
+  node: SchemaNode,
+  errors: SchemaValidationError[],
+): void {
+  if (node.isNull()) {
+    return;
+  }
+
+  if (node.isObject()) {
+    const children = node.properties();
+    const nameSet = new Set<string>();
+
+    for (const child of children) {
+      const childName = child.name();
+
+      if (childName === '') {
+        errors.push(createError(child.id(), 'empty-name', 'Field name cannot be empty'));
+      } else if (nameSet.has(childName)) {
+        errors.push(
+          createError(child.id(), 'duplicate-name', `Duplicate field name: ${childName}`),
+        );
+      } else if (!isValidFieldName(childName)) {
+        errors.push(createError(child.id(), 'invalid-name', FIELD_NAME_ERROR_MESSAGE));
+      }
+
+      nameSet.add(childName);
+      collectValidationErrors(child, errors);
+    }
+  } else if (node.isArray()) {
+    collectValidationErrors(node.items(), errors);
+  }
+}
+
+function createError(
+  nodeId: string,
+  type: SchemaValidationErrorType,
+  message: string,
+): SchemaValidationError {
+  return { nodeId, type, message };
+}

--- a/src/core/validation/schema/index.ts
+++ b/src/core/validation/schema/index.ts
@@ -1,0 +1,6 @@
+export type {
+  SchemaValidationError,
+  SchemaValidationErrorType,
+} from './types.js';
+export { validateSchema } from './SchemaValidator.js';
+export { isValidFieldName, FIELD_NAME_ERROR_MESSAGE } from './FieldNameValidator.js';

--- a/src/core/validation/schema/types.ts
+++ b/src/core/validation/schema/types.ts
@@ -1,0 +1,10 @@
+export type SchemaValidationErrorType =
+  | 'empty-name'
+  | 'duplicate-name'
+  | 'invalid-name';
+
+export interface SchemaValidationError {
+  nodeId: string;
+  type: SchemaValidationErrorType;
+  message: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,16 @@ export * from './consts/index.js';
 export * from './model/index.js';
 export * from './lib/index.js';
 export * from './validation-schemas/index.js';
+
+// Core validation exports
+export {
+  validateSchema,
+  validateFormulas,
+  isValidFieldName,
+  FIELD_NAME_ERROR_MESSAGE,
+} from './core/validation/index.js';
+export type {
+  SchemaValidationError,
+  SchemaValidationErrorType,
+  FormulaValidationError,
+} from './core/validation/index.js';

--- a/src/model/schema-model/NodeFactory.ts
+++ b/src/model/schema-model/NodeFactory.ts
@@ -31,4 +31,8 @@ export class NodeFactory {
     const items = createStringNode(nanoid(), 'items', { defaultValue: '' });
     return createArrayNode(nanoid(), name, items);
   }
+
+  createArrayNodeWithItems(name: string, items: SchemaNode): SchemaNode {
+    return createArrayNode(nanoid(), name, items);
+  }
 }

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -212,6 +212,7 @@ export class SchemaModelImpl implements SchemaModel {
     const newRoot = this._nodeFactory.createNode(name, newType);
     this._currentTree.replaceRoot(newRoot);
     this._currentTree.trackReplacement(oldId, newRoot.id());
+    this._buildFormulaIndex();
 
     return {
       replacedNodeId: oldId,

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -7,10 +7,16 @@ import { SchemaSerializer } from '../../core/schema-serializer/index.js';
 import type { JsonObjectSchema } from '../../types/index.js';
 import type { ReactivityAdapter } from '../../core/reactivity/index.js';
 import type { AnnotationsMap } from '../../core/types/index.js';
-import type { SchemaModel, ReactivityOptions, FieldType } from './types.js';
+import type { SchemaModel, ReactivityOptions, FieldType, ReplaceResult } from './types.js';
 import { SchemaParser } from './SchemaParser.js';
 import { NodeFactory } from './NodeFactory.js';
 import { ParsedFormula, FormulaDependencyIndex } from '../schema-formula/index.js';
+import {
+  validateSchema,
+  validateFormulas,
+  type SchemaValidationError,
+  type FormulaValidationError,
+} from '../../core/validation/index.js';
 import { generateDefaultValue as generateDefaultValueFn } from '../default-value/index.js';
 
 export class SchemaModelImpl implements SchemaModel {
@@ -48,6 +54,9 @@ export class SchemaModelImpl implements SchemaModel {
         updateFormula: 'action',
         updateForeignKey: 'action',
         updateDefaultValue: 'action',
+        wrapInArray: 'action',
+        wrapRootInArray: 'action',
+        replaceRoot: 'action',
         markAsSaved: 'action',
         revert: 'action',
       } as AnnotationsMap<this>);
@@ -153,12 +162,146 @@ export class SchemaModelImpl implements SchemaModel {
     node.setDefaultValue(value);
   }
 
+  wrapInArray(nodeId: string): ReplaceResult | null {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull() || node.isArray()) {
+      return null;
+    }
+
+    const path = this._currentTree.pathOf(nodeId);
+    if (path.isEmpty()) {
+      return null;
+    }
+
+    const name = node.name();
+    const arrayNode = this._nodeFactory.createArrayNodeWithItems(name, node);
+    this._currentTree.setNodeAt(path, arrayNode);
+    node.setName('');
+    this._currentTree.trackReplacement(nodeId, arrayNode.id());
+
+    return {
+      replacedNodeId: nodeId,
+      newNodeId: arrayNode.id(),
+    };
+  }
+
+  wrapRootInArray(): ReplaceResult | null {
+    const currentRoot = this._currentTree.root();
+    if (currentRoot.isArray()) {
+      return null;
+    }
+
+    const oldId = currentRoot.id();
+    const name = currentRoot.name();
+    currentRoot.setName('');
+    const arrayNode = this._nodeFactory.createArrayNodeWithItems(name, currentRoot);
+    this._currentTree.replaceRoot(arrayNode);
+    this._currentTree.trackReplacement(oldId, arrayNode.id());
+
+    return {
+      replacedNodeId: oldId,
+      newNodeId: arrayNode.id(),
+    };
+  }
+
+  replaceRoot(newType: FieldType): ReplaceResult | null {
+    const currentRoot = this._currentTree.root();
+    const oldId = currentRoot.id();
+    const name = currentRoot.name();
+
+    const newRoot = this._nodeFactory.createNode(name, newType);
+    this._currentTree.replaceRoot(newRoot);
+    this._currentTree.trackReplacement(oldId, newRoot.id());
+
+    return {
+      replacedNodeId: oldId,
+      newNodeId: newRoot.id(),
+    };
+  }
+
+  canMoveNode(nodeId: string, targetParentId: string): boolean {
+    if (nodeId === targetParentId) {
+      return false;
+    }
+
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return false;
+    }
+
+    const target = this._currentTree.nodeById(targetParentId);
+    if (target.isNull()) {
+      return false;
+    }
+
+    if (!target.isObject()) {
+      return false;
+    }
+
+    const nodePath = this._currentTree.pathOf(nodeId);
+    if (nodePath.isEmpty()) {
+      return false;
+    }
+
+    const targetPath = this._currentTree.pathOf(targetParentId);
+    if (targetPath.equals(nodePath) || targetPath.isChildOf(nodePath)) {
+      return false;
+    }
+
+    const nodeParentPath = nodePath.parent();
+    if (targetPath.equals(nodeParentPath)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  hasValidDropTarget(nodeId: string): boolean {
+    const node = this._currentTree.nodeById(nodeId);
+    if (node.isNull()) {
+      return false;
+    }
+
+    const nodePath = this._currentTree.pathOf(nodeId);
+    if (nodePath.isEmpty()) {
+      return false;
+    }
+
+    for (const candidateId of this._currentTree.nodeIds()) {
+      if (this.canMoveNode(nodeId, candidateId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  getFormulaDependents(nodeId: string): readonly string[] {
+    return this._formulaIndex.getDependents(nodeId);
+  }
+
+  hasFormulaDependents(nodeId: string): boolean {
+    return this._formulaIndex.hasDependents(nodeId);
+  }
+
+  getValidationErrors(): SchemaValidationError[] {
+    return validateSchema(this._currentTree.root());
+  }
+
+  getFormulaErrors(): FormulaValidationError[] {
+    return validateFormulas(this._currentTree);
+  }
+
   isDirty(): boolean {
     return this.getPatches().length > 0;
   }
 
   isValid(): boolean {
-    return this._currentTree.root().isObject();
+    return (
+      this._currentTree.root().isObject() &&
+      this.getValidationErrors().length === 0 &&
+      this.getFormulaErrors().length === 0
+    );
   }
 
   getPatches(): SchemaPatch[] {

--- a/src/model/schema-model/__tests__/SchemaModel.dragDrop.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.dragDrop.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  simpleSchema,
+  nestedSchema,
+  arraySchema,
+  findNodeIdByName,
+  findNestedNodeId,
+} from './test-helpers.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+
+describe('SchemaModel drag-drop operations', () => {
+  describe('canMoveNode', () => {
+    it('returns true for valid move to different object', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['field', 'target'],
+        properties: {
+          field: { type: JsonSchemaTypeName.String, default: '' },
+          target: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: [],
+            properties: {},
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const fieldId = findNodeIdByName(model, 'field');
+      const targetId = findNodeIdByName(model, 'target');
+
+      expect(model.canMoveNode(fieldId!, targetId!)).toBe(true);
+    });
+
+    it('returns false when moving to self', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(model.canMoveNode(nameId!, nameId!)).toBe(false);
+    });
+
+    it('returns false when node does not exist', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(model.canMoveNode('non-existent', nameId!)).toBe(false);
+    });
+
+    it('returns false when target does not exist', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(model.canMoveNode(nameId!, 'non-existent')).toBe(false);
+    });
+
+    it('returns false when target is not object', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+      const ageId = findNodeIdByName(model, 'age');
+
+      expect(model.canMoveNode(nameId!, ageId!)).toBe(false);
+    });
+
+    it('returns false when target is an array', () => {
+      const model = createSchemaModel(arraySchema());
+      const rootId = model.root().id();
+      const itemsId = findNodeIdByName(model, 'items');
+      model.addField(rootId, 'field', 'string');
+      const fieldId = findNodeIdByName(model, 'field');
+
+      expect(model.canMoveNode(fieldId!, itemsId!)).toBe(false);
+    });
+
+    it('returns false when moving to descendant', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['outer'],
+        properties: {
+          outer: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['inner'],
+            properties: {
+              inner: {
+                type: JsonSchemaTypeName.Object,
+                additionalProperties: false,
+                required: [],
+                properties: {},
+              },
+            },
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const outerId = findNodeIdByName(model, 'outer');
+      const innerId = findNestedNodeId(model, 'outer', 'inner');
+
+      expect(model.canMoveNode(outerId!, innerId!)).toBe(false);
+    });
+
+    it('returns false when trying to move root', () => {
+      const model = createSchemaModel(nestedSchema());
+      const rootId = model.root().id();
+      const userId = findNodeIdByName(model, 'user');
+
+      expect(model.canMoveNode(rootId, userId!)).toBe(false);
+    });
+
+    it('returns false when moving to direct parent', () => {
+      const model = createSchemaModel(nestedSchema());
+      const userId = findNodeIdByName(model, 'user');
+      const firstNameId = findNestedNodeId(model, 'user', 'firstName');
+
+      expect(model.canMoveNode(firstNameId!, userId!)).toBe(false);
+    });
+
+    it('returns true when moving to different branch', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['branch1', 'branch2'],
+        properties: {
+          branch1: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['field'],
+            properties: {
+              field: { type: JsonSchemaTypeName.String, default: '' },
+            },
+          },
+          branch2: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: [],
+            properties: {},
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const fieldId = findNestedNodeId(model, 'branch1', 'field');
+      const branch2Id = findNodeIdByName(model, 'branch2');
+
+      expect(model.canMoveNode(fieldId!, branch2Id!)).toBe(true);
+    });
+  });
+
+  describe('hasValidDropTarget', () => {
+    it('returns true when valid target exists', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['field', 'target'],
+        properties: {
+          field: { type: JsonSchemaTypeName.String, default: '' },
+          target: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: [],
+            properties: {},
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const fieldId = findNodeIdByName(model, 'field');
+
+      expect(model.hasValidDropTarget(fieldId!)).toBe(true);
+    });
+
+    it('returns false when no valid target exists (flat schema)', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(model.hasValidDropTarget(nameId!)).toBe(false);
+    });
+
+    it('returns false when node does not exist', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.hasValidDropTarget('non-existent')).toBe(false);
+    });
+
+    it('returns false for root node', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root().id();
+
+      expect(model.hasValidDropTarget(rootId)).toBe(false);
+    });
+
+    it('returns true when nested object has sibling object', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['obj1', 'obj2'],
+        properties: {
+          obj1: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['field'],
+            properties: {
+              field: { type: JsonSchemaTypeName.String, default: '' },
+            },
+          },
+          obj2: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: [],
+            properties: {},
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const fieldId = findNestedNodeId(model, 'obj1', 'field');
+
+      expect(model.hasValidDropTarget(fieldId!)).toBe(true);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.formulaDependents.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.formulaDependents.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import { schemaWithFormula, simpleSchema, findNodeIdByName } from './test-helpers.js';
+
+describe('SchemaModel formula dependents', () => {
+  describe('getFormulaDependents', () => {
+    it('returns dependents for field referenced in formula', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+      const totalId = findNodeIdByName(model, 'total');
+
+      const dependents = model.getFormulaDependents(priceId!);
+
+      expect(dependents).toContain(totalId);
+    });
+
+    it('returns dependents for all referenced fields', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+      const quantityId = findNodeIdByName(model, 'quantity');
+      const totalId = findNodeIdByName(model, 'total');
+
+      expect(model.getFormulaDependents(priceId!)).toContain(totalId);
+      expect(model.getFormulaDependents(quantityId!)).toContain(totalId);
+    });
+
+    it('returns empty array for field with no dependents', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const totalId = findNodeIdByName(model, 'total');
+
+      const dependents = model.getFormulaDependents(totalId!);
+
+      expect(dependents).toHaveLength(0);
+    });
+
+    it('returns empty array for non-existent node', () => {
+      const model = createSchemaModel(schemaWithFormula());
+
+      const dependents = model.getFormulaDependents('non-existent');
+
+      expect(dependents).toHaveLength(0);
+    });
+
+    it('returns empty array when no formulas exist', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const dependents = model.getFormulaDependents(nameId!);
+
+      expect(dependents).toHaveLength(0);
+    });
+
+    it('updates when formula is added', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+      const ageId = findNodeIdByName(model, 'age');
+
+      expect(model.getFormulaDependents(nameId!)).toHaveLength(0);
+
+      model.updateFormula(ageId!, 'name');
+
+      expect(model.getFormulaDependents(nameId!)).toContain(ageId);
+    });
+
+    it('updates when formula is removed', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+      const totalId = findNodeIdByName(model, 'total');
+
+      expect(model.getFormulaDependents(priceId!)).toContain(totalId);
+
+      model.updateFormula(totalId!, undefined);
+
+      expect(model.getFormulaDependents(priceId!)).toHaveLength(0);
+    });
+  });
+
+  describe('hasFormulaDependents', () => {
+    it('returns true when field has dependents', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+
+      expect(model.hasFormulaDependents(priceId!)).toBe(true);
+    });
+
+    it('returns false when field has no dependents', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const totalId = findNodeIdByName(model, 'total');
+
+      expect(model.hasFormulaDependents(totalId!)).toBe(false);
+    });
+
+    it('returns false for non-existent node', () => {
+      const model = createSchemaModel(schemaWithFormula());
+
+      expect(model.hasFormulaDependents('non-existent')).toBe(false);
+    });
+
+    it('returns false when no formulas exist', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(model.hasFormulaDependents(nameId!)).toBe(false);
+    });
+
+    it('updates when formula is added', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+      const ageId = findNodeIdByName(model, 'age');
+
+      expect(model.hasFormulaDependents(nameId!)).toBe(false);
+
+      model.updateFormula(ageId!, 'name');
+
+      expect(model.hasFormulaDependents(nameId!)).toBe(true);
+    });
+
+    it('updates when formula is removed', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+      const totalId = findNodeIdByName(model, 'total');
+
+      expect(model.hasFormulaDependents(priceId!)).toBe(true);
+
+      model.updateFormula(totalId!, undefined);
+
+      expect(model.hasFormulaDependents(priceId!)).toBe(false);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.formulaDependents.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.formulaDependents.spec.ts
@@ -127,4 +127,27 @@ describe('SchemaModel formula dependents', () => {
       expect(model.hasFormulaDependents(priceId!)).toBe(false);
     });
   });
+
+  describe('replaceRoot clears formula index', () => {
+    it('clears formula dependents after replaceRoot', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+
+      expect(model.hasFormulaDependents(priceId!)).toBe(true);
+
+      model.replaceRoot('object');
+
+      expect(model.getFormulaDependents(priceId!)).toHaveLength(0);
+      expect(model.hasFormulaDependents(priceId!)).toBe(false);
+    });
+
+    it('returns empty dependents for any nodeId after replaceRoot to empty object', () => {
+      const model = createSchemaModel(schemaWithFormula());
+
+      model.replaceRoot('object');
+
+      expect(model.getFormulaDependents('any-id')).toHaveLength(0);
+      expect(model.hasFormulaDependents('any-id')).toBe(false);
+    });
+  });
 });

--- a/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  emptySchema,
+  simpleSchema,
+  schemaWithFormula,
+  findNodeIdByName,
+} from './test-helpers.js';
+
+describe('SchemaModel validation', () => {
+  describe('getValidationErrors', () => {
+    it('returns empty array for valid schema', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const errors = model.getValidationErrors();
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('detects empty field name after adding field with empty name', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+      const node = model.addField(rootId, '', 'string');
+
+      const errors = model.getValidationErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: node.id(),
+        type: 'empty-name',
+      });
+    });
+
+    it('detects invalid field name', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+      const node = model.addField(rootId, '123invalid', 'string');
+
+      const errors = model.getValidationErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: node.id(),
+        type: 'invalid-name',
+      });
+    });
+
+    it('detects reserved name starting with __', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+      const node = model.addField(rootId, '__reserved', 'string');
+
+      const errors = model.getValidationErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: node.id(),
+        type: 'invalid-name',
+      });
+    });
+
+    it('detects duplicate field names', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+      model.addField(rootId, 'field', 'string');
+      const duplicate = model.addField(rootId, 'field', 'string');
+
+      const errors = model.getValidationErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: duplicate.id(),
+        type: 'duplicate-name',
+      });
+    });
+  });
+
+  describe('getFormulaErrors', () => {
+    it('returns empty array when no formulas exist', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const errors = model.getFormulaErrors();
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('returns empty array for valid formulas', () => {
+      const model = createSchemaModel(schemaWithFormula());
+
+      const errors = model.getFormulaErrors();
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('detects missing formula dependency after field removal', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+
+      model.removeField(priceId!);
+
+      const errors = model.getFormulaErrors();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        nodeId: findNodeIdByName(model, 'total'),
+        message: 'Cannot resolve formula dependency: target node not found',
+      });
+    });
+  });
+
+  describe('isValid', () => {
+    it('returns true for valid schema', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.isValid()).toBe(true);
+    });
+
+    it('returns false when schema has validation errors', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root().id();
+      model.addField(rootId, '', 'string');
+
+      expect(model.isValid()).toBe(false);
+    });
+
+    it('returns false when schema has formula errors', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+
+      model.removeField(priceId!);
+
+      expect(model.isValid()).toBe(false);
+    });
+
+    it('returns false when root is not object', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.replaceRoot('array');
+
+      expect(model.isValid()).toBe(false);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.wrap.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.wrap.spec.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import {
+  emptySchema,
+  simpleSchema,
+  arraySchema,
+  findNodeIdByName,
+} from './test-helpers.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+
+describe('SchemaModel wrap operations', () => {
+  describe('wrapInArray', () => {
+    it('wraps primitive field in array', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      const result = model.wrapInArray(nameId!);
+
+      expect(result).not.toBeNull();
+      expect(result!.replacedNodeId).toBe(nameId);
+
+      const newNode = model.nodeById(result!.newNodeId);
+      expect(newNode.isArray()).toBe(true);
+      expect(newNode.name()).toBe('name');
+      expect(newNode.items().isNull()).toBe(false);
+    });
+
+    it('wraps object field in array', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['user'],
+        properties: {
+          user: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: ['name'],
+            properties: {
+              name: {
+                type: JsonSchemaTypeName.String,
+                default: '',
+              },
+            },
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const userId = findNodeIdByName(model, 'user');
+
+      const result = model.wrapInArray(userId!);
+
+      expect(result).not.toBeNull();
+      const arrayNode = model.nodeById(result!.newNodeId);
+      expect(arrayNode.isArray()).toBe(true);
+      expect(arrayNode.name()).toBe('user');
+      expect(arrayNode.items().isObject()).toBe(true);
+    });
+
+    it('returns null when node does not exist', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const result = model.wrapInArray('non-existent-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when node is already an array', () => {
+      const model = createSchemaModel(arraySchema());
+      const itemsId = findNodeIdByName(model, 'items');
+
+      const result = model.wrapInArray(itemsId!);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when trying to wrap root', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root().id();
+
+      const result = model.wrapInArray(rootId);
+
+      expect(result).toBeNull();
+    });
+
+    it('preserves field order after wrapping', () => {
+      const model = createSchemaModel(simpleSchema());
+      const root = model.root();
+      const originalOrder = root.properties().map((p) => p.name());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.wrapInArray(nameId!);
+
+      const newOrder = model.root().properties().map((p) => p.name());
+      expect(newOrder).toEqual(originalOrder);
+    });
+
+    it('generates correct patch', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.wrapInArray(nameId!);
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('marks model as dirty', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      expect(model.isDirty()).toBe(false);
+      model.wrapInArray(nameId!);
+      expect(model.isDirty()).toBe(true);
+    });
+  });
+
+  describe('wrapRootInArray', () => {
+    it('wraps object root in array', () => {
+      const model = createSchemaModel(simpleSchema());
+      const oldRootId = model.root().id();
+
+      const result = model.wrapRootInArray();
+
+      expect(result).not.toBeNull();
+      expect(result!.replacedNodeId).toBe(oldRootId);
+
+      const newRoot = model.root();
+      expect(newRoot.isArray()).toBe(true);
+      expect(newRoot.items().isObject()).toBe(true);
+    });
+
+    it('returns null when root is already an array', () => {
+      const model = createSchemaModel(emptySchema());
+      model.replaceRoot('array');
+
+      const result = model.wrapRootInArray();
+
+      expect(result).toBeNull();
+    });
+
+    it('preserves root children as items children', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.wrapRootInArray();
+
+      const items = model.root().items();
+      const nameNode = items.property('name');
+      const ageNode = items.property('age');
+
+      expect(nameNode.isNull()).toBe(false);
+      expect(ageNode.isNull()).toBe(false);
+    });
+
+    it('generates correct patch', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.wrapRootInArray();
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('marks model as dirty', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.isDirty()).toBe(false);
+      model.wrapRootInArray();
+      expect(model.isDirty()).toBe(true);
+    });
+  });
+
+  describe('replaceRoot', () => {
+    it('replaces object root with array', () => {
+      const model = createSchemaModel(simpleSchema());
+      const oldRootId = model.root().id();
+
+      const result = model.replaceRoot('array');
+
+      expect(result).not.toBeNull();
+      expect(result!.replacedNodeId).toBe(oldRootId);
+
+      const newRoot = model.root();
+      expect(newRoot.isArray()).toBe(true);
+      expect(newRoot.id()).toBe(result!.newNodeId);
+    });
+
+    it('replaces object root with string', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const result = model.replaceRoot('string');
+
+      expect(result).not.toBeNull();
+      const newRoot = model.root();
+      expect(newRoot.isPrimitive()).toBe(true);
+    });
+
+    it('preserves root name', () => {
+      const model = createSchemaModel(simpleSchema());
+      const originalName = model.root().name();
+
+      model.replaceRoot('array');
+
+      expect(model.root().name()).toBe(originalName);
+    });
+
+    it('generates correct patch', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      model.replaceRoot('array');
+
+      expect(model.getPatches()).toMatchSnapshot();
+    });
+
+    it('marks model as dirty', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      expect(model.isDirty()).toBe(false);
+      model.replaceRoot('array');
+      expect(model.isDirty()).toBe(true);
+    });
+
+    it('replaces with number type', () => {
+      const model = createSchemaModel(emptySchema());
+
+      const result = model.replaceRoot('number');
+
+      expect(result).not.toBeNull();
+      const newRoot = model.root();
+      expect(newRoot.isPrimitive()).toBe(true);
+    });
+
+    it('replaces with boolean type', () => {
+      const model = createSchemaModel(emptySchema());
+
+      const result = model.replaceRoot('boolean');
+
+      expect(result).not.toBeNull();
+      const newRoot = model.root();
+      expect(newRoot.isPrimitive()).toBe(true);
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.wrap.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.wrap.spec.ts.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel wrap operations replaceRoot generates correct patch 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": {
+      "fromType": "object",
+      "toType": "array<string>",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": "",
+      "toDefault": undefined,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "name",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "/properties/name",
+      "value": {
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": {
+      "fromType": "string",
+      "toType": "array<string>",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel wrap operations wrapRootInArray generates correct patch 1`] = `
+[
+  {
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "",
+    "foreignKeyChange": undefined,
+    "formulaChange": undefined,
+    "patch": {
+      "op": "replace",
+      "path": "",
+      "value": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "age": {
+              "default": 0,
+              "type": "number",
+            },
+            "name": {
+              "default": "",
+              "type": "string",
+            },
+          },
+          "required": [
+            "age",
+            "name",
+          ],
+          "type": "object",
+        },
+        "type": "array",
+      },
+    },
+    "typeChange": {
+      "fromType": "object",
+      "toType": "array<object>",
+    },
+  },
+]
+`;

--- a/src/model/schema-model/index.ts
+++ b/src/model/schema-model/index.ts
@@ -1,4 +1,4 @@
-export type { SchemaModel, ReactivityOptions, FieldType } from './types.js';
+export type { SchemaModel, ReactivityOptions, FieldType, ReplaceResult } from './types.js';
 export { createSchemaModel } from './SchemaModelImpl.js';
 export { SchemaParser } from './SchemaParser.js';
 export { NodeFactory } from './NodeFactory.js';

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -15,6 +15,11 @@ export type FieldType =
   | 'object'
   | 'array';
 
+export interface ReplaceResult {
+  replacedNodeId: string;
+  newNodeId: string;
+}
+
 export interface SchemaModel {
   root(): SchemaNode;
   nodeById(id: string): SchemaNode;
@@ -28,6 +33,19 @@ export interface SchemaModel {
   updateFormula(nodeId: string, expression: string | undefined): void;
   updateForeignKey(nodeId: string, foreignKey: string | undefined): void;
   updateDefaultValue(nodeId: string, value: unknown): void;
+
+  wrapInArray(nodeId: string): ReplaceResult | null;
+  wrapRootInArray(): ReplaceResult | null;
+  replaceRoot(newType: FieldType): ReplaceResult | null;
+
+  canMoveNode(nodeId: string, targetParentId: string): boolean;
+  hasValidDropTarget(nodeId: string): boolean;
+
+  getFormulaDependents(nodeId: string): readonly string[];
+  hasFormulaDependents(nodeId: string): boolean;
+
+  getValidationErrors(): import('../../core/validation/schema/types.js').SchemaValidationError[];
+  getFormulaErrors(): import('../../core/validation/formula/types.js').FormulaValidationError[];
 
   isDirty(): boolean;
   isValid(): boolean;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds schema and formula validation with clear errors, plus new editing APIs to wrap fields/roots in arrays and replace the root. This improves model correctness, drag‑drop safety, and schema tree operations.

- **New Features**
  - Validation
    - Schema: isValidFieldName, validateSchema with empty/duplicate/invalid name errors; docs added.
    - Formula: validateFormulas to detect missing dependencies; fieldPath included in errors.
    - SchemaModel: getValidationErrors, getFormulaErrors, isValid now checks both.
  - Editing & Queries
    - wrapInArray(nodeId), wrapRootInArray(), replaceRoot(newType) returning ReplaceResult.
    - Drag‑drop helpers: canMoveNode, hasValidDropTarget.
    - Formula dependents: getFormulaDependents, hasFormulaDependents.
  - Tree & Nodes
    - SchemaTree.replaceRoot(newRoot) with index rebuild; setNodeAt now uses replaceChild to preserve order.
    - SchemaNode.replaceChild(name, node) added; implemented in ObjectNode (BaseNode/NullNode default to false).
    - NodeFactory.createArrayNodeWithItems(name, items) helper.
  - Tests & Docs
    - Comprehensive tests for validators, wrap/replace, drag‑drop, and tree root replacement.
    - Validation README section with usage examples.

<sup>Written for commit 54a657bf73a3b16fc22ea6e66606af1c4f39ff1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

