### PR TITLE
fix: replacement patch

### DIFF
--- a/src/core/schema-diff/ChangeCollector.ts
+++ b/src/core/schema-diff/ChangeCollector.ts
@@ -35,11 +35,19 @@ export class ChangeCollector {
         const originalId = this.index.getOriginalNodeId(nodeId);
         if (originalId) {
           const baseNode = this.baseTree.nodeById(originalId);
-          changes.push({
-            type: 'modified',
-            baseNode,
-            currentNode,
-          });
+          if (baseNode.isNull()) {
+            changes.push({
+              type: 'added',
+              baseNode: null,
+              currentNode,
+            });
+          } else {
+            changes.push({
+              type: 'modified',
+              baseNode,
+              currentNode,
+            });
+          }
         }
         continue;
       }

--- a/src/core/schema-diff/ChangeCollector.ts
+++ b/src/core/schema-diff/ChangeCollector.ts
@@ -1,3 +1,4 @@
+import type { SchemaNode } from '../schema-node/index.js';
 import type { SchemaTree } from '../schema-tree/index.js';
 import type { RawChange } from './types.js';
 import { NodePathIndex } from './NodePathIndex.js';
@@ -30,62 +31,63 @@ export class ChangeCollector {
   private collectFromCurrentTree(changes: RawChange[]): void {
     for (const nodeId of this.currentTree.nodeIds()) {
       const currentNode = this.currentTree.nodeById(nodeId);
+      this.collectNodeChange(changes, nodeId, currentNode);
+    }
+  }
 
-      if (this.index.isReplacement(nodeId)) {
-        const originalId = this.index.getOriginalNodeId(nodeId);
-        if (originalId) {
-          const baseNode = this.baseTree.nodeById(originalId);
-          if (baseNode.isNull()) {
-            changes.push({
-              type: 'added',
-              baseNode: null,
-              currentNode,
-            });
-          } else {
-            changes.push({
-              type: 'modified',
-              baseNode,
-              currentNode,
-            });
-          }
-        }
-        continue;
-      }
+  private collectNodeChange(
+    changes: RawChange[],
+    nodeId: string,
+    currentNode: SchemaNode,
+  ): void {
+    if (this.index.isReplacement(nodeId)) {
+      this.collectReplacementChange(changes, nodeId, currentNode);
+      return;
+    }
 
-      const basePath = this.index.getBasePath(nodeId);
-      if (!basePath) {
-        changes.push({
-          type: 'added',
-          baseNode: null,
-          currentNode,
-        });
-        continue;
-      }
+    const basePath = this.index.getBasePath(nodeId);
+    if (!basePath) {
+      changes.push({ type: 'added', baseNode: null, currentNode });
+      return;
+    }
 
-      const currentPath = this.currentTree.pathOf(nodeId);
-      const baseNode = this.baseTree.nodeById(nodeId);
+    const currentPath = this.currentTree.pathOf(nodeId);
+    const baseNode = this.baseTree.nodeById(nodeId);
 
-      if (!basePath.equals(currentPath)) {
-        changes.push({
-          type: 'moved',
-          baseNode,
-          currentNode,
-        });
+    if (!basePath.equals(currentPath)) {
+      this.collectMovedChange(changes, baseNode, currentNode);
+    } else if (!areNodesEqual(currentNode, baseNode, this.context)) {
+      changes.push({ type: 'modified', baseNode, currentNode });
+    }
+  }
 
-        if (!areNodesContentEqual(currentNode, baseNode, this.context)) {
-          changes.push({
-            type: 'modified',
-            baseNode,
-            currentNode,
-          });
-        }
-      } else if (!areNodesEqual(currentNode, baseNode, this.context)) {
-        changes.push({
-          type: 'modified',
-          baseNode,
-          currentNode,
-        });
-      }
+  private collectReplacementChange(
+    changes: RawChange[],
+    nodeId: string,
+    currentNode: SchemaNode,
+  ): void {
+    const originalId = this.index.getOriginalNodeId(nodeId);
+    if (!originalId) {
+      return;
+    }
+
+    const baseNode = this.baseTree.nodeById(originalId);
+    if (baseNode.isNull()) {
+      changes.push({ type: 'added', baseNode: null, currentNode });
+    } else {
+      changes.push({ type: 'modified', baseNode, currentNode });
+    }
+  }
+
+  private collectMovedChange(
+    changes: RawChange[],
+    baseNode: SchemaNode,
+    currentNode: SchemaNode,
+  ): void {
+    changes.push({ type: 'moved', baseNode, currentNode });
+
+    if (!areNodesContentEqual(currentNode, baseNode, this.context)) {
+      changes.push({ type: 'modified', baseNode, currentNode });
     }
   }
 
@@ -98,11 +100,7 @@ export class ChangeCollector {
       const currentNode = this.currentTree.nodeById(nodeId);
       if (currentNode.isNull()) {
         const baseNode = this.baseTree.nodeById(nodeId);
-        changes.push({
-          type: 'removed',
-          baseNode,
-          currentNode: null,
-        });
+        changes.push({ type: 'removed', baseNode, currentNode: null });
       }
     }
   }

