### PR TITLE
feat: schema node reactivity

### DIFF
--- a/src/core/schema-node/README.md
+++ b/src/core/schema-node/README.md
@@ -96,3 +96,40 @@ const base = user.clone();
 user.property('missing').property('also-missing').items();  // NULL_NODE
 NULL_NODE.isNull();  // true
 ```
+
+## Reactivity Support
+
+Nodes can be made reactive for use with MobX. Use the `makeNodeReactive` or `makeTreeNodesReactive` helpers:
+
+```typescript
+import {
+  createObjectNode,
+  createStringNode,
+  makeNodeReactive,
+  makeTreeNodesReactive,
+} from '@revisium/schema-toolkit/core';
+import { mobxAdapter } from '@revisium/schema-toolkit-ui';
+
+// Make a single node reactive
+const node = createStringNode('id', 'name', { defaultValue: '' });
+makeNodeReactive(node, mobxAdapter);
+
+// Make entire tree reactive (recursive)
+const root = createObjectNode('root', 'root', [
+  createStringNode('c1', 'field1', { defaultValue: '' }),
+  createStringNode('c2', 'field2', { defaultValue: '' }),
+]);
+makeTreeNodesReactive(root, mobxAdapter);
+```
+
+### Node Annotations by Type
+
+| Node Type | Observable Fields | Actions |
+|-----------|------------------|---------|
+| All nodes | `_name`, `_metadata` (ref) | `setName`, `setMetadata` |
+| Primitive | + `_formula` (ref), `_defaultValue`, `_foreignKey` | + `setFormula`, `setDefaultValue`, `setForeignKey` |
+| StringNode | + `_contentMediaType` | + `setContentMediaType` |
+| ObjectNode | + `_children` (shallow) | + `addChild`, `removeChild`, `replaceChild` |
+| ArrayNode | + `_items` (ref) | + `setItems` |
+
+When using `SchemaModel` with reactivity, all nodes are automatically made reactive.

--- a/src/core/schema-node/__tests__/reactivity.spec.ts
+++ b/src/core/schema-node/__tests__/reactivity.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { ReactivityAdapter } from '../../reactivity/index.js';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+  createRefNode,
+  makeNodeReactive,
+  makeTreeNodesReactive,
+  getNodeAnnotations,
+  NULL_NODE,
+} from '../index.js';
+
+describe('node reactivity', () => {
+  let mockAdapter: ReactivityAdapter;
+  let makeObservableSpy: jest.Mock;
+
+  beforeEach(() => {
+    makeObservableSpy = jest.fn();
+    mockAdapter = {
+      makeObservable: makeObservableSpy,
+      observableArray: () => [],
+      observableMap: () => new Map(),
+      reaction: () => () => {},
+      runInAction: <T>(fn: () => T) => fn(),
+    };
+  });
+
+  describe('getNodeAnnotations', () => {
+    it('returns correct annotations for string node', () => {
+      const annotations = getNodeAnnotations('string');
+
+      expect(annotations['_name']).toBe('observable');
+      expect(annotations['_metadata']).toBe('observable.ref');
+      expect(annotations['_formula']).toBe('observable.ref');
+      expect(annotations['_defaultValue']).toBe('observable');
+      expect(annotations['_foreignKey']).toBe('observable');
+      expect(annotations['_contentMediaType']).toBe('observable');
+      expect(annotations['setName']).toBe('action');
+      expect(annotations['setFormula']).toBe('action');
+      expect(annotations['setContentMediaType']).toBe('action');
+    });
+
+    it('returns correct annotations for number node', () => {
+      const annotations = getNodeAnnotations('number');
+
+      expect(annotations['_name']).toBe('observable');
+      expect(annotations['_formula']).toBe('observable.ref');
+      expect(annotations['_defaultValue']).toBe('observable');
+      expect(annotations['setDefaultValue']).toBe('action');
+    });
+
+    it('returns correct annotations for boolean node', () => {
+      const annotations = getNodeAnnotations('boolean');
+
+      expect(annotations['_name']).toBe('observable');
+      expect(annotations['_formula']).toBe('observable.ref');
+      expect(annotations['_defaultValue']).toBe('observable');
+    });
+
+    it('returns correct annotations for object node', () => {
+      const annotations = getNodeAnnotations('object');
+
+      expect(annotations['_name']).toBe('observable');
+      expect(annotations['_metadata']).toBe('observable.ref');
+      expect(annotations['_children']).toBe('observable.shallow');
+      expect(annotations['addChild']).toBe('action');
+      expect(annotations['removeChild']).toBe('action');
+      expect(annotations['replaceChild']).toBe('action');
+    });
+
+    it('returns correct annotations for array node', () => {
+      const annotations = getNodeAnnotations('array');
+
+      expect(annotations['_name']).toBe('observable');
+      expect(annotations['_metadata']).toBe('observable.ref');
+      expect(annotations['_items']).toBe('observable.ref');
+      expect(annotations['setItems']).toBe('action');
+    });
+
+    it('returns correct annotations for ref node', () => {
+      const annotations = getNodeAnnotations('ref');
+
+      expect(annotations['_name']).toBe('observable');
+      expect(annotations['_metadata']).toBe('observable.ref');
+      expect(annotations['setName']).toBe('action');
+      expect(annotations['setMetadata']).toBe('action');
+    });
+
+    it('returns empty annotations for null node', () => {
+      const annotations = getNodeAnnotations('null');
+
+      expect(Object.keys(annotations)).toHaveLength(0);
+    });
+  });
+
+  describe('makeNodeReactive', () => {
+    it('calls makeObservable for string node', () => {
+      const node = createStringNode('id1', 'name', { defaultValue: '' });
+
+      makeNodeReactive(node, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(1);
+      expect(makeObservableSpy).toHaveBeenCalledWith(node, expect.any(Object));
+    });
+
+    it('calls makeObservable for object node', () => {
+      const node = createObjectNode('id1', 'obj', []);
+
+      makeNodeReactive(node, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(1);
+      const [, annotations] = makeObservableSpy.mock.calls[0] as [
+        unknown,
+        Record<string, string>,
+      ];
+      expect(annotations['_children']).toBe('observable.shallow');
+    });
+
+    it('calls makeObservable for array node', () => {
+      const items = createStringNode('items-id', 'items', { defaultValue: '' });
+      const node = createArrayNode('id1', 'arr', items);
+
+      makeNodeReactive(node, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(1);
+      const [, annotations] = makeObservableSpy.mock.calls[0] as [
+        unknown,
+        Record<string, string>,
+      ];
+      expect(annotations['_items']).toBe('observable.ref');
+    });
+
+    it('calls makeObservable for ref node', () => {
+      const node = createRefNode('id1', 'ref', '#/definitions/Type');
+
+      makeNodeReactive(node, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips null nodes', () => {
+      makeNodeReactive(NULL_NODE, mockAdapter);
+
+      expect(makeObservableSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('makeTreeNodesReactive', () => {
+    it('applies reactivity to all nodes in tree', () => {
+      const child1 = createStringNode('c1', 'name', { defaultValue: '' });
+      const child2 = createNumberNode('c2', 'age', { defaultValue: 0 });
+      const root = createObjectNode('root', 'root', [child1, child2]);
+
+      makeTreeNodesReactive(root, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles nested objects', () => {
+      const nested = createStringNode('nested', 'field', { defaultValue: '' });
+      const obj = createObjectNode('obj', 'inner', [nested]);
+      const root = createObjectNode('root', 'root', [obj]);
+
+      makeTreeNodesReactive(root, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles arrays', () => {
+      const items = createStringNode('items', 'items', { defaultValue: '' });
+      const arr = createArrayNode('arr', 'list', items);
+      const root = createObjectNode('root', 'root', [arr]);
+
+      makeTreeNodesReactive(root, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles deeply nested structures', () => {
+      const leaf = createBooleanNode('leaf', 'active', { defaultValue: false });
+      const items = createObjectNode('items', 'items', [leaf]);
+      const arr = createArrayNode('arr', 'users', items);
+      const obj = createObjectNode('obj', 'data', [arr]);
+      const root = createObjectNode('root', 'root', [obj]);
+
+      makeTreeNodesReactive(root, mockAdapter);
+
+      expect(makeObservableSpy).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/src/core/schema-node/index.ts
+++ b/src/core/schema-node/index.ts
@@ -13,3 +13,9 @@ export { createStringNode } from './StringNode.js';
 export { createNumberNode } from './NumberNode.js';
 export { createBooleanNode } from './BooleanNode.js';
 export { createRefNode } from './RefNode.js';
+
+export {
+  makeNodeReactive,
+  makeTreeNodesReactive,
+  getNodeAnnotations,
+} from './reactivity.js';

--- a/src/core/schema-node/reactivity.ts
+++ b/src/core/schema-node/reactivity.ts
@@ -1,0 +1,108 @@
+import type { SchemaNode, NodeType } from './types.js';
+import type { ReactivityAdapter } from '../reactivity/index.js';
+import type { AnnotationType } from '../types/index.js';
+
+type NodeAnnotations = Record<string, AnnotationType>;
+
+const BASE_NODE_ANNOTATIONS: NodeAnnotations = {
+  _name: 'observable',
+  _metadata: 'observable.ref',
+  setName: 'action',
+  setMetadata: 'action',
+};
+
+const PRIMITIVE_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...BASE_NODE_ANNOTATIONS,
+  _formula: 'observable.ref',
+  _defaultValue: 'observable',
+  _foreignKey: 'observable',
+  setFormula: 'action',
+  setDefaultValue: 'action',
+  setForeignKey: 'action',
+};
+
+const STRING_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...PRIMITIVE_NODE_ANNOTATIONS,
+  _contentMediaType: 'observable',
+  setContentMediaType: 'action',
+};
+
+const NUMBER_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...PRIMITIVE_NODE_ANNOTATIONS,
+};
+
+const BOOLEAN_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...PRIMITIVE_NODE_ANNOTATIONS,
+};
+
+const OBJECT_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...BASE_NODE_ANNOTATIONS,
+  _children: 'observable.shallow',
+  addChild: 'action',
+  removeChild: 'action',
+  replaceChild: 'action',
+};
+
+const ARRAY_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...BASE_NODE_ANNOTATIONS,
+  _items: 'observable.ref',
+  setItems: 'action',
+};
+
+const REF_NODE_ANNOTATIONS: NodeAnnotations = {
+  ...BASE_NODE_ANNOTATIONS,
+};
+
+export function getNodeAnnotations(nodeType: NodeType): NodeAnnotations {
+  switch (nodeType) {
+    case 'string':
+      return STRING_NODE_ANNOTATIONS;
+    case 'number':
+      return NUMBER_NODE_ANNOTATIONS;
+    case 'boolean':
+      return BOOLEAN_NODE_ANNOTATIONS;
+    case 'object':
+      return OBJECT_NODE_ANNOTATIONS;
+    case 'array':
+      return ARRAY_NODE_ANNOTATIONS;
+    case 'ref':
+      return REF_NODE_ANNOTATIONS;
+    case 'null':
+      return {};
+    default:
+      return {};
+  }
+}
+
+export function makeNodeReactive(
+  node: SchemaNode,
+  adapter: ReactivityAdapter,
+): void {
+  if (node.isNull()) {
+    return;
+  }
+
+  const annotations = getNodeAnnotations(node.nodeType());
+  adapter.makeObservable(
+    node,
+    annotations as Record<
+      string,
+      'observable' | 'observable.ref' | 'observable.shallow' | 'computed' | 'action'
+    >,
+  );
+}
+
+export function makeTreeNodesReactive(
+  root: SchemaNode,
+  adapter: ReactivityAdapter,
+): void {
+  makeNodeReactive(root, adapter);
+
+  if (root.isObject()) {
+    for (const child of root.properties()) {
+      makeTreeNodesReactive(child, adapter);
+    }
+  } else if (root.isArray()) {
+    makeTreeNodesReactive(root.items(), adapter);
+  }
+}

--- a/src/core/schema-tree/index.ts
+++ b/src/core/schema-tree/index.ts
@@ -1,2 +1,3 @@
 export type { SchemaTree } from './types.js';
+export type { SchemaTreeOptions } from './SchemaTreeImpl.js';
 export { createSchemaTree } from './SchemaTreeImpl.js';

--- a/src/core/types/README.md
+++ b/src/core/types/README.md
@@ -6,7 +6,12 @@ Type definitions for MobX-style annotations.
 
 ```typescript
 // Annotation type for observable properties
