### PR TITLE
fix: drops and formulas

### DIFF
--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -3,6 +3,7 @@ import { NULL_NODE } from '../schema-node/index.js';
 import type { Path } from '../path/index.js';
 import type { SchemaTree } from './types.js';
 import { TreeNodeIndex } from './TreeNodeIndex.js';
+import { makeObservable } from '../reactivity/index.js';
 
 export class SchemaTreeImpl implements SchemaTree {
   private readonly index = new TreeNodeIndex();
@@ -12,6 +13,16 @@ export class SchemaTreeImpl implements SchemaTree {
   constructor(rootNode: SchemaNode) {
     this._rootNode = rootNode;
     this.index.rebuild(rootNode);
+
+    makeObservable(this, {
+      _rootNode: 'observable.ref',
+      addChildTo: 'action',
+      removeNodeAt: 'action',
+      renameNode: 'action',
+      moveNode: 'action',
+      setNodeAt: 'action',
+      replaceRoot: 'action',
+    });
   }
 
   root(): SchemaNode {
@@ -53,7 +64,7 @@ export class SchemaTreeImpl implements SchemaTree {
   }
 
   countNodes(): number {
-    return this.index.countNodes();
+    return this.index.nodeCount;
   }
 
   clone(): SchemaTree {

--- a/src/core/schema-tree/TreeNodeIndex.ts
+++ b/src/core/schema-tree/TreeNodeIndex.ts
@@ -2,10 +2,18 @@ import type { SchemaNode } from '../schema-node/index.js';
 import { NULL_NODE } from '../schema-node/index.js';
 import type { Path } from '../path/index.js';
 import { EMPTY_PATH } from '../path/index.js';
+import { observable, makeObservable } from '../reactivity/index.js';
 
 export class TreeNodeIndex {
-  private readonly nodeIndex = new Map<string, SchemaNode>();
-  private readonly pathIndex = new Map<string, Path>();
+  private readonly nodeIndex: Map<string, SchemaNode> = observable.map();
+  private readonly pathIndex: Map<string, Path> = observable.map();
+
+  constructor() {
+    makeObservable(this, {
+      rebuild: 'action',
+      nodeCount: 'computed',
+    });
+  }
 
   rebuild(rootNode: SchemaNode): void {
     this.nodeIndex.clear();
@@ -21,7 +29,7 @@ export class TreeNodeIndex {
     return this.pathIndex.get(id) ?? EMPTY_PATH;
   }
 
-  countNodes(): number {
+  get nodeCount(): number {
     return this.nodeIndex.size;
   }
 

--- a/src/core/schema-tree/__tests__/SchemaTree.reactivity.spec.ts
+++ b/src/core/schema-tree/__tests__/SchemaTree.reactivity.spec.ts
@@ -153,6 +153,26 @@ describe('SchemaTree reactivity', () => {
 
       dispose();
     });
+
+    it('pathOf() reflects changes after moveNode', () => {
+      const fieldNode = createStringNode('field-id', 'field');
+      const targetNode = createObjectNode('target-id', 'target');
+      const root = createObjectNode('root-id', 'root', [fieldNode, targetNode]);
+      const tree = createSchemaTree(root);
+
+      let observedPath = '';
+      const dispose = autorun(() => {
+        observedPath = tree.pathOf('field-id').asJsonPointer();
+      });
+
+      expect(observedPath).toBe('/properties/field');
+
+      tree.moveNode('field-id', 'target-id');
+
+      expect(observedPath).toBe('/properties/target/properties/field');
+
+      dispose();
+    });
   });
 
   describe('countNodes reactivity', () => {

--- a/src/core/schema-tree/__tests__/SchemaTree.reactivity.spec.ts
+++ b/src/core/schema-tree/__tests__/SchemaTree.reactivity.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from '@jest/globals';
+import { autorun } from 'mobx';
+import { createSchemaTree } from '../index.js';
+import {
+  createObjectNode,
+  createStringNode,
+  createNumberNode,
+} from '../../schema-node/index.js';
+import { jsonPointerToPath } from '../../path/index.js';
+
+describe('SchemaTree reactivity', () => {
+  describe('root reactivity', () => {
+    it('root() is reactive to addChildTo', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      let observedChildCount = 0;
+      const dispose = autorun(() => {
+        observedChildCount = tree.root().properties().length;
+      });
+
+      expect(observedChildCount).toBe(0);
+
+      const newNode = createStringNode('new-id', 'field');
+      tree.addChildTo('root-id', newNode);
+
+      expect(observedChildCount).toBe(1);
+
+      dispose();
+    });
+
+    it('root() is reactive to removeNodeAt', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      let observedChildCount = 0;
+      const dispose = autorun(() => {
+        observedChildCount = tree.root().properties().length;
+      });
+
+      expect(observedChildCount).toBe(1);
+
+      tree.removeNodeAt(jsonPointerToPath('/properties/name'));
+
+      expect(observedChildCount).toBe(0);
+
+      dispose();
+    });
+
+    it('root() is reactive to setNodeAt', () => {
+      const oldNode = createStringNode('old-id', 'field');
+      const root = createObjectNode('root-id', 'root', [oldNode]);
+      const tree = createSchemaTree(root);
+
+      let observedNodeType = '';
+      const dispose = autorun(() => {
+        const field = tree.root().property('field');
+        observedNodeType = field.nodeType();
+      });
+
+      expect(observedNodeType).toBe('string');
+
+      const newNode = createNumberNode('new-id', 'field');
+      tree.setNodeAt(jsonPointerToPath('/properties/field'), newNode);
+
+      expect(observedNodeType).toBe('number');
+
+      dispose();
+    });
+
+    it('root() is reactive to replaceRoot', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      let observedRootId = '';
+      const dispose = autorun(() => {
+        observedRootId = tree.root().id();
+      });
+
+      expect(observedRootId).toBe('root-id');
+
+      const newRoot = createObjectNode('new-root-id', 'root');
+      tree.replaceRoot(newRoot);
+
+      expect(observedRootId).toBe('new-root-id');
+
+      dispose();
+    });
+
+    it('root() is reactive to renameNode', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      let observedFieldName = '';
+      const dispose = autorun(() => {
+        const props = tree.root().properties();
+        const firstProp = props[0];
+        if (firstProp) {
+          observedFieldName = firstProp.name();
+        }
+      });
+
+      expect(observedFieldName).toBe('name');
+
+      tree.renameNode('name-id', 'newName');
+
+      expect(observedFieldName).toBe('newName');
+
+      dispose();
+    });
+  });
+
+  describe('nodeById reactivity', () => {
+    it('nodeById() reflects changes after addChildTo', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      let observedNode = tree.nodeById('new-id');
+      const dispose = autorun(() => {
+        observedNode = tree.nodeById('new-id');
+      });
+
+      expect(observedNode.isNull()).toBe(true);
+
+      const newNode = createStringNode('new-id', 'field');
+      tree.addChildTo('root-id', newNode);
+
+      expect(observedNode.isNull()).toBe(false);
+      expect(observedNode.id()).toBe('new-id');
+
+      dispose();
+    });
+  });
+
+  describe('pathOf reactivity', () => {
+    it('pathOf() reflects changes after renameNode', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+
+      let observedPath = '';
+      const dispose = autorun(() => {
+        observedPath = tree.pathOf('name-id').asJsonPointer();
+      });
+
+      expect(observedPath).toBe('/properties/name');
+
+      tree.renameNode('name-id', 'newName');
+
+      expect(observedPath).toBe('/properties/newName');
+
+      dispose();
+    });
+  });
+
+  describe('countNodes reactivity', () => {
+    it('countNodes() is reactive to addChildTo', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+
+      let observedCount = 0;
+      const dispose = autorun(() => {
+        observedCount = tree.countNodes();
+      });
+
+      expect(observedCount).toBe(1);
+
+      const newNode = createStringNode('new-id', 'field');
+      tree.addChildTo('root-id', newNode);
+
+      expect(observedCount).toBe(2);
+
+      dispose();
+    });
+  });
+});

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -5,6 +5,7 @@ export * from './table/index.js';
 export * from './default-value/index.js';
 export * from './foreign-key-resolver/index.js';
 export * from './data-model/index.js';
