### PR TITLE
fix: formula parsing

### DIFF
--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -39,6 +39,7 @@ export class SchemaModelImpl implements SchemaModel {
     makeObservable(this, {
       _currentTree: 'observable.ref',
       _baseTree: 'observable.ref',
+      _formulaParseErrors: 'observable.ref',
       root: 'computed',
       isDirty: 'computed',
       isValid: 'computed',
@@ -148,10 +149,10 @@ export class SchemaModelImpl implements SchemaModel {
         node.setFormula(formula);
         this._formulaIndex.registerFormula(nodeId, formula);
       } catch (error) {
-        this._formulaParseErrors.push({
-          nodeId,
-          message: (error as Error).message,
-        });
+        this._formulaParseErrors = [
+          ...this._formulaParseErrors,
+          { nodeId, message: (error as Error).message },
+        ];
       }
     }
   }

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -150,7 +150,7 @@ export class SchemaModelImpl implements SchemaModel {
       } catch (error) {
         this._formulaParseErrors.push({
           nodeId,
-          message: error instanceof Error ? error.message : String(error),
+          message: (error as Error).message,
         });
       }
     }

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -25,12 +25,14 @@ export class SchemaModelImpl implements SchemaModel {
   private readonly _serializer = new SchemaSerializer();
   private readonly _nodeFactory = new NodeFactory();
   private readonly _formulaIndex = new FormulaDependencyIndex();
+  private readonly _formulaParseErrors: TreeFormulaValidationError[] = [];
 
   constructor(schema: JsonObjectSchema) {
     const parser = new SchemaParser();
     const rootNode = parser.parse(schema);
     this._currentTree = createSchemaTree(rootNode);
     parser.parseFormulas(this._currentTree);
+    this._formulaParseErrors = parser.parseErrors;
     this._buildFormulaIndex();
     this._baseTree = this._currentTree.clone();
 
@@ -289,7 +291,7 @@ export class SchemaModelImpl implements SchemaModel {
   }
 
   get formulaErrors(): TreeFormulaValidationError[] {
-    return validateFormulas(this._currentTree);
+    return [...this._formulaParseErrors, ...validateFormulas(this._currentTree)];
   }
 
   get isDirty(): boolean {

--- a/src/model/schema-model/SchemaParser.ts
+++ b/src/model/schema-model/SchemaParser.ts
@@ -50,7 +50,7 @@ export class SchemaParser {
       } catch (error) {
         this._parseErrors.push({
           nodeId: pending.nodeId,
-          message: error instanceof Error ? error.message : String(error),
+          message: (error as Error).message,
         });
       }
     }

--- a/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
@@ -180,6 +180,32 @@ describe('SchemaModel validation', () => {
 
       expect(model.formulaErrors).toHaveLength(1);
     });
+
+    it('clears parse error when formula is updated', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          value: { type: JsonSchemaTypeName.Number, default: 0 },
+          computed: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': { version: 1, expression: 'unknownField * 2' },
+          },
+        },
+        additionalProperties: false,
+        required: ['value', 'computed'],
+      };
+
+      const model = createSchemaModel(schema);
+      expect(model.formulaErrors).toHaveLength(1);
+
+      const computedId = findNodeIdByName(model, 'computed');
+      model.updateFormula(computedId!, 'value * 2');
+
+      expect(model.formulaErrors).toHaveLength(0);
+      expect(model.isValid).toBe(true);
+    });
   });
 
   describe('isValid', () => {

--- a/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
@@ -206,6 +206,16 @@ describe('SchemaModel validation', () => {
       expect(model.formulaErrors).toHaveLength(0);
       expect(model.isValid).toBe(true);
     });
+
+    it('captures parse error when updateFormula sets invalid formula', () => {
+      const model = createSchemaModel(simpleSchema());
+      const ageId = findNodeIdByName(model, 'age');
+
+      model.updateFormula(ageId!, 'nonExistentField + 1');
+
+      expect(model.formulaErrors).toHaveLength(1);
+      expect(model.formulaErrors[0]?.message).toContain('nonExistentField');
+    });
   });
 
   describe('isValid', () => {

--- a/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../SchemaModelImpl.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
 import {
   emptySchema,
   simpleSchema,
@@ -105,6 +106,79 @@ describe('SchemaModel validation', () => {
         nodeId: findNodeIdByName(model, 'total'),
         message: 'Cannot resolve formula dependency: target node not found',
       });
+    });
+
+    it('captures formula parse error for invalid dependency at init time', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          value: { type: JsonSchemaTypeName.Number, default: 0 },
+          computed: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': { version: 1, expression: 'unknownField * 2' },
+          },
+        },
+        additionalProperties: false,
+        required: ['value', 'computed'],
+      };
+
+      const model = createSchemaModel(schema);
+
+      expect(model.formulaErrors).toHaveLength(1);
+      expect(model.formulaErrors[0]?.message).toContain('unknownField');
+    });
+
+    it('valid formulas still work when another formula has parse error', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          value: { type: JsonSchemaTypeName.Number, default: 10 },
+          validComputed: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': { version: 1, expression: 'value * 2' },
+          },
+          invalidComputed: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': { version: 1, expression: 'missingField + 1' },
+          },
+        },
+        additionalProperties: false,
+        required: ['value', 'validComputed', 'invalidComputed'],
+      };
+
+      const model = createSchemaModel(schema);
+
+      expect(model.formulaErrors).toHaveLength(1);
+      expect(model.formulaErrors[0]?.message).toContain('missingField');
+
+      const validComputedNode = model.root.property('validComputed');
+      expect(validComputedNode.hasFormula()).toBe(true);
+    });
+
+    it('captures syntax error in formula expression', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        properties: {
+          computed: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': { version: 1, expression: '+ + invalid syntax' },
+          },
+        },
+        additionalProperties: false,
+        required: ['computed'],
+      };
+
+      const model = createSchemaModel(schema);
+
+      expect(model.formulaErrors).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Capture and report formula parse errors during schema initialization and updates so invalid formulas don’t break parsing. Errors appear in SchemaModel.formulaErrors; valid formulas still work and errors clear when fixed.

- **Bug Fixes**
  - Wrapped ParsedFormula creation in SchemaParser.parseFormulas and SchemaModelImpl.updateFormula with try/catch; collect errors.
  - SchemaModelImpl stores parse errors and merges them with validateFormulas in formulaErrors.
  - Added tests for invalid dependencies, syntax errors, unaffected valid formulas, and clearing errors after update.

<sup>Written for commit b7e2cffbb3dc9d13365ebad7b669b77930c1cdc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