-type AnnotationType = 'observable' | 'computed' | 'action';
+type AnnotationType =
+  | 'observable'        // Deep observable
+  | 'observable.ref'    // Reference observable (only reference changes trigger)
+  | 'observable.shallow'// Shallow observable (array changes tracked, not element changes)
+  | 'computed'          // Computed value
+  | 'action';           // Action that mutates state
 
 // Map of property names to their annotation types
 type AnnotationsMap<T> = { [K in keyof T]?: AnnotationType };

--- a/src/core/types/annotations.ts
+++ b/src/core/types/annotations.ts
@@ -1,4 +1,9 @@
-export type AnnotationType = 'observable' | 'observable.ref' | 'computed' | 'action';
+export type AnnotationType =
+  | 'observable'
+  | 'observable.ref'
+  | 'observable.shallow'
+  | 'computed'
+  | 'action';
 
 export type AnnotationsMap<T> = {
   [K in keyof T]?: AnnotationType;

--- a/src/model/schema-model/NodeFactory.ts
+++ b/src/model/schema-model/NodeFactory.ts
@@ -6,33 +6,60 @@ import {
   createStringNode,
   createNumberNode,
   createBooleanNode,
+  makeNodeReactive,
 } from '../../core/schema-node/index.js';
+import type { ReactivityAdapter } from '../../core/reactivity/index.js';
 import type { FieldType } from './types.js';
 
 export class NodeFactory {
+  private readonly _reactivity: ReactivityAdapter | undefined;
+
+  constructor(reactivity?: ReactivityAdapter) {
+    this._reactivity = reactivity;
+  }
+
   createNode(name: string, type: FieldType): SchemaNode {
+    let node: SchemaNode;
+
     switch (type) {
       case 'string':
-        return createStringNode(nanoid(), name, { defaultValue: '' });
+        node = createStringNode(nanoid(), name, { defaultValue: '' });
+        break;
       case 'number':
-        return createNumberNode(nanoid(), name, { defaultValue: 0 });
+        node = createNumberNode(nanoid(), name, { defaultValue: 0 });
+        break;
       case 'boolean':
-        return createBooleanNode(nanoid(), name, { defaultValue: false });
+        node = createBooleanNode(nanoid(), name, { defaultValue: false });
+        break;
       case 'object':
-        return createObjectNode(nanoid(), name, []);
+        node = createObjectNode(nanoid(), name, []);
+        break;
       case 'array':
-        return this.createArrayNode(name);
+        node = this.createArrayNodeInternal(name);
+        break;
       default:
         throw new Error(`Unknown field type: ${type}`);
     }
+
+    this.applyReactivity(node);
+    return node;
   }
 
-  private createArrayNode(name: string): SchemaNode {
+  private createArrayNodeInternal(name: string): SchemaNode {
     const items = createStringNode(nanoid(), 'items', { defaultValue: '' });
+    this.applyReactivity(items);
     return createArrayNode(nanoid(), name, items);
   }
 
   createArrayNodeWithItems(name: string, items: SchemaNode): SchemaNode {
-    return createArrayNode(nanoid(), name, items);
+    const node = createArrayNode(nanoid(), name, items);
+    this.applyReactivity(node);
+    return node;
+  }
+
+  private applyReactivity(node: SchemaNode): void {
+    if (this._reactivity) {
+      makeNodeReactive(node, this._reactivity);
+    }
   }
 }

--- a/src/model/schema-model/README.md
+++ b/src/model/schema-model/README.md
@@ -135,6 +135,16 @@ const model = createSchemaModel(schema, { reactivity: mobxAdapter });
 
 // Now model properties are observable
 // - root, isDirty, patches, etc. will trigger MobX reactions
+
+// Individual nodes are also reactive - mutations trigger reactions
+import { autorun } from 'mobx';
+
+const node = model.nodeById('some-id');
+autorun(() => {
+  console.log('Name changed:', node.name());
+});
+
+model.renameField('some-id', 'newName'); // Triggers autorun
 ```
 
 ## Computed Properties
@@ -168,6 +178,27 @@ const errors2 = model.validationErrors; // returns cached result
 model.renameField(nodeId, 'newName');   // invalidates cache
 const errors3 = model.validationErrors; // traverses tree, caches new result
 ```
+
+### Node-Level Reactivity
+
+When reactivity is enabled, individual SchemaNode instances are also made observable. This enables fine-grained UI updates when node properties change:
+
+```typescript
+import { autorun } from 'mobx';
+
+const node = model.root.property('name');
+
+// React to name changes
+autorun(() => console.log('Name:', node.name()));
+
+// React to metadata changes
+autorun(() => console.log('Title:', node.metadata().title));
+
+// React to children changes (for object nodes)
+autorun(() => console.log('Children count:', model.root.properties().length));
+```
+
+See `core/schema-node/README.md` for the full list of observable fields per node type.
 
 ## Field Types
 

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -25,17 +25,19 @@ export class SchemaModelImpl implements SchemaModel {
   private readonly _reactivity: ReactivityAdapter | undefined;
   private readonly _patchBuilder = new PatchBuilder();
   private readonly _serializer = new SchemaSerializer();
-  private readonly _nodeFactory = new NodeFactory();
+  private readonly _nodeFactory: NodeFactory;
   private readonly _formulaIndex = new FormulaDependencyIndex();
 
   constructor(schema: JsonObjectSchema, options?: ReactivityOptions) {
-    const parser = new SchemaParser();
+    this._reactivity = options?.reactivity;
+    this._nodeFactory = new NodeFactory(this._reactivity);
+
+    const parser = new SchemaParser(this._reactivity);
     const rootNode = parser.parse(schema);
-    this._currentTree = createSchemaTree(rootNode);
+    this._currentTree = createSchemaTree(rootNode, { reactivity: this._reactivity });
     parser.parseFormulas(this._currentTree);
     this._buildFormulaIndex();
     this._baseTree = this._currentTree.clone();
-    this._reactivity = options?.reactivity;
 
     if (this._reactivity) {
       this._reactivity.makeObservable(this, {

--- a/src/model/schema-model/SchemaParser.ts
+++ b/src/model/schema-model/SchemaParser.ts
@@ -18,8 +18,10 @@ import {
   createNumberNode,
   createBooleanNode,
   createRefNode,
+  makeNodeReactive,
 } from '../../core/schema-node/index.js';
 import type { SchemaTree } from '../../core/schema-tree/index.js';
+import type { ReactivityAdapter } from '../../core/reactivity/index.js';
 import { ParsedFormula } from '../schema-formula/index.js';
 
 interface PendingFormula {
@@ -29,6 +31,11 @@ interface PendingFormula {
 
 export class SchemaParser {
   private pendingFormulas: PendingFormula[] = [];
+  private readonly _reactivity: ReactivityAdapter | undefined;
+
+  constructor(reactivity?: ReactivityAdapter) {
+    this._reactivity = reactivity;
+  }
 
   parse(schema: JsonObjectSchema): SchemaNode {
     this.pendingFormulas = [];
@@ -49,11 +56,8 @@ export class SchemaParser {
 
   private parseNode(schema: JsonSchema, name: string): SchemaNode {
     if ('$ref' in schema) {
-      return createRefNode(
-        nanoid(),
-        name,
-        schema.$ref,
-        this.extractMetadata(schema),
+      return this.applyReactivity(
+        createRefNode(nanoid(), name, schema.$ref, this.extractMetadata(schema)),
       );
     }
 
@@ -84,50 +88,50 @@ export class SchemaParser {
       }
     }
 
-    return createObjectNode(
-      nanoid(),
-      name,
-      children,
-      this.extractMetadata(schema),
+    return this.applyReactivity(
+      createObjectNode(nanoid(), name, children, this.extractMetadata(schema)),
     );
   }
 
   private parseArray(schema: JsonArraySchema, name: string): SchemaNode {
     const items = this.parseNode(schema.items, 'items');
-    return createArrayNode(
-      nanoid(),
-      name,
-      items,
-      this.extractMetadata(schema),
+    return this.applyReactivity(
+      createArrayNode(nanoid(), name, items, this.extractMetadata(schema)),
     );
   }
 
   private parseString(schema: JsonStringSchema, name: string): SchemaNode {
     const nodeId = nanoid();
     this.collectFormula(nodeId, schema['x-formula']);
-    return createStringNode(nodeId, name, {
-      defaultValue: schema.default,
-      foreignKey: schema.foreignKey,
-      metadata: this.extractMetadata(schema),
-    });
+    return this.applyReactivity(
+      createStringNode(nodeId, name, {
+        defaultValue: schema.default,
+        foreignKey: schema.foreignKey,
+        metadata: this.extractMetadata(schema),
+      }),
+    );
   }
 
   private parseNumber(schema: JsonNumberSchema, name: string): SchemaNode {
     const nodeId = nanoid();
     this.collectFormula(nodeId, schema['x-formula']);
-    return createNumberNode(nodeId, name, {
-      defaultValue: schema.default,
-      metadata: this.extractMetadata(schema),
-    });
+    return this.applyReactivity(
+      createNumberNode(nodeId, name, {
+        defaultValue: schema.default,
+        metadata: this.extractMetadata(schema),
+      }),
+    );
   }
 
   private parseBoolean(schema: JsonBooleanSchema, name: string): SchemaNode {
     const nodeId = nanoid();
     this.collectFormula(nodeId, schema['x-formula']);
-    return createBooleanNode(nodeId, name, {
-      defaultValue: schema.default,
-      metadata: this.extractMetadata(schema),
-    });
+    return this.applyReactivity(
+      createBooleanNode(nodeId, name, {
+        defaultValue: schema.default,
+        metadata: this.extractMetadata(schema),
+      }),
+    );
   }
 
   private extractMetadata(schema: JsonSchema): NodeMetadata | undefined {
@@ -154,5 +158,12 @@ export class SchemaParser {
     if (xFormula) {
       this.pendingFormulas.push({ nodeId, expression: xFormula.expression });
     }
+  }
+
+  private applyReactivity(node: SchemaNode): SchemaNode {
+    if (this._reactivity) {
+      makeNodeReactive(node, this._reactivity);
+    }
+    return node;
   }
 }

--- a/src/model/schema-model/__tests__/SchemaModel.reactivity.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.reactivity.spec.ts
@@ -19,19 +19,25 @@ describe('SchemaModel reactivity', () => {
   });
 
   describe('initialization with reactivity', () => {
-    it('calls makeObservable when adapter provided', () => {
+    type MockCall = [unknown, Record<string, string>];
+
+    it('calls makeObservable for model and nodes when adapter provided', () => {
       createSchemaModel(emptySchema(), { reactivity: mockAdapter });
 
-      expect(makeObservableSpy).toHaveBeenCalledTimes(1);
+      expect(makeObservableSpy).toHaveBeenCalled();
+      const calls = makeObservableSpy.mock.calls as MockCall[];
+      const modelCall = calls.find((call) => call[1]?.['_currentTree'] !== undefined);
+      expect(modelCall).toBeDefined();
     });
 
-    it('passes correct annotations to makeObservable', () => {
+    it('passes correct annotations to makeObservable for model', () => {
       createSchemaModel(emptySchema(), { reactivity: mockAdapter });
 
-      const callArgs = makeObservableSpy.mock.calls[0];
-      expect(callArgs).toBeDefined();
+      const calls = makeObservableSpy.mock.calls as MockCall[];
+      const modelCall = calls.find((call) => call[1]?.['_currentTree'] !== undefined);
+      expect(modelCall).toBeDefined();
 
-      const [target, annotations] = callArgs as [unknown, Record<string, string>];
+      const [target, annotations] = modelCall!;
 
       expect(target).toBeDefined();
       expect(annotations['_currentTree']).toBe('observable.ref');
@@ -42,6 +48,17 @@ describe('SchemaModel reactivity', () => {
       expect(annotations['removeField']).toBe('action');
       expect(annotations['markAsSaved']).toBe('action');
       expect(annotations['revert']).toBe('action');
+    });
+
+    it('calls makeObservable for nodes when adapter provided', () => {
+      createSchemaModel(emptySchema(), { reactivity: mockAdapter });
+
+      const calls = makeObservableSpy.mock.calls as MockCall[];
+      const nodeCall = calls.find((call) => call[1]?.['_children'] !== undefined);
+      expect(nodeCall).toBeDefined();
+      const [, annotations] = nodeCall!;
+      expect(annotations['_children']).toBe('observable.shallow');
+      expect(annotations['addChild']).toBe('action');
     });
 
     it('does not call makeObservable when no adapter', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds MobX-style reactivity to schema nodes and trees so node changes are observable and actions trigger reactions. Provides helper APIs and integrates reactivity across SchemaModel, SchemaParser, NodeFactory, and SchemaTree.

- **New Features**
  - Added makeNodeReactive, makeTreeNodesReactive, and getNodeAnnotations to enable node-level reactivity.
  - Defined per-node annotations, including observable.ref and observable.shallow for refs and children.
  - Extended AnnotationType with observable.shallow; updated docs and tests.
  - SchemaTree now accepts a reactivity adapter and makes cloned trees reactive when provided.
  - SchemaParser and NodeFactory accept a ReactivityAdapter and auto-make parsed/created nodes reactive.
  - SchemaModel wires in node reactivity when initialized with a ReactivityAdapter.

- **Migration**
  - To enable: pass reactivity: mobxAdapter to createSchemaModel or createSchemaTree, or call makeNodeReactive/makeTreeNodesReactive manually.
  - No changes needed if reactivity is not used; existing behavior remains the same.

<sup>Written for commit 5d48ab2a6ac63d4cfdb1a9c2a11191589eeeffbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