+export * from './schema-formula/index.js';
 
 export {
   ValueType,

--- a/src/model/schema-formula/index.ts
+++ b/src/model/schema-formula/index.ts
@@ -1,7 +1,6 @@
 // Core types
-export type { Formula } from './core/index.js';
 export type { FormulaDependency } from './core/index.js';
-export { ResolvedDependency, FormulaError } from './core/index.js';
+export { ResolvedDependency } from './core/index.js';
 
 // Parsing
 export { ParsedFormula } from './parsing/index.js';

--- a/src/model/schema-model/__tests__/SchemaModel.serializeFormula.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.serializeFormula.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+import { findNodeIdByName, findNestedNodeId } from './test-helpers.js';
+
+describe('SchemaModel serializeFormula', () => {
+  const schemaWithFormulaInNested = (): JsonObjectSchema => ({
+    type: JsonSchemaTypeName.Object,
+    additionalProperties: false,
+    required: ['value', 'nested'],
+    properties: {
+      value: {
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+      },
+      nested: {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['sum'],
+        properties: {
+          sum: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': {
+              version: 1,
+              expression: '../value + 2',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  describe('serializeFormula', () => {
+    it('returns empty string for node without formula', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['field'],
+        properties: {
+          field: { type: JsonSchemaTypeName.String, default: '' },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const fieldId = findNodeIdByName(model, 'field');
+
+      expect(model.serializeFormula(fieldId!)).toBe('');
+    });
+
+    it('returns serialized formula for node with formula', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['price', 'total'],
+        properties: {
+          price: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+          },
+          total: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': {
+              version: 1,
+              expression: 'price * 2',
+            },
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const totalId = findNodeIdByName(model, 'total');
+
+      expect(model.serializeFormula(totalId!)).toBe('price * 2');
+    });
+
+    it('updates relative path when node is moved', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: ['value', 'sum', 'target'],
+        properties: {
+          value: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+          },
+          sum: {
+            type: JsonSchemaTypeName.Number,
+            default: 0,
+            readOnly: true,
+            'x-formula': {
+              version: 1,
+              expression: 'value + 2',
+            },
+          },
+          target: {
+            type: JsonSchemaTypeName.Object,
+            additionalProperties: false,
+            required: [],
+            properties: {},
+          },
+        },
+      };
+      const model = createSchemaModel(schema);
+      const sumId = findNodeIdByName(model, 'sum');
+      const targetId = findNodeIdByName(model, 'target');
+
+      expect(model.serializeFormula(sumId!)).toBe('value + 2');
+
+      model.moveNode(sumId!, targetId!);
+
+      expect(model.serializeFormula(sumId!)).toBe('../value + 2');
+    });
+
+    it('serializes nested formula with relative path', () => {
+      const model = createSchemaModel(schemaWithFormulaInNested());
+      const sumId = findNestedNodeId(model, 'nested', 'sum');
+
+      expect(model.serializeFormula(sumId!)).toBe('../value + 2');
+    });
+
+    it('updates path when formula node moved to root', () => {
+      const model = createSchemaModel(schemaWithFormulaInNested());
+      const sumId = findNestedNodeId(model, 'nested', 'sum');
+      const rootId = model.root.id();
+
+      expect(model.serializeFormula(sumId!)).toBe('../value + 2');
+
+      model.moveNode(sumId!, rootId);
+
+      expect(model.serializeFormula(sumId!)).toBe('value + 2');
+    });
+
+    it('returns empty string for non-existent node', () => {
+      const schema: JsonObjectSchema = {
+        type: JsonSchemaTypeName.Object,
+        additionalProperties: false,
+        required: [],
+        properties: {},
+      };
+      const model = createSchemaModel(schema);
+
+      expect(model.serializeFormula('non-existent')).toBe('');
+    });
+  });
+});

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -37,9 +37,11 @@ export interface SchemaModel {
 
   canMoveNode(nodeId: string, targetParentId: string): boolean;
   hasValidDropTarget(nodeId: string): boolean;
+  moveNode(nodeId: string, targetParentId: string): void;
 
   getFormulaDependents(nodeId: string): readonly string[];
   hasFormulaDependents(nodeId: string): boolean;
+  serializeFormula(nodeId: string): string;
 
   readonly validationErrors: SchemaValidationError[];
   readonly formulaErrors: TreeFormulaValidationError[];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved drag-and-drop validation to prevent moving fields out of array items, and added formula serialization that keeps relative paths correct after node moves. The schema tree is now reactive so the UI updates instantly.

- **Bug Fixes**
  - Blocks moving a node from array items to non-array locations or between different arrays.

- **New Features**
  - Added SchemaModel.moveNode(nodeId, targetParentId) with validation.
  - Added SchemaModel.serializeFormula(nodeId) to output formulas with correct relative paths after moves.
  - Made SchemaTree and TreeNodeIndex observable so root(), nodeById(), pathOf(), and countNodes() react to changes.

<sup>Written for commit 17df061c19d617231746bd3f3eecf845feb82c79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