--- a/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
@@ -51,6 +51,56 @@ describe('SchemaModel patches', () => {
       expect(model.patches).toMatchSnapshot();
     });
 
+    it('returns replace patch for primitive to object type change', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.changeFieldType(nameId!, 'object');
+
+      const patches = model.patches;
+      expect(patches).toHaveLength(1);
+      expect(patches[0]?.patch.op).toBe('replace');
+      expect(patches[0]?.typeChange).toMatchObject({
+        fromType: 'string',
+        toType: 'object',
+      });
+    });
+
+    it('returns replace patch for primitive to array type change', () => {
+      const model = createSchemaModel(simpleSchema());
+      const nameId = findNodeIdByName(model, 'name');
+
+      model.changeFieldType(nameId!, 'array');
+
+      const patches = model.patches;
+      expect(patches).toHaveLength(1);
+      expect(patches[0]?.patch.op).toBe('replace');
+      expect(patches[0]?.typeChange).toMatchObject({
+        fromType: 'string',
+        toType: 'array<string>',
+      });
+    });
+
+    it('handles type change on newly created field (not yet saved)', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root.id();
+
+      const newField = model.addField(rootId, 'newField', 'string');
+      model.changeFieldType(newField.id(), 'object');
+
+      expect(model.patches).toMatchSnapshot();
+    });
+
+    it('handles type change on newly created field to array (not yet saved)', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root.id();
+
+      const newField = model.addField(rootId, 'newField', 'string');
+      model.changeFieldType(newField.id(), 'array');
+
+      expect(model.patches).toMatchSnapshot();
+    });
+
     it('returns replace patch for default value change', () => {
       const model = createSchemaModel(simpleSchema());
       const nameId = findNodeIdByName(model, 'name');

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
@@ -13,6 +13,45 @@ exports[`SchemaModel patches getJsonPatches returns plain JSON patches 1`] = `
 ]
 `;
 
+exports[`SchemaModel patches getPatches handles type change on newly created field (not yet saved) 1`] = `
+[
+  {
+    "fieldName": "newField",
+    "metadataChanges": [],
+    "patch": {
+      "op": "add",
+      "path": "/properties/newField",
+      "value": {
+        "additionalProperties": false,
+        "properties": {},
+        "required": [],
+        "type": "object",
+      },
+    },
+  },
+]
+`;
+
+exports[`SchemaModel patches getPatches handles type change on newly created field to array (not yet saved) 1`] = `
+[
+  {
+    "fieldName": "newField",
+    "metadataChanges": [],
+    "patch": {
+      "op": "add",
+      "path": "/properties/newField",
+      "value": {
+        "items": {
+          "default": "",
+          "type": "string",
+        },
+        "type": "array",
+      },
+    },
+  },
+]
+`;
+
 exports[`SchemaModel patches getPatches includes formula change info 1`] = `
 [
   {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes patch generation for schema type changes and new fields. We now emit “replace” for primitive → object/array changes and “add” when the base node is missing, so diffs and applied patches are correct.

- **Bug Fixes**
  - ChangeCollector marks nodes with a null base as “added” instead of “modified”.
  - Tests verify “replace” patches for string → object and string → array changes.
  - Snapshot tests cover type changes on newly created (unsaved) fields producing “add” patches with correct payloads.

<sup>Written for commit f67cd4068b8c43f241328d36e3c3455dcd0afe42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

