### PR TITLE
feat: schema updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@revisium/formula": "^0.10.0",
+        "eventemitter3": "^5.0.4",
         "nanoid": "^3.3.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@jest/globals": "^29.7.0",
+        "@types/eventemitter3": "^1.2.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^24.10.7",
         "ajv": "^8.17.1",
@@ -2212,6 +2214,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha512-qB+RJcqIM5b8/CfmjqiBylK2KxBGKpRlewjsfq+IVFrDhclWO9JodK4g3NbY0Kpf/3CcLbz+tHMH6bxJEw0Z3A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -3561,6 +3570,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@jest/globals": "^29.7.0",
-        "@types/eventemitter3": "^1.2.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^24.10.7",
         "ajv": "^8.17.1",
@@ -2211,13 +2210,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha512-qB+RJcqIM5b8/CfmjqiBylK2KxBGKpRlewjsfq+IVFrDhclWO9JodK4g3NbY0Kpf/3CcLbz+tHMH6bxJEw0Z3A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@jest/globals": "^29.7.0",
-    "@types/eventemitter3": "^1.2.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.10.7",
     "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@jest/globals": "^29.7.0",
+    "@types/eventemitter3": "^1.2.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.10.7",
     "ajv": "^8.17.1",
@@ -186,6 +187,7 @@
   },
   "dependencies": {
     "@revisium/formula": "^0.10.0",
+    "eventemitter3": "^5.0.4",
     "nanoid": "^3.3.7"
   },
   "engines": {

--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -81,6 +81,10 @@ export abstract class BaseNode implements SchemaNode {
     return undefined;
   }
 
+  contentMediaType(): string | undefined {
+    return undefined;
+  }
+
   abstract clone(): SchemaNode;
 
   setName(name: string): void {
@@ -116,6 +120,10 @@ export abstract class BaseNode implements SchemaNode {
   }
 
   setForeignKey(_key: string | undefined): void {
+    // No-op by default
+  }
+
+  setContentMediaType(_mediaType: string | undefined): void {
     // No-op by default
   }
 }

--- a/src/core/schema-node/NullNode.ts
+++ b/src/core/schema-node/NullNode.ts
@@ -109,6 +109,14 @@ class NullNodeImpl implements SchemaNode {
   setForeignKey(_key: string | undefined): void {
     // No-op for null
   }
+
+  contentMediaType(): string | undefined {
+    return undefined;
+  }
+
+  setContentMediaType(_mediaType: string | undefined): void {
+    // No-op for null
+  }
 }
 
 export const NULL_NODE: SchemaNode = new NullNodeImpl();

--- a/src/core/schema-node/StringNode.ts
+++ b/src/core/schema-node/StringNode.ts
@@ -1,4 +1,5 @@
 import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
+import type { ContentMediaType } from '../../types/index.js';
 import { PrimitiveNode } from './PrimitiveNode.js';
 
 export interface StringNodeOptions {
@@ -6,19 +7,31 @@ export interface StringNodeOptions {
   readonly foreignKey?: string;
   readonly formula?: Formula;
   readonly metadata?: NodeMetadata;
+  readonly contentMediaType?: ContentMediaType;
 }
 
 export class StringNode extends PrimitiveNode {
+  private _contentMediaType: ContentMediaType | undefined;
+
   constructor(
     id: string,
     name: string,
     options: StringNodeOptions = {},
   ) {
     super(id, name, options);
+    this._contentMediaType = options.contentMediaType;
   }
 
   nodeType(): NodeType {
     return 'string';
+  }
+
+  contentMediaType(): ContentMediaType | undefined {
+    return this._contentMediaType;
+  }
+
+  setContentMediaType(mediaType: ContentMediaType | undefined): void {
+    this._contentMediaType = mediaType;
   }
 
   clone(): SchemaNode {
@@ -31,6 +44,7 @@ export class StringNode extends PrimitiveNode {
       foreignKey: this._foreignKey,
       formula: this._formula,
       metadata: this._metadata,
+      contentMediaType: this._contentMediaType,
     };
   }
 }

--- a/src/core/schema-node/types.ts
+++ b/src/core/schema-node/types.ts
@@ -40,6 +40,7 @@ export interface SchemaNode {
   hasFormula(): boolean;
   defaultValue(): unknown;
   foreignKey(): string | undefined;
+  contentMediaType(): string | undefined;
 
   clone(): SchemaNode;
 
@@ -52,4 +53,5 @@ export interface SchemaNode {
   setDefaultValue(value: unknown): void;
   setFormula(formula: Formula | undefined): void;
   setForeignKey(key: string | undefined): void;
+  setContentMediaType(mediaType: string | undefined): void;
 }

--- a/src/core/schema-patch/PatchGenerator.ts
+++ b/src/core/schema-patch/PatchGenerator.ts
@@ -14,6 +14,7 @@ import type {
   RemovedChange,
   ModifiedChange,
 } from '../schema-diff/index.js';
+import type { JsonPatchMove } from '../../types/index.js';
 import type { JsonPatch } from './types.js';
 
 export class PatchGenerator {
@@ -41,7 +42,7 @@ export class PatchGenerator {
     const childChangePaths = new Set([
       ...addPatches.map((p) => p.path),
       ...removePatches.map((p) => p.path),
-      ...movePatches.flatMap((p) => [p.path, p.from ?? '']).filter(Boolean),
+      ...movePatches.flatMap((p) => [p.path, (p as JsonPatchMove).from]).filter(Boolean),
     ]);
 
     const replacePatches = this.generateReplacePatches(

--- a/src/core/schema-patch/__tests__/PatchEnricher.edgeCases.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.edgeCases.spec.ts
@@ -16,7 +16,7 @@ describe('PatchEnricher edge cases', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: 'invalid-no-slash' };
+      const patch = { op: 'add', path: 'invalid-no-slash' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -44,10 +44,10 @@ describe('PatchEnricher edge cases', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = {
+      const patch = {
         op: 'add',
         path: '/properties/nonexistent/properties/deep',
-      };
+      } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });

--- a/src/core/schema-patch/__tests__/PatchEnricher.replace.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.replace.spec.ts
@@ -21,7 +21,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     current.trackReplacement('old-field', 'new-field');
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -35,7 +35,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     current.trackReplacement('old-field', 'new-field');
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -47,7 +47,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -59,7 +59,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -71,7 +71,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -83,7 +83,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -95,7 +95,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -107,7 +107,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -119,7 +119,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/field' };
+    const patch = { op: 'replace', path: '/properties/field' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });
@@ -131,7 +131,7 @@ describe('PatchEnricher replace patch enrichment', () => {
     );
 
     const enricher = new PatchEnricher(current, base);
-    const patch: JsonPatch = { op: 'replace', path: '/properties/items' };
+    const patch = { op: 'replace', path: '/properties/items' } as JsonPatch;
 
     expect(enricher.enrich(patch)).toMatchSnapshot();
   });

--- a/src/core/schema-patch/__tests__/PatchEnricher.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.spec.ts
@@ -21,7 +21,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, current);
-      const patch: JsonPatch = { op: 'replace', path: '/properties/name' };
+      const patch = { op: 'replace', path: '/properties/name' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -33,7 +33,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, current);
-      const patch: JsonPatch = { op: 'replace', path: '/properties/nested/properties/field' };
+      const patch = { op: 'replace', path: '/properties/nested/properties/field' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -45,7 +45,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, current);
-      const patch: JsonPatch = { op: 'replace', path: '/properties/items/items/properties/name' };
+      const patch = { op: 'replace', path: '/properties/items/items/properties/name' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -59,7 +59,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: '/properties/computed' };
+      const patch = { op: 'add', path: '/properties/computed' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -71,7 +71,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+      const patch = { op: 'add', path: '/properties/field' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -83,7 +83,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+      const patch = { op: 'add', path: '/properties/field' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -95,7 +95,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+      const patch = { op: 'add', path: '/properties/field' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -107,7 +107,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: '/properties/categoryId' };
+      const patch = { op: 'add', path: '/properties/categoryId' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -119,7 +119,19 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'add', path: '/properties/field' };
+      const patch = { op: 'add', path: '/properties/field' } as JsonPatch;
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('includes contentMediaType in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([str('avatar', { contentMediaType: 'text/plain' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch = { op: 'add', path: '/properties/avatar' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -147,7 +159,7 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'replace', path: '' };
+      const patch = { op: 'replace', path: '' } as JsonPatch;
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });
@@ -159,7 +171,133 @@ describe('PatchEnricher', () => {
       );
 
       const enricher = new PatchEnricher(current, base);
-      const patch: JsonPatch = { op: 'replace', path: '' };
+      const patch = { op: 'replace', path: '' } as JsonPatch;
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+
+  describe('replace patch enrichment', () => {
+    it('detects contentMediaType change', () => {
+      const { base, current } = treePair(
+        objRoot([str('image', { contentMediaType: 'text/plain' })]),
+        objRoot([str('image', { contentMediaType: 'text/markdown' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch = { op: 'replace', path: '/properties/image' } as JsonPatch;
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('detects contentMediaType removal', () => {
+      const { base, current } = treePair(
+        objRoot([str('image', { contentMediaType: 'text/plain' })]),
+        objRoot([str('image')]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch = { op: 'replace', path: '/properties/image' } as JsonPatch;
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('detects contentMediaType addition', () => {
+      const { base, current } = treePair(
+        objRoot([str('image')]),
+        objRoot([str('image', { contentMediaType: 'text/plain' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch = { op: 'replace', path: '/properties/image' } as JsonPatch;
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+  });
+
+  describe('move patch enrichment', () => {
+    it('detects rename (same parent)', () => {
+      const { base, current } = treePair(
+        objRoot([str('oldName')]),
+        objRoot([str('newName')]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'move',
+        from: '/properties/oldName',
+        path: '/properties/newName',
+      };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('detects movesIntoArray when moving from root to array items', () => {
+      const { base, current } = treePair(
+        objRoot([str('field'), arr('items', obj('', []))]),
+        objRoot([arr('items', obj('', [str('field')]))]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'move',
+        from: '/properties/field',
+        path: '/properties/items/items/properties/field',
+      };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('does not set movesIntoArray when moving within same level', () => {
+      const { base, current } = treePair(
+        objRoot([obj('nested', [str('field')])]),
+        objRoot([obj('other', [str('field')])]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'move',
+        from: '/properties/nested/properties/field',
+        path: '/properties/other/properties/field',
+      };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('does not set movesIntoArray when moving out of array', () => {
+      const { base, current } = treePair(
+        objRoot([arr('items', obj('', [str('field')]))]),
+        objRoot([arr('items', obj('', [])), str('field')]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'move',
+        from: '/properties/items/items/properties/field',
+        path: '/properties/field',
+      };
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('detects movesIntoArray when moving into deeper array nesting', () => {
+      const { base, current } = treePair(
+        objRoot([
+          arr('outer', obj('', [str('field')])),
+          arr('items', obj('', [arr('nested', obj('', []))])),
+        ]),
+        objRoot([
+          arr('outer', obj('', [])),
+          arr('items', obj('', [arr('nested', obj('', [str('field')]))])),
+        ]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch: JsonPatch = {
+        op: 'move',
+        from: '/properties/outer/items/properties/field',
+        path: '/properties/items/items/properties/nested/items/properties/field',
+      };
 
       expect(enricher.enrich(patch)).toMatchSnapshot();
     });

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.arrays.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.arrays.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`PatchBuilder array operations generates add patch for field inside arra
 [
   {
     "fieldName": "items[*].newField",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/items/items/properties/newField",
@@ -22,6 +23,8 @@ exports[`PatchBuilder array operations generates move patch for renamed field in
     "fieldName": "items[*].newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/items/items/properties/oldName",
       "op": "move",
@@ -35,6 +38,7 @@ exports[`PatchBuilder array operations generates remove patch for field inside a
 [
   {
     "fieldName": "items[*].fieldA",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/items/items/properties/fieldA",
@@ -46,6 +50,7 @@ exports[`PatchBuilder array operations generates remove patch for field inside a
 exports[`PatchBuilder array operations generates replace patch for array when only array metadata changes 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": {
@@ -55,6 +60,9 @@ exports[`PatchBuilder array operations generates replace patch for array when on
     "fieldName": "items",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items",
@@ -75,6 +83,7 @@ exports[`PatchBuilder array operations generates replace patch for array when on
 exports[`PatchBuilder array operations generates replace patch for field inside array items 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "initial",
       "toDefault": "modified",
@@ -84,6 +93,9 @@ exports[`PatchBuilder array operations generates replace patch for field inside 
     "fieldName": "items[*].name",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items/properties/name",
@@ -100,12 +112,14 @@ exports[`PatchBuilder array operations generates replace patch for field inside 
 exports[`PatchBuilder array operations generates replace patch for items when array items type changes 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "items[*]",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items",
@@ -125,6 +139,7 @@ exports[`PatchBuilder array operations generates replace patch for items when ar
 exports[`PatchBuilder array operations generates two patches when both array metadata and items type change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": {
@@ -134,6 +149,9 @@ exports[`PatchBuilder array operations generates two patches when both array met
     "fieldName": "items",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items",
@@ -149,12 +167,14 @@ exports[`PatchBuilder array operations generates two patches when both array met
     "typeChange": undefined,
   },
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "items[*]",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.basic.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.basic.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`PatchBuilder basic operations adding nested field generates add patch f
 [
   {
     "fieldName": "nested.new",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/nested/properties/new",
@@ -20,6 +21,7 @@ exports[`PatchBuilder basic operations adding top-level field generates add patc
 [
   {
     "fieldName": "newField",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -35,6 +37,7 @@ exports[`PatchBuilder basic operations adding top-level field generates add patc
 exports[`PatchBuilder basic operations modifying field generates replace patch when default value changes 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "initial",
       "toDefault": "modified",
@@ -44,6 +47,9 @@ exports[`PatchBuilder basic operations modifying field generates replace patch w
     "fieldName": "name",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -63,6 +69,7 @@ exports[`PatchBuilder basic operations removing field generates remove patch whe
 [
   {
     "fieldName": "nested.fieldA",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/nested/properties/fieldA",
@@ -75,6 +82,7 @@ exports[`PatchBuilder basic operations removing field generates remove patch whe
 [
   {
     "fieldName": "name",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/name",
@@ -89,6 +97,8 @@ exports[`PatchBuilder basic operations renaming field generates move patch when 
     "fieldName": "newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldName",
       "op": "move",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.edgeCases.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.edgeCases.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`PatchBuilder edge cases removes parent with children - single remove pa
 [
   {
     "fieldName": "parent",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/parent",
@@ -18,6 +19,8 @@ exports[`PatchBuilder edge cases rename + modify generates move then replace 1`]
     "fieldName": "newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldName",
       "op": "move",
@@ -25,6 +28,7 @@ exports[`PatchBuilder edge cases rename + modify generates move then replace 1`]
     },
   },
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": undefined,
       "toDefault": "modified",
@@ -34,6 +38,9 @@ exports[`PatchBuilder edge cases rename + modify generates move then replace 1`]
     "fieldName": "newName",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/newName",
@@ -53,6 +60,8 @@ exports[`PatchBuilder edge cases renames parent - children move together, single
     "fieldName": "newParent",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldParent",
       "op": "move",
@@ -70,6 +79,8 @@ exports[`PatchBuilder patch ordering array items rename with nested modification
     "fieldName": "items[*].newField",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/items/items/properties/oldField",
       "op": "move",
@@ -77,6 +88,7 @@ exports[`PatchBuilder patch ordering array items rename with nested modification
     },
   },
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": undefined,
       "toDefault": "modified",
@@ -86,6 +98,9 @@ exports[`PatchBuilder patch ordering array items rename with nested modification
     "fieldName": "items[*].newField",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items/properties/newField",
@@ -105,6 +120,8 @@ exports[`PatchBuilder patch ordering move patches come before add/remove 1`] = `
     "fieldName": "renamedA",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/fieldA",
       "op": "move",
@@ -113,6 +130,7 @@ exports[`PatchBuilder patch ordering move patches come before add/remove 1`] = `
   },
   {
     "fieldName": "newField",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -124,6 +142,7 @@ exports[`PatchBuilder patch ordering move patches come before add/remove 1`] = `
   },
   {
     "fieldName": "fieldB",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/fieldB",
@@ -138,6 +157,8 @@ exports[`PatchBuilder patch ordering multiple renames in sequence 1`] = `
     "fieldName": "x",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/a",
       "op": "move",
@@ -148,6 +169,8 @@ exports[`PatchBuilder patch ordering multiple renames in sequence 1`] = `
     "fieldName": "y",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/b",
       "op": "move",
@@ -158,6 +181,8 @@ exports[`PatchBuilder patch ordering multiple renames in sequence 1`] = `
     "fieldName": "z",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/c",
       "op": "move",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "initial",
       "toDefault": "modified",
@@ -12,6 +13,9 @@ exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -28,6 +32,7 @@ exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": {
       "fromDeprecated": undefined,
@@ -37,6 +42,9 @@ exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "deprecated",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -54,6 +62,7 @@ exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": {
@@ -63,6 +72,9 @@ exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -80,6 +92,7 @@ exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
@@ -89,6 +102,9 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
       "toForeignKey": "users",
     },
     "formulaChange": undefined,
+    "metadataChanges": [
+      "foreignKey",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -106,6 +122,7 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
@@ -115,6 +132,9 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
       "toForeignKey": "categories",
     },
     "formulaChange": undefined,
+    "metadataChanges": [
+      "foreignKey",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -132,6 +152,7 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
@@ -141,6 +162,9 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
       "toForeignKey": undefined,
     },
     "formulaChange": undefined,
+    "metadataChanges": [
+      "foreignKey",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -157,6 +181,7 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
@@ -168,6 +193,9 @@ exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
       "toFormula": "value * 2",
       "toVersion": 1,
     },
+    "metadataChanges": [
+      "formula",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -189,6 +217,7 @@ exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
@@ -200,6 +229,9 @@ exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
       "toFormula": undefined,
       "toVersion": undefined,
     },
+    "metadataChanges": [
+      "formula",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/computed",
@@ -216,12 +248,14 @@ exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects type change from string to number 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -244,6 +278,8 @@ exports[`PatchBuilder SchemaPatch metadata marks move as rename when parent is s
     "fieldName": "newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldName",
       "op": "move",
@@ -261,6 +297,9 @@ exports[`PatchBuilder add patch metadata includes default value in add patch whe
       "toDefault": "my default",
     },
     "fieldName": "field",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field",
@@ -281,6 +320,9 @@ exports[`PatchBuilder add patch metadata includes deprecated in add patch when f
       "toDeprecated": true,
     },
     "fieldName": "field",
+    "metadataChanges": [
+      "deprecated",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field",
@@ -302,6 +344,9 @@ exports[`PatchBuilder add patch metadata includes description in add patch when 
       "toDescription": "My description",
     },
     "fieldName": "field",
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field",
@@ -323,6 +368,9 @@ exports[`PatchBuilder add patch metadata includes foreignKey in add patch when f
       "fromForeignKey": undefined,
       "toForeignKey": "categories",
     },
+    "metadataChanges": [
+      "foreignKey",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/categoryId",
@@ -346,6 +394,9 @@ exports[`PatchBuilder add patch metadata includes formula in add patch when fiel
       "toFormula": "value * 2",
       "toVersion": 1,
     },
+    "metadataChanges": [
+      "formula",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/computed",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
@@ -6,6 +6,8 @@ exports[`PatchBuilder nested operations generates move patch for renamed nested 
     "fieldName": "nested.newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/nested/properties/oldName",
       "op": "move",
@@ -18,6 +20,7 @@ exports[`PatchBuilder nested operations generates move patch for renamed nested 
 exports[`PatchBuilder nested operations generates multiple patches for multiple changes in one object 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "a",
       "toDefault": "modified",
@@ -27,6 +30,9 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
     "fieldName": "nested.fieldA",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/nested/properties/fieldA",
@@ -39,6 +45,7 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
   },
   {
     "fieldName": "nested.fieldD",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/nested/properties/fieldD",
@@ -50,6 +57,7 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
   },
   {
     "fieldName": "nested.fieldB",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/nested/properties/fieldB",
@@ -61,6 +69,7 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
 exports[`PatchBuilder nested operations generates replace patch for nested field modification 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": 10,
       "toDefault": 20,
@@ -70,6 +79,9 @@ exports[`PatchBuilder nested operations generates replace patch for nested field
     "fieldName": "nested.value",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/nested/properties/value",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.rootChanges.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.rootChanges.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`PatchBuilder root changes array root array root - description change on root 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": {
@@ -12,6 +13,9 @@ exports[`PatchBuilder root changes array root array root - description change on
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -32,6 +36,7 @@ exports[`PatchBuilder root changes array root array root - description change on
 exports[`PatchBuilder root changes array root array root - items default value change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "old",
       "toDefault": "new",
@@ -41,6 +46,9 @@ exports[`PatchBuilder root changes array root array root - items default value c
     "fieldName": "[*]",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/items",
@@ -58,6 +66,7 @@ exports[`PatchBuilder root changes array root array root with object items - add
 [
   {
     "fieldName": "[*].new",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/items/properties/new",
@@ -74,6 +83,7 @@ exports[`PatchBuilder root changes array root array root with object items - rem
 [
   {
     "fieldName": "[*].fieldA",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/items/properties/fieldA",
@@ -88,6 +98,8 @@ exports[`PatchBuilder root changes array root array root with object items - ren
     "fieldName": "[*].newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/items/properties/oldName",
       "op": "move",
@@ -102,6 +114,7 @@ exports[`PatchBuilder root changes array root array root with primitive items - 
 exports[`PatchBuilder root changes nested arrays array of arrays - inner items change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "old",
       "toDefault": "new",
@@ -111,6 +124,9 @@ exports[`PatchBuilder root changes nested arrays array of arrays - inner items c
     "fieldName": "[*][*]",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/items/items",
@@ -130,6 +146,7 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - ad
 [
   {
     "fieldName": "[*][*].new",
+    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/items/items/properties/new",
@@ -146,6 +163,7 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - re
 [
   {
     "fieldName": "[*][*].fieldA",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/items/items/properties/fieldA",
@@ -160,6 +178,8 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - re
     "fieldName": "[*][*].newName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/items/items/properties/oldName",
       "op": "move",
@@ -172,6 +192,7 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - re
 exports[`PatchBuilder root changes object root generates replace patch when root deprecated changes 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": {
       "fromDeprecated": undefined,
@@ -181,6 +202,9 @@ exports[`PatchBuilder root changes object root generates replace patch when root
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "deprecated",
+    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -207,6 +231,7 @@ exports[`PatchBuilder root changes object root generates replace patch when root
 exports[`PatchBuilder root changes object root generates replace patch when root description changes 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": {
@@ -216,6 +241,9 @@ exports[`PatchBuilder root changes object root generates replace patch when root
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -242,6 +270,7 @@ exports[`PatchBuilder root changes object root generates replace patch when root
 exports[`PatchBuilder root changes primitive root boolean root - deprecated change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": {
       "fromDeprecated": undefined,
@@ -251,6 +280,9 @@ exports[`PatchBuilder root changes primitive root boolean root - deprecated chan
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "deprecated",
+    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -268,6 +300,7 @@ exports[`PatchBuilder root changes primitive root boolean root - deprecated chan
 exports[`PatchBuilder root changes primitive root number root - default value change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": 0,
       "toDefault": 42,
@@ -277,6 +310,9 @@ exports[`PatchBuilder root changes primitive root number root - default value ch
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -293,6 +329,7 @@ exports[`PatchBuilder root changes primitive root number root - default value ch
 exports[`PatchBuilder root changes primitive root string root - default value change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "old",
       "toDefault": "new",
@@ -302,6 +339,9 @@ exports[`PatchBuilder root changes primitive root string root - default value ch
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -318,6 +358,7 @@ exports[`PatchBuilder root changes primitive root string root - default value ch
 exports[`PatchBuilder root changes primitive root string root - description change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": {
@@ -327,6 +368,9 @@ exports[`PatchBuilder root changes primitive root string root - description chan
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "description",
+    ],
     "patch": {
       "op": "replace",
       "path": "",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.typeChanges.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.typeChanges.spec.ts.snap
@@ -3,12 +3,14 @@
 exports[`PatchBuilder type changes object to array 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -31,12 +33,14 @@ exports[`PatchBuilder type changes object to array 1`] = `
 exports[`PatchBuilder type changes object to primitive 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -56,12 +60,14 @@ exports[`PatchBuilder type changes object to primitive 1`] = `
 exports[`PatchBuilder type changes primitive to array 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -84,12 +90,14 @@ exports[`PatchBuilder type changes primitive to array 1`] = `
 exports[`PatchBuilder type changes primitive to object 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.edgeCases.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.edgeCases.spec.ts.snap
@@ -5,6 +5,8 @@ exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in 
   "fieldName": "field",
   "formulaChange": undefined,
   "isRename": undefined,
+  "metadataChanges": [],
+  "movesIntoArray": undefined,
   "patch": {
     "from": "invalid-no-slash",
     "op": "move",
@@ -16,6 +18,7 @@ exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in 
 exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in path 1`] = `
 {
   "fieldName": "",
+  "metadataChanges": [],
   "patch": {
     "op": "add",
     "path": "invalid-no-slash",
@@ -26,6 +29,7 @@ exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in 
 exports[`PatchEnricher edge cases invalid paths handles path to non-existent node 1`] = `
 {
   "fieldName": "nonexistent.deep",
+  "metadataChanges": [],
   "patch": {
     "op": "add",
     "path": "/properties/nonexistent/properties/deep",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
@@ -10,6 +10,10 @@ exports[`PatchEnricher move patch enrichment detects formula change on move 1`] 
     "toVersion": 1,
   },
   "isRename": true,
+  "metadataChanges": [
+    "formula",
+  ],
+  "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/oldName",
     "op": "move",
@@ -23,6 +27,8 @@ exports[`PatchEnricher move patch enrichment does not mark as rename when parent
   "fieldName": "target.field",
   "formulaChange": undefined,
   "isRename": undefined,
+  "metadataChanges": [],
+  "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/source/properties/field",
     "op": "move",
@@ -36,6 +42,8 @@ exports[`PatchEnricher move patch enrichment marks as rename when parent is same
   "fieldName": "newName",
   "formulaChange": undefined,
   "isRename": true,
+  "metadataChanges": [],
+  "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/oldName",
     "op": "move",
@@ -46,12 +54,14 @@ exports[`PatchEnricher move patch enrichment marks as rename when parent is same
 
 exports[`PatchEnricher replace patch enrichment detects array type with items 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
   "fieldName": "field",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -65,6 +75,7 @@ exports[`PatchEnricher replace patch enrichment detects array type with items 1`
 
 exports[`PatchEnricher replace patch enrichment detects default value change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": {
     "fromDefault": "old",
     "toDefault": "new",
@@ -74,6 +85,9 @@ exports[`PatchEnricher replace patch enrichment detects default value change 1`]
   "fieldName": "field",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [
+    "default",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -84,6 +98,7 @@ exports[`PatchEnricher replace patch enrichment detects default value change 1`]
 
 exports[`PatchEnricher replace patch enrichment detects deprecated change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": {
     "fromDeprecated": undefined,
@@ -93,6 +108,9 @@ exports[`PatchEnricher replace patch enrichment detects deprecated change 1`] = 
   "fieldName": "field",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [
+    "deprecated",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -103,6 +121,7 @@ exports[`PatchEnricher replace patch enrichment detects deprecated change 1`] = 
 
 exports[`PatchEnricher replace patch enrichment detects description change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": {
@@ -112,6 +131,9 @@ exports[`PatchEnricher replace patch enrichment detects description change 1`] =
   "fieldName": "field",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [
+    "description",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -122,6 +144,7 @@ exports[`PatchEnricher replace patch enrichment detects description change 1`] =
 
 exports[`PatchEnricher replace patch enrichment detects foreignKey change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
@@ -131,6 +154,9 @@ exports[`PatchEnricher replace patch enrichment detects foreignKey change 1`] = 
     "toForeignKey": "categories",
   },
   "formulaChange": undefined,
+  "metadataChanges": [
+    "foreignKey",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -141,6 +167,7 @@ exports[`PatchEnricher replace patch enrichment detects foreignKey change 1`] = 
 
 exports[`PatchEnricher replace patch enrichment detects formula addition 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
@@ -152,6 +179,9 @@ exports[`PatchEnricher replace patch enrichment detects formula addition 1`] = `
     "toFormula": "value * 2",
     "toVersion": 1,
   },
+  "metadataChanges": [
+    "formula",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -162,6 +192,7 @@ exports[`PatchEnricher replace patch enrichment detects formula addition 1`] = `
 
 exports[`PatchEnricher replace patch enrichment detects formula change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
@@ -173,6 +204,9 @@ exports[`PatchEnricher replace patch enrichment detects formula change 1`] = `
     "toFormula": "value * 3",
     "toVersion": 1,
   },
+  "metadataChanges": [
+    "formula",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -183,6 +217,7 @@ exports[`PatchEnricher replace patch enrichment detects formula change 1`] = `
 
 exports[`PatchEnricher replace patch enrichment detects formula removal 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
@@ -194,6 +229,9 @@ exports[`PatchEnricher replace patch enrichment detects formula removal 1`] = `
     "toFormula": undefined,
     "toVersion": undefined,
   },
+  "metadataChanges": [
+    "formula",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -204,12 +242,14 @@ exports[`PatchEnricher replace patch enrichment detects formula removal 1`] = `
 
 exports[`PatchEnricher replace patch enrichment detects type change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
   "fieldName": "field",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
@@ -223,6 +263,7 @@ exports[`PatchEnricher replace patch enrichment detects type change 1`] = `
 
 exports[`PatchEnricher replace patch enrichment skips defaultChange for array replace when only metadata changes 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": {
@@ -232,6 +273,9 @@ exports[`PatchEnricher replace patch enrichment skips defaultChange for array re
   "fieldName": "items",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [
+    "description",
+  ],
   "patch": {
     "op": "replace",
     "path": "/properties/items",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PatchEnricher add patch enrichment includes contentMediaType in add patch metadata 1`] = `
+{
+  "contentMediaTypeChange": {
+    "fromContentMediaType": undefined,
+    "toContentMediaType": "text/plain",
+  },
+  "fieldName": "avatar",
+  "metadataChanges": [
+    "contentMediaType",
+  ],
+  "patch": {
+    "op": "add",
+    "path": "/properties/avatar",
+  },
+}
+`;
+
 exports[`PatchEnricher add patch enrichment includes deprecated in add patch metadata 1`] = `
 {
   "deprecatedChange": {
@@ -7,6 +24,9 @@ exports[`PatchEnricher add patch enrichment includes deprecated in add patch met
     "toDeprecated": true,
   },
   "fieldName": "field",
+  "metadataChanges": [
+    "deprecated",
+  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
@@ -21,6 +41,9 @@ exports[`PatchEnricher add patch enrichment includes description in add patch me
     "toDescription": "My description",
   },
   "fieldName": "field",
+  "metadataChanges": [
+    "description",
+  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
@@ -35,6 +58,9 @@ exports[`PatchEnricher add patch enrichment includes foreignKey in add patch met
     "fromForeignKey": undefined,
     "toForeignKey": "categories",
   },
+  "metadataChanges": [
+    "foreignKey",
+  ],
   "patch": {
     "op": "add",
     "path": "/properties/categoryId",
@@ -51,6 +77,9 @@ exports[`PatchEnricher add patch enrichment includes formula in add patch metada
     "toFormula": "value * 2",
     "toVersion": 1,
   },
+  "metadataChanges": [
+    "formula",
+  ],
   "patch": {
     "op": "add",
     "path": "/properties/computed",
@@ -65,6 +94,9 @@ exports[`PatchEnricher add patch enrichment includes non-standard default value 
     "toDefault": "my default",
   },
   "fieldName": "field",
+  "metadataChanges": [
+    "default",
+  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
@@ -79,6 +111,9 @@ exports[`PatchEnricher add patch enrichment skips standard default values in add
     "toDefault": "",
   },
   "fieldName": "field",
+  "metadataChanges": [
+    "default",
+  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
@@ -88,12 +123,14 @@ exports[`PatchEnricher add patch enrichment skips standard default values in add
 
 exports[`PatchEnricher fieldName extraction extracts array items field name 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
   "fieldName": "items[*].name",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/items/items/properties/name",
@@ -104,12 +141,14 @@ exports[`PatchEnricher fieldName extraction extracts array items field name 1`] 
 
 exports[`PatchEnricher fieldName extraction extracts nested field name 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
   "fieldName": "nested.field",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/nested/properties/field",
@@ -120,12 +159,14 @@ exports[`PatchEnricher fieldName extraction extracts nested field name 1`] = `
 
 exports[`PatchEnricher fieldName extraction extracts simple field name 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": undefined,
   "fieldName": "name",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/name",
@@ -134,9 +175,85 @@ exports[`PatchEnricher fieldName extraction extracts simple field name 1`] = `
 }
 `;
 
+exports[`PatchEnricher move patch enrichment detects movesIntoArray when moving from root to array items 1`] = `
+{
+  "fieldName": "items[*].field",
+  "formulaChange": undefined,
+  "isRename": undefined,
+  "metadataChanges": [],
+  "movesIntoArray": true,
+  "patch": {
+    "from": "/properties/field",
+    "op": "move",
+    "path": "/properties/items/items/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher move patch enrichment detects movesIntoArray when moving into deeper array nesting 1`] = `
+{
+  "fieldName": "items[*].nested[*].field",
+  "formulaChange": undefined,
+  "isRename": undefined,
+  "metadataChanges": [],
+  "movesIntoArray": true,
+  "patch": {
+    "from": "/properties/outer/items/properties/field",
+    "op": "move",
+    "path": "/properties/items/items/properties/nested/items/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher move patch enrichment detects rename (same parent) 1`] = `
+{
+  "fieldName": "newName",
+  "formulaChange": undefined,
+  "isRename": true,
+  "metadataChanges": [],
+  "movesIntoArray": undefined,
+  "patch": {
+    "from": "/properties/oldName",
+    "op": "move",
+    "path": "/properties/newName",
+  },
+}
+`;
+
+exports[`PatchEnricher move patch enrichment does not set movesIntoArray when moving out of array 1`] = `
+{
+  "fieldName": "field",
+  "formulaChange": undefined,
+  "isRename": undefined,
+  "metadataChanges": [],
+  "movesIntoArray": undefined,
+  "patch": {
+    "from": "/properties/items/items/properties/field",
+    "op": "move",
+    "path": "/properties/field",
+  },
+}
+`;
+
+exports[`PatchEnricher move patch enrichment does not set movesIntoArray when moving within same level 1`] = `
+{
+  "fieldName": "other.field",
+  "formulaChange": undefined,
+  "isRename": undefined,
+  "metadataChanges": [],
+  "movesIntoArray": undefined,
+  "patch": {
+    "from": "/properties/nested/properties/field",
+    "op": "move",
+    "path": "/properties/other/properties/field",
+  },
+}
+`;
+
 exports[`PatchEnricher remove patch enrichment returns patch with fieldName only 1`] = `
 {
   "fieldName": "field",
+  "metadataChanges": [],
   "patch": {
     "op": "remove",
     "path": "/properties/field",
@@ -144,8 +261,78 @@ exports[`PatchEnricher remove patch enrichment returns patch with fieldName only
 }
 `;
 
+exports[`PatchEnricher replace patch enrichment detects contentMediaType addition 1`] = `
+{
+  "contentMediaTypeChange": {
+    "fromContentMediaType": undefined,
+    "toContentMediaType": "text/plain",
+  },
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "image",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "metadataChanges": [
+    "contentMediaType",
+  ],
+  "patch": {
+    "op": "replace",
+    "path": "/properties/image",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects contentMediaType change 1`] = `
+{
+  "contentMediaTypeChange": {
+    "fromContentMediaType": "text/plain",
+    "toContentMediaType": "text/markdown",
+  },
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "image",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "metadataChanges": [
+    "contentMediaType",
+  ],
+  "patch": {
+    "op": "replace",
+    "path": "/properties/image",
+  },
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects contentMediaType removal 1`] = `
+{
+  "contentMediaTypeChange": {
+    "fromContentMediaType": "text/plain",
+    "toContentMediaType": undefined,
+  },
+  "defaultChange": undefined,
+  "deprecatedChange": undefined,
+  "descriptionChange": undefined,
+  "fieldName": "image",
+  "foreignKeyChange": undefined,
+  "formulaChange": undefined,
+  "metadataChanges": [
+    "contentMediaType",
+  ],
+  "patch": {
+    "op": "replace",
+    "path": "/properties/image",
+  },
+  "typeChange": undefined,
+}
+`;
+
 exports[`PatchEnricher root node patches enriches primitive root default change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": {
     "fromDefault": "old",
     "toDefault": "new",
@@ -155,6 +342,9 @@ exports[`PatchEnricher root node patches enriches primitive root default change 
   "fieldName": "",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [
+    "default",
+  ],
   "patch": {
     "op": "replace",
     "path": "",
@@ -165,6 +355,7 @@ exports[`PatchEnricher root node patches enriches primitive root default change 
 
 exports[`PatchEnricher root node patches enriches root description change 1`] = `
 {
+  "contentMediaTypeChange": undefined,
   "defaultChange": undefined,
   "deprecatedChange": undefined,
   "descriptionChange": {
@@ -174,6 +365,9 @@ exports[`PatchEnricher root node patches enriches root description change 1`] = 
   "fieldName": "",
   "foreignKeyChange": undefined,
   "formulaChange": undefined,
+  "metadataChanges": [
+    "description",
+  ],
   "patch": {
     "op": "replace",
     "path": "",

--- a/src/core/schema-patch/__tests__/test-helpers.ts
+++ b/src/core/schema-patch/__tests__/test-helpers.ts
@@ -16,6 +16,7 @@ import type {
   MovedChange,
   ModifiedChange,
 } from '../../schema-diff/index.js';
+import type { ContentMediaType } from '../../../types/index.js';
 import { createMockFormula } from '../../schema-node/__tests__/test-helpers.js';
 
 export { createMockFormula };
@@ -40,6 +41,7 @@ interface PrimitiveNodeOptions {
   foreignKey?: string;
   description?: string;
   deprecated?: boolean;
+  contentMediaType?: ContentMediaType;
 }
 
 interface ObjectNodeOptions {
@@ -73,6 +75,7 @@ export const str = (
     formula: opts?.formula,
     foreignKey: opts?.foreignKey,
     metadata: buildMetadata(opts),
+    contentMediaType: opts?.contentMediaType,
   });
 };
 
@@ -145,6 +148,7 @@ export const strRoot = (
     formula: opts?.formula,
     foreignKey: opts?.foreignKey,
     metadata: buildMetadata(opts),
+    contentMediaType: opts?.contentMediaType,
   });
 };
 

--- a/src/core/schema-patch/index.ts
+++ b/src/core/schema-patch/index.ts
@@ -1,4 +1,4 @@
 export { PatchBuilder } from './PatchBuilder.js';
 export { PatchGenerator } from './PatchGenerator.js';
 export { PatchEnricher } from './PatchEnricher.js';
-export type { JsonPatch, SchemaPatch, DefaultValueType } from './types.js';
+export type { JsonPatch, SchemaPatch, DefaultValueType, MetadataChangeType } from './types.js';

--- a/src/core/schema-patch/types.ts
+++ b/src/core/schema-patch/types.ts
@@ -1,17 +1,23 @@
-import type { JsonSchema } from '../../types/index.js';
+import type { JsonPatch } from '../../types/index.js';
 
-export interface JsonPatch {
-  op: 'add' | 'remove' | 'replace' | 'move';
-  path: string;
-  from?: string;
-  value?: JsonSchema;
-}
+export type { JsonPatch };
 
 export type DefaultValueType = string | number | boolean | undefined;
+
+export type MetadataChangeType =
+  | 'formula'
+  | 'description'
+  | 'deprecated'
+  | 'foreignKey'
+  | 'default'
+  | 'enum'
+  | 'format'
+  | 'contentMediaType';
 
 export interface SchemaPatch {
   patch: JsonPatch;
   fieldName: string;
+  metadataChanges: MetadataChangeType[];
   typeChange?: {
     fromType: string;
     toType: string;
@@ -38,5 +44,10 @@ export interface SchemaPatch {
     fromForeignKey: string | undefined;
     toForeignKey: string | undefined;
   };
+  contentMediaTypeChange?: {
+    fromContentMediaType: string | undefined;
+    toContentMediaType: string | undefined;
+  };
   isRename?: boolean;
+  movesIntoArray?: boolean;
 }

--- a/src/core/schema-serializer/SchemaSerializer.ts
+++ b/src/core/schema-serializer/SchemaSerializer.ts
@@ -132,6 +132,11 @@ export class SchemaSerializer {
       result.foreignKey = foreignKey;
     }
 
+    const contentMediaType = node.contentMediaType();
+    if (contentMediaType && this.isValidContentMediaType(contentMediaType)) {
+      result.contentMediaType = contentMediaType;
+    }
+
     const formula = node.formula();
     if (formula) {
       result.readOnly = true;
@@ -201,5 +206,19 @@ export class SchemaSerializer {
 
   private shouldExclude(node: SchemaNode): boolean {
     return this.excludeNodeIds.has(node.id());
+  }
+
+  private isValidContentMediaType(
+    value: string,
+  ): value is NonNullable<JsonStringSchema['contentMediaType']> {
+    const validTypes = [
+      'text/plain',
+      'text/markdown',
+      'text/html',
+      'application/json',
+      'application/schema+json',
+      'application/yaml',
+    ];
+    return validTypes.includes(value);
   }
 }

--- a/src/core/validation/formula/FormulaValidator.ts
+++ b/src/core/validation/formula/FormulaValidator.ts
@@ -1,9 +1,9 @@
 import type { SchemaTree } from '../../schema-tree/index.js';
 import type { SchemaNode } from '../../schema-node/index.js';
-import type { FormulaValidationError } from './types.js';
+import type { TreeFormulaValidationError } from './types.js';
 
-export function validateFormulas(tree: SchemaTree): FormulaValidationError[] {
-  const errors: FormulaValidationError[] = [];
+export function validateFormulas(tree: SchemaTree): TreeFormulaValidationError[] {
+  const errors: TreeFormulaValidationError[] = [];
   collectFormulaErrors(tree.root(), tree, errors, '');
   return errors;
 }
@@ -11,7 +11,7 @@ export function validateFormulas(tree: SchemaTree): FormulaValidationError[] {
 function collectFormulaErrors(
   node: SchemaNode,
   tree: SchemaTree,
-  errors: FormulaValidationError[],
+  errors: TreeFormulaValidationError[],
   fieldPath: string,
 ): void {
   if (node.isNull()) {
@@ -25,7 +25,7 @@ function collectFormulaErrors(
 function validateNodeFormula(
   node: SchemaNode,
   tree: SchemaTree,
-  errors: FormulaValidationError[],
+  errors: TreeFormulaValidationError[],
   fieldPath: string,
 ): void {
   if (!node.isPrimitive() || !node.hasFormula()) {
@@ -52,7 +52,7 @@ function validateNodeFormula(
 function collectChildErrors(
   node: SchemaNode,
   tree: SchemaTree,
-  errors: FormulaValidationError[],
+  errors: TreeFormulaValidationError[],
   fieldPath: string,
 ): void {
   if (node.isObject()) {

--- a/src/core/validation/formula/index.ts
+++ b/src/core/validation/formula/index.ts
@@ -1,2 +1,2 @@
-export type { FormulaValidationError } from './types.js';
+export type { TreeFormulaValidationError } from './types.js';
 export { validateFormulas } from './FormulaValidator.js';

--- a/src/core/validation/formula/types.ts
+++ b/src/core/validation/formula/types.ts
@@ -1,4 +1,4 @@
-export interface FormulaValidationError {
+export interface TreeFormulaValidationError {
   nodeId: string;
   message: string;
   fieldPath?: string;

--- a/src/core/validation/index.ts
+++ b/src/core/validation/index.ts
@@ -25,5 +25,5 @@ export type {
 } from './schema/index.js';
 export { validateSchema, isValidFieldName, FIELD_NAME_ERROR_MESSAGE } from './schema/index.js';
 
-export type { FormulaValidationError } from './formula/index.js';
+export type { TreeFormulaValidationError } from './formula/index.js';
 export { validateFormulas } from './formula/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// Re-export everything for convenience
 export * from './types/index.js';
 export * from './plugins/index.js';
 export * from './mocks/index.js';
@@ -6,16 +5,4 @@ export * from './consts/index.js';
 export * from './model/index.js';
 export * from './lib/index.js';
 export * from './validation-schemas/index.js';
-
-// Core validation exports
-export {
-  validateSchema,
-  validateFormulas,
-  isValidFieldName,
-  FIELD_NAME_ERROR_MESSAGE,
-} from './core/validation/index.js';
-export type {
-  SchemaValidationError,
-  SchemaValidationErrorType,
-  FormulaValidationError,
-} from './core/validation/index.js';
+export * from './core/index.js';

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -15,7 +15,7 @@ import {
   validateSchema,
   validateFormulas,
   type SchemaValidationError,
-  type FormulaValidationError,
+  type TreeFormulaValidationError,
 } from '../../core/validation/index.js';
 import { generateDefaultValue as generateDefaultValueFn } from '../default-value/index.js';
 
@@ -293,7 +293,7 @@ export class SchemaModelImpl implements SchemaModel {
     return validateSchema(this._currentTree.root());
   }
 
-  get formulaErrors(): FormulaValidationError[] {
+  get formulaErrors(): TreeFormulaValidationError[] {
     return validateFormulas(this._currentTree);
   }
 

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.edgeCases.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.edgeCases.spec.ts.snap
@@ -3,12 +3,14 @@
 exports[`SchemaModel edge cases array operations changes array to object 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "items",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/items",
@@ -30,6 +32,7 @@ exports[`SchemaModel edge cases array operations changes array to object 1`] = `
 exports[`SchemaModel edge cases array operations modifies array items type 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "",
       "toDefault": 0,
@@ -39,6 +42,9 @@ exports[`SchemaModel edge cases array operations modifies array items type 1`] =
     "fieldName": "items[*]",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items",
@@ -61,6 +67,8 @@ exports[`SchemaModel edge cases complex operations handles multiple renames 1`] 
     "fieldName": "givenName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/name",
       "op": "move",
@@ -78,6 +86,9 @@ exports[`SchemaModel edge cases complex operations handles remove then add same 
       "toDefault": 0,
     },
     "fieldName": "name",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/name",
@@ -89,6 +100,7 @@ exports[`SchemaModel edge cases complex operations handles remove then add same 
   },
   {
     "fieldName": "name",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/name",
@@ -100,6 +112,7 @@ exports[`SchemaModel edge cases complex operations handles remove then add same 
 exports[`SchemaModel edge cases complex operations handles type change then modification 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "",
       "toDefault": 42,
@@ -109,6 +122,9 @@ exports[`SchemaModel edge cases complex operations handles type change then modi
     "fieldName": "name",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -133,6 +149,9 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
       "toDefault": "",
     },
     "fieldName": "field1",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field1",
@@ -148,6 +167,9 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
       "toDefault": 0,
     },
     "fieldName": "field2",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -163,6 +185,9 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
       "toDefault": false,
     },
     "fieldName": "field3",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field3",
@@ -183,6 +208,9 @@ exports[`SchemaModel edge cases multiple changes before save correctly handles r
       "toDefault": 0,
     },
     "fieldName": "field2",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -203,6 +231,9 @@ exports[`SchemaModel edge cases nested operations adds field to nested object 1`
       "toDefault": 0,
     },
     "fieldName": "user.age",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/user/properties/age",
@@ -219,6 +250,7 @@ exports[`SchemaModel edge cases nested operations removes nested object with chi
 [
   {
     "fieldName": "user",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/user",
@@ -233,6 +265,8 @@ exports[`SchemaModel edge cases nested operations renames nested field 1`] = `
     "fieldName": "user.givenName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/user/properties/firstName",
       "op": "move",
@@ -245,6 +279,7 @@ exports[`SchemaModel edge cases nested operations renames nested field 1`] = `
 exports[`SchemaModel edge cases save and continue editing can modify saved fields 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "",
       "toDefault": "changed",
@@ -254,6 +289,9 @@ exports[`SchemaModel edge cases save and continue editing can modify saved field
     "fieldName": "field",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -275,6 +313,9 @@ exports[`SchemaModel edge cases save and continue editing tracks new changes aft
       "toDefault": 0,
     },
     "fieldName": "new",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/new",

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`SchemaModel patches getJsonPatches returns plain JSON patches 1`] = `
 exports[`SchemaModel patches getPatches includes formula change info 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
@@ -27,6 +28,9 @@ exports[`SchemaModel patches getPatches includes formula change info 1`] = `
       "toFormula": "name",
       "toVersion": 1,
     },
+    "metadataChanges": [
+      "formula",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/age",
@@ -53,6 +57,9 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
       "toDefault": "",
     },
     "fieldName": "field1",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field1",
@@ -68,6 +75,9 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
       "toDefault": 0,
     },
     "fieldName": "field2",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -83,6 +93,9 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
       "toDefault": false,
     },
     "fieldName": "field3",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field3",
@@ -103,6 +116,9 @@ exports[`SchemaModel patches getPatches returns add patch for new field 1`] = `
       "toDefault": "",
     },
     "fieldName": "newField",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -123,6 +139,8 @@ exports[`SchemaModel patches getPatches returns move patch for renamed field 1`]
     "fieldName": "fullName",
     "formulaChange": undefined,
     "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/name",
       "op": "move",
@@ -136,6 +154,7 @@ exports[`SchemaModel patches getPatches returns remove patch for deleted field 1
 [
   {
     "fieldName": "name",
+    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/name",
@@ -147,6 +166,7 @@ exports[`SchemaModel patches getPatches returns remove patch for deleted field 1
 exports[`SchemaModel patches getPatches returns replace patch for default value change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "",
       "toDefault": "changed",
@@ -156,6 +176,9 @@ exports[`SchemaModel patches getPatches returns replace patch for default value 
     "fieldName": "name",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -172,6 +195,7 @@ exports[`SchemaModel patches getPatches returns replace patch for default value 
 exports[`SchemaModel patches getPatches returns replace patch for type change 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "",
       "toDefault": 0,
@@ -181,6 +205,9 @@ exports[`SchemaModel patches getPatches returns replace patch for type change 1`
     "fieldName": "name",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.state.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.state.spec.ts.snap
@@ -151,6 +151,9 @@ exports[`SchemaModel state management markAsSaved resets base tree - new changes
       "toDefault": 0,
     },
     "fieldName": "field2",
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.wrap.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.wrap.spec.ts.snap
@@ -3,12 +3,14 @@
 exports[`SchemaModel wrap operations replaceRoot generates correct patch 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "",
@@ -31,6 +33,7 @@ exports[`SchemaModel wrap operations replaceRoot generates correct patch 1`] = `
 exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": {
       "fromDefault": "",
       "toDefault": undefined,
@@ -40,6 +43,9 @@ exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
     "fieldName": "name",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [
+      "default",
+    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -62,12 +68,14 @@ exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
 exports[`SchemaModel wrap operations wrapRootInArray generates correct patch 1`] = `
 [
   {
+    "contentMediaTypeChange": undefined,
     "defaultChange": undefined,
     "deprecatedChange": undefined,
     "descriptionChange": undefined,
     "fieldName": "",
     "foreignKeyChange": undefined,
     "formulaChange": undefined,
+    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "",

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -4,7 +4,7 @@ import type { Path } from '../../core/path/index.js';
 import type { SchemaPatch, JsonPatch } from '../../core/schema-patch/index.js';
 import type { JsonObjectSchema } from '../../types/index.js';
 import type { SchemaValidationError } from '../../core/validation/schema/types.js';
-import type { FormulaValidationError } from '../../core/validation/formula/types.js';
+import type { TreeFormulaValidationError } from '../../core/validation/formula/types.js';
 
 export interface ReactivityOptions {
   reactivity?: ReactivityAdapter;
@@ -47,7 +47,7 @@ export interface SchemaModel {
   hasFormulaDependents(nodeId: string): boolean;
 
   readonly validationErrors: SchemaValidationError[];
-  readonly formulaErrors: FormulaValidationError[];
+  readonly formulaErrors: TreeFormulaValidationError[];
 
   readonly isDirty: boolean;
   readonly isValid: boolean;

--- a/src/model/schema/json-boolean.store.ts
+++ b/src/model/schema/json-boolean.store.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from 'eventemitter3';
 import {
   JsonBooleanSchema,
   JsonRefSchema,

--- a/src/model/schema/json-number.store.ts
+++ b/src/model/schema/json-number.store.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from 'eventemitter3';
 import {
   JsonNumberSchema,
   JsonRefSchema,

--- a/src/model/schema/json-string.store.ts
+++ b/src/model/schema/json-string.store.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from 'eventemitter3';
 import {
   JsonRefSchema,
   JsonSchemaTypeName,

--- a/src/types/schema.types.ts
+++ b/src/types/schema.types.ts
@@ -17,6 +17,14 @@ export type JsonSchemaSharedFields = {
   title?: string;
 };
 
+export type ContentMediaType =
+  | 'text/plain'
+  | 'text/markdown'
+  | 'text/html'
+  | 'application/json'
+  | 'application/schema+json'
+  | 'application/yaml';
+
 export type JsonStringSchema = {
   type: JsonSchemaTypeName.String;
   default: string;
@@ -28,13 +36,7 @@ export type JsonStringSchema = {
   deprecated?: boolean;
   pattern?: string;
   format?: 'date-time' | 'date' | 'time' | 'email' | 'regex';
-  contentMediaType?:
-    | 'text/plain'
-    | 'text/markdown'
-    | 'text/html'
-    | 'application/json'
-    | 'application/schema+json'
-    | 'application/yaml';
+  contentMediaType?: ContentMediaType;
   minLength?: number;
   maxLength?: number;
   enum?: string[];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds contentMediaType support for string fields and enriches SchemaPatch with a metadataChanges list, contentMediaTypeChange, and movesIntoArray for move operations. Also switches stores to eventemitter3 and renames the formula validation error type.

- **New Features**
  - StringNode supports contentMediaType with getter/setter and cloning; serializer outputs it for valid types.
  - New ContentMediaType type and JsonStringSchema.contentMediaType updated.
  - PatchEnricher:
    - Adds metadataChanges: ['formula' | 'default' | 'description' | 'deprecated' | 'foreignKey' | 'contentMediaType' | 'enum' | 'format'].
    - Tracks contentMediaTypeChange.
    - Flags movesIntoArray on move patches; still detects isRename and formulaChange.
  - Exposes MetadataChangeType and JsonPatch from schema-patch index; tests updated.
  - Replaced node:events with eventemitter3 in schema stores (browser-friendly).

- **Migration**
  - Rename FormulaValidationError to TreeFormulaValidationError and update imports from core/validation.
  - If you referenced Node’s EventEmitter via our stores, no code changes are needed; eventemitter3 is now bundled.

<sup>Written for commit 7ae83321f9bbbfcf3c7388801f3516724103e4c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

