### PR TITLE
feat: foreign-key empty

### DIFF
--- a/src/core/validation/schema/SchemaValidator.ts
+++ b/src/core/validation/schema/SchemaValidator.ts
@@ -16,6 +16,13 @@ function collectValidationErrors(
     return;
   }
 
+  const foreignKey = node.foreignKey();
+  if (foreignKey === '') {
+    errors.push(
+      createError(node.id(), 'empty-foreign-key', 'Foreign key table reference cannot be empty'),
+    );
+  }
+
   if (node.isObject()) {
     const children = node.properties();
     const nameSet = new Set<string>();

--- a/src/core/validation/schema/__tests__/SchemaValidator.spec.ts
+++ b/src/core/validation/schema/__tests__/SchemaValidator.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../../../../model/schema-model/index.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../../types/index.js';
+
+describe('SchemaValidator', () => {
+  describe('foreignKey validation', () => {
+    it('returns error for empty foreignKey', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['categoryId'],
+        properties: {
+          categoryId: {
+            type: JsonSchemaTypeName.String,
+            default: '',
+            foreignKey: '',
+          },
+        },
+      };
+
+      const model = createSchemaModel(schema);
+      const errors = model.validationErrors;
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.type).toBe('empty-foreign-key');
+      expect(errors[0]?.message).toContain('Foreign key');
+    });
+
+    it('does not return error for non-empty foreignKey', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['categoryId'],
+        properties: {
+          categoryId: {
+            type: JsonSchemaTypeName.String,
+            default: '',
+            foreignKey: 'categories',
+          },
+        },
+      };
+
+      const model = createSchemaModel(schema);
+      const errors = model.validationErrors;
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('does not return error for field without foreignKey', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['name'],
+        properties: {
+          name: {
+            type: JsonSchemaTypeName.String,
+            default: '',
+          },
+        },
+      };
+
+      const model = createSchemaModel(schema);
+      const errors = model.validationErrors;
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/core/validation/schema/types.ts
+++ b/src/core/validation/schema/types.ts
@@ -1,7 +1,8 @@
 export type SchemaValidationErrorType =
   | 'empty-name'
   | 'duplicate-name'
-  | 'invalid-name';
+  | 'invalid-name'
+  | 'empty-foreign-key';
 
 export interface SchemaValidationError {
   nodeId: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a schema validation rule that flags empty foreignKey values. Prevents empty table references and surfaces an "empty-foreign-key" error.

- **New Features**
  - Validate and error when foreignKey is an empty string.
  - Add "empty-foreign-key" to SchemaValidationErrorType.
  - Tests for empty, non-empty, and missing foreignKey cases.

<sup>Written for commit 276aabc36f2eaa4a6339f710cf74069ced5a3ab7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

