### PR TITLE
feat: empty property

### DIFF
--- a/src/core/path/PathParser.ts
+++ b/src/core/path/PathParser.ts
@@ -7,23 +7,25 @@ export function jsonPointerToSegments(pointer: string): PathSegment[] {
     return [];
   }
 
-  const parts = pointer.split('/').filter(Boolean);
+  const parts = pointer.startsWith('/') ? pointer.slice(1).split('/') : pointer.split('/');
   const segments: PathSegment[] = [];
 
   let i = 0;
   while (i < parts.length) {
     const part = parts[i];
     if (part === 'properties') {
-      const name = parts[i + 1];
-      if (name === undefined || name === '') {
-        throw new Error(
-          `Invalid path: 'properties' segment requires a name in path ${pointer}`,
-        );
+      const hasNextPart = i + 1 < parts.length;
+      if (hasNextPart) {
+        const name = parts[i + 1] ?? '';
+        segments.push(new PropertySegment(name));
+        i += 2;
+      } else {
+        i += 1;
       }
-      segments.push(new PropertySegment(name));
-      i += 2;
     } else if (part === 'items') {
       segments.push(new ItemsSegment());
+      i += 1;
+    } else if (part === '') {
       i += 1;
     } else {
       throw new Error(`Invalid path segment: ${part} in path ${pointer}`);

--- a/src/core/path/__tests__/PathParser.spec.ts
+++ b/src/core/path/__tests__/PathParser.spec.ts
@@ -53,16 +53,23 @@ describe('PathParser', () => {
       );
     });
 
-    it('throws for properties without name', () => {
-      expect(() => jsonPointerToSegments('/properties')).toThrow(
-        "Invalid path: 'properties' segment requires a name",
-      );
+    it('returns empty array for properties without name', () => {
+      const segments = jsonPointerToSegments('/properties');
+      expect(segments).toEqual([]);
     });
 
-    it('throws for properties with empty name', () => {
-      expect(() => jsonPointerToSegments('/properties/')).toThrow(
-        "Invalid path: 'properties' segment requires a name",
-      );
+    it('returns single segment with empty name for /properties/', () => {
+      const segments = jsonPointerToSegments('/properties/');
+      expect(segments.length).toBe(1);
+      expect(segments[0]?.isProperty()).toBe(true);
+      expect(segments[0]?.propertyName()).toBe('');
+    });
+
+    it('handles path with empty name followed by another property', () => {
+      const segments = jsonPointerToSegments('/properties//properties/name');
+      expect(segments.length).toBe(2);
+      expect(segments[0]?.propertyName()).toBe('');
+      expect(segments[1]?.propertyName()).toBe('name');
     });
   });
 

--- a/src/core/schema-patch/__tests__/PatchGenerator.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchGenerator.spec.ts
@@ -228,4 +228,66 @@ describe('PatchGenerator', () => {
       expect(patches).toMatchSnapshot();
     });
   });
+
+  describe('empty field names', () => {
+    it('generates add patch for field with empty name', () => {
+      const { base, current } = treePair(
+        objRoot([str('existing')]),
+        objRoot([str('existing'), str('', { id: 'empty-name-field' })]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({ added: [current.root().properties()[1]] }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates remove patch for field with empty name', () => {
+      const { base, current } = treePair(
+        objRoot([str('existing'), str('', { id: 'empty-name-field' })]),
+        objRoot([str('existing')]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({ removed: [base.root().properties()[1]] }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates move patch when renaming field from empty to non-empty name', () => {
+      const { base, current } = treePair(
+        objRoot([str('', { id: 'field-id' })]),
+        objRoot([str('newName', { id: 'field-id' })]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          moved: [[base.root().properties()[0], current.root().properties()[0]]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+
+    it('generates move patch when renaming field from non-empty to empty name', () => {
+      const { base, current } = treePair(
+        objRoot([str('oldName', { id: 'field-id' })]),
+        objRoot([str('', { id: 'field-id' })]),
+      );
+
+      const generator = new PatchGenerator(current, base);
+      const patches = generator.generate(
+        changes({
+          moved: [[base.root().properties()[0], current.root().properties()[0]]],
+        }),
+      );
+
+      expect(patches).toMatchSnapshot();
+    });
+  });
 });

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchGenerator.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchGenerator.spec.ts.snap
@@ -51,6 +51,48 @@ exports[`PatchGenerator array patches generates separate patches for array metad
 ]
 `;
 
+exports[`PatchGenerator empty field names generates add patch for field with empty name 1`] = `
+[
+  {
+    "op": "add",
+    "path": "/properties/",
+    "value": {
+      "default": "",
+      "type": "string",
+    },
+  },
+]
+`;
+
+exports[`PatchGenerator empty field names generates move patch when renaming field from empty to non-empty name 1`] = `
+[
+  {
+    "from": "/properties/",
+    "op": "move",
+    "path": "/properties/newName",
+  },
+]
+`;
+
+exports[`PatchGenerator empty field names generates move patch when renaming field from non-empty to empty name 1`] = `
+[
+  {
+    "from": "/properties/oldName",
+    "op": "move",
+    "path": "/properties/",
+  },
+]
+`;
+
+exports[`PatchGenerator empty field names generates remove patch for field with empty name 1`] = `
+[
+  {
+    "op": "remove",
+    "path": "/properties/",
+  },
+]
+`;
+
 exports[`PatchGenerator generate add patches generates add patch for nested field 1`] = `
 [
   {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for empty property names in JSON pointers and schema patches. PathParser no longer throws on '/properties' or '/properties/', and PatchGenerator can add/remove/move fields with empty names.

- **New Features**
  - PathParser: accepts pointers with/without leading slash and handles empty segments; '/properties' returns [], '/properties/' yields a property segment with an empty name.
  - PatchGenerator: emits add/remove/move patches for empty-name fields using the path '/properties/'; tests and snapshots added.

<sup>Written for commit 880b5aa0f46fed4b5a16745ca1c8919bffa63cd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

