### PR TITLE
chore: refactor tests

### DIFF
--- a/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
+++ b/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
@@ -10,8 +10,8 @@ import {
   createRefNode,
 } from '../../schema-node/index.js';
 import type { NodeMetadata } from '../../schema-node/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
 import { createMockFormula } from '../../schema-node/__tests__/test-helpers.js';
+import { obj, str, num, bool, arr, ref } from '../../../mocks/schema.mocks.js';
 
 describe('SchemaSerializer', () => {
   let serializer: SchemaSerializer;
@@ -27,12 +27,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {},
-        additionalProperties: false,
-        required: [],
-      });
+      expect(result).toEqual(obj({}));
     });
 
     it('serializes object with string field', () => {
@@ -43,17 +38,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          name: {
-            type: JsonSchemaTypeName.String,
-            default: '',
-          },
-        },
-        additionalProperties: false,
-        required: ['name'],
-      });
+      expect(result).toEqual(obj({ name: str() }));
     });
 
     it('serializes object with multiple fields', () => {
@@ -66,16 +51,12 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: 'test' },
-          age: { type: JsonSchemaTypeName.Number, default: 25 },
-          active: { type: JsonSchemaTypeName.Boolean, default: true },
-        },
-        additionalProperties: false,
-        required: ['name', 'age', 'active'],
+      expect(result.properties).toEqual({
+        name: str({ default: 'test' }),
+        age: num({ default: 25 }),
+        active: bool({ default: true }),
       });
+      expect(result.required).toEqual(['name', 'age', 'active']);
     });
   });
 
@@ -88,10 +69,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.field).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: 'hello',
-      });
+      expect(result.properties.field).toEqual(str({ default: 'hello' }));
     });
 
     it('serializes string with empty default', () => {
@@ -102,10 +80,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.field).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-      });
+      expect(result.properties.field).toEqual(str());
     });
 
     it('serializes string with foreignKey', () => {
@@ -119,11 +94,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.userId).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        foreignKey: 'users',
-      });
+      expect(result.properties.userId).toEqual(str({ foreignKey: 'users' }));
     });
 
     it('serializes string with formula', () => {
@@ -137,15 +108,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.computed).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        readOnly: true,
-        'x-formula': {
-          version: 1,
-          expression: 'name + " " + surname',
-        },
-      });
+      expect(result.properties.computed).toEqual(
+        str({ readOnly: true, formula: 'name + " " + surname' }),
+      );
     });
   });
 
@@ -158,10 +123,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.count).toEqual({
-        type: JsonSchemaTypeName.Number,
-        default: 42,
-      });
+      expect(result.properties.count).toEqual(num({ default: 42 }));
     });
 
     it('serializes number with zero default', () => {
@@ -172,10 +134,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.count).toEqual({
-        type: JsonSchemaTypeName.Number,
-        default: 0,
-      });
+      expect(result.properties.count).toEqual(num());
     });
 
     it('serializes number with formula', () => {
@@ -189,15 +148,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.total).toEqual({
-        type: JsonSchemaTypeName.Number,
-        default: 0,
-        readOnly: true,
-        'x-formula': {
-          version: 1,
-          expression: 'price * quantity',
-        },
-      });
+      expect(result.properties.total).toEqual(
+        num({ readOnly: true, formula: 'price * quantity' }),
+      );
     });
   });
 
@@ -210,10 +163,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.enabled).toEqual({
-        type: JsonSchemaTypeName.Boolean,
-        default: true,
-      });
+      expect(result.properties.enabled).toEqual(bool({ default: true }));
     });
 
     it('serializes boolean with false default', () => {
@@ -224,10 +174,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.enabled).toEqual({
-        type: JsonSchemaTypeName.Boolean,
-        default: false,
-      });
+      expect(result.properties.enabled).toEqual(bool());
     });
 
     it('serializes boolean with formula', () => {
@@ -241,15 +188,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.isValid).toEqual({
-        type: JsonSchemaTypeName.Boolean,
-        default: false,
-        readOnly: true,
-        'x-formula': {
-          version: 1,
-          expression: 'price > 0',
-        },
-      });
+      expect(result.properties.isValid).toEqual(
+        bool({ readOnly: true, formula: 'price > 0' }),
+      );
     });
   });
 
@@ -266,13 +207,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.tags).toEqual({
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.String,
-          default: '',
-        },
-      });
+      expect(result.properties.tags).toEqual(arr(str()));
     });
 
     it('serializes array with object items', () => {
@@ -290,18 +225,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.items).toEqual({
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.Object,
-          properties: {
-            name: { type: JsonSchemaTypeName.String, default: '' },
-            quantity: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-          additionalProperties: false,
-          required: ['name', 'quantity'],
-        },
-      });
+      expect(result.properties.items).toMatchObject(
+        arr(obj({ name: str(), quantity: num() })),
+      );
     });
 
     it('serializes nested arrays', () => {
@@ -320,16 +246,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.matrix).toEqual({
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.Array,
-          items: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-          },
-        },
-      });
+      expect(result.properties.matrix).toEqual(arr(arr(num())));
     });
   });
 
@@ -342,9 +259,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.file).toEqual({
-        $ref: 'File',
-      });
+      expect(result.properties.file).toEqual(ref('File'));
     });
 
     it('serializes array of refs', () => {
@@ -359,12 +274,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.files).toEqual({
-        type: JsonSchemaTypeName.Array,
-        items: {
-          $ref: 'File',
-        },
-      });
+      expect(result.properties.files).toEqual(arr(ref('File')));
     });
   });
 
@@ -380,14 +290,8 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.address).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          street: { type: JsonSchemaTypeName.String, default: '' },
-          city: { type: JsonSchemaTypeName.String, default: '' },
-        },
-        additionalProperties: false,
-        required: ['street', 'city'],
+      expect(result.properties.address).toMatchObject({
+        properties: { street: str(), city: str() },
       });
     });
 
@@ -403,21 +307,11 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.level1).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          level2: {
-            type: JsonSchemaTypeName.Object,
-            properties: {
-              value: { type: JsonSchemaTypeName.String, default: 'deep' },
-            },
-            additionalProperties: false,
-            required: ['value'],
-          },
-        },
-        additionalProperties: false,
-        required: ['level2'],
-      });
+      expect(result.properties.level1).toEqual(
+        obj({
+          level2: obj({ value: str({ default: 'deep' }) }),
+        }),
+      );
     });
   });
 
@@ -431,11 +325,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.name).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        title: 'User Name',
-      });
+      expect(result.properties.name).toEqual(str({ title: 'User Name' }));
     });
 
     it('serializes description', () => {
@@ -447,11 +337,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.name).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        description: 'The user full name',
-      });
+      expect(result.properties.name).toEqual(
+        str({ description: 'The user full name' }),
+      );
     });
 
     it('serializes deprecated flag', () => {
@@ -463,11 +351,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.oldField).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        deprecated: true,
-      });
+      expect(result.properties.oldField).toEqual(str({ deprecated: true }));
     });
 
     it('serializes all metadata fields', () => {
@@ -483,13 +367,13 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.legacy).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        title: 'Legacy Field',
-        description: 'This field is deprecated',
-        deprecated: true,
-      });
+      expect(result.properties.legacy).toEqual(
+        str({
+          title: 'Legacy Field',
+          description: 'This field is deprecated',
+          deprecated: true,
+        }),
+      );
     });
 
     it('serializes metadata on root object', () => {
@@ -499,14 +383,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {},
-        additionalProperties: false,
-        required: [],
-        title: 'User Schema',
-        description: 'User data',
-      });
+      expect(result).toEqual(
+        obj({}, { title: 'User Schema', description: 'User data' }),
+      );
     });
 
     it('serializes metadata on array field', () => {
@@ -523,14 +402,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.tags).toEqual({
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.String,
-          default: '',
-        },
-        title: 'Tags List',
-      });
+      expect(result.properties.tags).toEqual(arr(str(), { title: 'Tags List' }));
     });
 
     it('serializes metadata on ref field', () => {
@@ -542,10 +414,9 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.properties.avatar).toEqual({
-        $ref: 'File',
-        title: 'Profile Picture',
-      });
+      expect(result.properties.avatar).toEqual(
+        ref('File', { title: 'Profile Picture' }),
+      );
     });
 
     it('does not include undefined metadata fields', () => {
@@ -576,15 +447,10 @@ describe('SchemaSerializer', () => {
         excludeNodeIds: new Set(['secret-id']),
       });
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-          age: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-        additionalProperties: false,
-        required: ['name', 'age'],
+      expect(result).toMatchObject({
+        properties: { name: str(), age: num() },
       });
+      expect((result as { required: string[] }).required).toEqual(['name', 'age']);
     });
 
     it('excludes multiple node IDs', () => {
@@ -599,14 +465,7 @@ describe('SchemaSerializer', () => {
         excludeNodeIds: new Set(['field1-id', 'field3-id']),
       });
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          field2: { type: JsonSchemaTypeName.String, default: '' },
-        },
-        additionalProperties: false,
-        required: ['field2'],
-      });
+      expect(result).toEqual(obj({ field2: str() }));
     });
 
     it('handles empty excludeNodeIds set', () => {
@@ -619,14 +478,7 @@ describe('SchemaSerializer', () => {
         excludeNodeIds: new Set(),
       });
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-        },
-        additionalProperties: false,
-        required: ['name'],
-      });
+      expect(result).toEqual(obj({ name: str() }));
     });
 
     it('excludes nested object properties', () => {
@@ -642,21 +494,7 @@ describe('SchemaSerializer', () => {
         excludeNodeIds: new Set(['hidden-id']),
       });
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          data: {
-            type: JsonSchemaTypeName.Object,
-            properties: {
-              visible: { type: JsonSchemaTypeName.String, default: '' },
-            },
-            additionalProperties: false,
-            required: ['visible'],
-          },
-        },
-        additionalProperties: false,
-        required: ['data'],
-      });
+      expect(result).toEqual(obj({ data: obj({ visible: str() }) }));
     });
 
     it('can exclude entire nested object', () => {
@@ -672,14 +510,7 @@ describe('SchemaSerializer', () => {
         excludeNodeIds: new Set(['obj-id']),
       });
 
-      expect(result).toEqual({
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-        },
-        additionalProperties: false,
-        required: ['name'],
-      });
+      expect(result).toEqual(obj({ name: str() }));
     });
   });
 
@@ -846,7 +677,7 @@ describe('SchemaSerializer', () => {
 
       const result = serializer.serializeTree(tree);
 
-      expect(result.type).toBe(JsonSchemaTypeName.Object);
+      expect(result.type).toBe('object');
       expect(result.required).toEqual([
         'id',
         'name',
@@ -857,18 +688,13 @@ describe('SchemaSerializer', () => {
         'tags',
         'image',
       ]);
-      expect(result.properties.total).toEqual({
-        type: JsonSchemaTypeName.Number,
-        default: 0,
-        readOnly: true,
-        'x-formula': { version: 1, expression: 'price * quantity' },
-      });
-      expect(result.properties.name).toEqual({
-        type: JsonSchemaTypeName.String,
-        default: '',
-        title: 'Product Name',
-      });
-      expect(result.properties.image).toEqual({ $ref: 'File' });
+      expect(result.properties.total).toEqual(
+        num({ readOnly: true, formula: 'price * quantity' }),
+      );
+      expect(result.properties.name).toEqual(
+        str({ title: 'Product Name' }),
+      );
+      expect(result.properties.image).toEqual(ref('File'));
     });
   });
 });

--- a/src/core/validation/schema/__tests__/SchemaValidator.spec.ts
+++ b/src/core/validation/schema/__tests__/SchemaValidator.spec.ts
@@ -1,22 +1,13 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../../../../model/schema-model/index.js';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../../types/index.js';
+import { obj, str } from '../../../../mocks/schema.mocks.js';
 
 describe('SchemaValidator', () => {
   describe('foreignKey validation', () => {
     it('returns error for empty foreignKey', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['categoryId'],
-        properties: {
-          categoryId: {
-            type: JsonSchemaTypeName.String,
-            default: '',
-            foreignKey: '',
-          },
-        },
-      };
+      const schema = obj({
+        categoryId: str({ foreignKey: '' }),
+      });
 
       const model = createSchemaModel(schema);
       const errors = model.validationErrors;
@@ -27,18 +18,9 @@ describe('SchemaValidator', () => {
     });
 
     it('does not return error for non-empty foreignKey', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['categoryId'],
-        properties: {
-          categoryId: {
-            type: JsonSchemaTypeName.String,
-            default: '',
-            foreignKey: 'categories',
-          },
-        },
-      };
+      const schema = obj({
+        categoryId: str({ foreignKey: 'categories' }),
+      });
 
       const model = createSchemaModel(schema);
       const errors = model.validationErrors;
@@ -47,17 +29,9 @@ describe('SchemaValidator', () => {
     });
 
     it('does not return error for field without foreignKey', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['name'],
-        properties: {
-          name: {
-            type: JsonSchemaTypeName.String,
-            default: '',
-          },
-        },
-      };
+      const schema = obj({
+        name: str(),
+      });
 
       const model = createSchemaModel(schema);
       const errors = model.validationErrors;

--- a/src/mocks/schema.mocks.ts
+++ b/src/mocks/schema.mocks.ts
@@ -1,5 +1,4 @@
 import {
-  ContentMediaType,
   JsonArraySchema,
   JsonBooleanSchema,
   JsonNumberSchema,
@@ -89,8 +88,8 @@ export const getStringSchema = (params: StringSchemaOptions = {}): JsonStringSch
   const { formula, ...rest } = params;
   return {
     type: JsonSchemaTypeName.String,
-    default: rest.default ?? '',
     ...rest,
+    default: rest.default ?? '',
     ...(formula && { 'x-formula': buildFormula(formula) }),
   };
 };
@@ -99,8 +98,8 @@ export const getNumberSchema = (params: NumberSchemaOptions = {}): JsonNumberSch
   const { formula, ...rest } = params;
   return {
     type: JsonSchemaTypeName.Number,
-    default: rest.default ?? 0,
     ...rest,
+    default: rest.default ?? 0,
     ...(formula && { 'x-formula': buildFormula(formula) }),
   };
 };
@@ -109,8 +108,8 @@ export const getBooleanSchema = (params: BooleanSchemaOptions = {}): JsonBoolean
   const { formula, ...rest } = params;
   return {
     type: JsonSchemaTypeName.Boolean,
-    default: rest.default ?? false,
     ...rest,
+    default: rest.default ?? false,
     ...(formula && { 'x-formula': buildFormula(formula) }),
   };
 };
@@ -160,5 +159,6 @@ export type {
   ObjectSchemaOptions,
   ArraySchemaOptions,
   RefSchemaOptions,
-  ContentMediaType,
 };
+
+export type { ContentMediaType } from '../types/schema.types.js';

--- a/src/model/data-model/__tests__/DataModel.spec.ts
+++ b/src/model/data-model/__tests__/DataModel.spec.ts
@@ -1,26 +1,15 @@
 import { describe, it, expect } from '@jest/globals';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
 import { createForeignKeyResolver } from '../../foreign-key-resolver/ForeignKeyResolverImpl.js';
 import { createDataModel } from '../DataModelImpl.js';
+import { obj, str } from '../../../mocks/schema.mocks.js';
 
-const createSimpleSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-  },
-});
+const createSimpleSchema = () => obj({ name: str() });
 
-const createSchemaWithFK = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'categoryId'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
-  },
-});
+const createSchemaWithFK = () =>
+  obj({
+    name: str(),
+    categoryId: str({ foreignKey: 'categories' }),
+  });
 
 describe('DataModel', () => {
   describe('table management', () => {

--- a/src/model/default-value/__tests__/generateDefaultValue.spec.ts
+++ b/src/model/default-value/__tests__/generateDefaultValue.spec.ts
@@ -1,28 +1,19 @@
 import { describe, it, expect } from '@jest/globals';
-import { JsonSchemaTypeName, type JsonSchema } from '../../../types/schema.types.js';
+import type { JsonSchema } from '../../../types/schema.types.js';
 import { generateDefaultValue } from '../generateDefaultValue.js';
+import { obj, str, num, bool, arr, ref } from '../../../mocks/schema.mocks.js';
 
 describe('generateDefaultValue', () => {
   describe('primitives', () => {
     describe('string', () => {
       it('returns empty string without default', () => {
-        const schema: JsonSchema = {
-          type: JsonSchemaTypeName.String,
-          default: '',
-        };
-
-        const result = generateDefaultValue(schema);
+        const result = generateDefaultValue(str());
 
         expect(result).toBe('');
       });
 
       it('returns schema default when provided', () => {
-        const schema: JsonSchema = {
-          type: JsonSchemaTypeName.String,
-          default: 'hello',
-        };
-
-        const result = generateDefaultValue(schema);
+        const result = generateDefaultValue(str({ default: 'hello' }));
 
         expect(result).toBe('hello');
       });
@@ -30,23 +21,13 @@ describe('generateDefaultValue', () => {
 
     describe('number', () => {
       it('returns 0 without default', () => {
-        const schema: JsonSchema = {
-          type: JsonSchemaTypeName.Number,
-          default: 0,
-        };
-
-        const result = generateDefaultValue(schema);
+        const result = generateDefaultValue(num());
 
         expect(result).toBe(0);
       });
 
       it('returns schema default when provided', () => {
-        const schema: JsonSchema = {
-          type: JsonSchemaTypeName.Number,
-          default: 42,
-        };
-
-        const result = generateDefaultValue(schema);
+        const result = generateDefaultValue(num({ default: 42 }));
 
         expect(result).toBe(42);
       });
@@ -54,23 +35,13 @@ describe('generateDefaultValue', () => {
 
     describe('boolean', () => {
       it('returns false without default', () => {
-        const schema: JsonSchema = {
-          type: JsonSchemaTypeName.Boolean,
-          default: false,
-        };
-
-        const result = generateDefaultValue(schema);
+        const result = generateDefaultValue(bool());
 
         expect(result).toBe(false);
       });
 
       it('returns schema default when provided', () => {
-        const schema: JsonSchema = {
-          type: JsonSchemaTypeName.Boolean,
-          default: true,
-        };
-
-        const result = generateDefaultValue(schema);
+        const result = generateDefaultValue(bool({ default: true }));
 
         expect(result).toBe(true);
       });
@@ -79,28 +50,16 @@ describe('generateDefaultValue', () => {
 
   describe('object', () => {
     it('returns empty object for empty schema', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: [],
-        properties: {},
-      };
-
-      const result = generateDefaultValue(schema);
+      const result = generateDefaultValue(obj({}));
 
       expect(result).toEqual({});
     });
 
     it('generates defaults for properties', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['name', 'age'],
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-          age: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        name: str(),
+        age: num(),
+      });
 
       const result = generateDefaultValue(schema);
 
@@ -108,15 +67,10 @@ describe('generateDefaultValue', () => {
     });
 
     it('uses property defaults', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['name', 'age'],
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: 'Unknown' },
-          age: { type: JsonSchemaTypeName.Number, default: 18 },
-        },
-      };
+      const schema = obj({
+        name: str({ default: 'Unknown' }),
+        age: num({ default: 18 }),
+      });
 
       const result = generateDefaultValue(schema);
 
@@ -124,22 +78,12 @@ describe('generateDefaultValue', () => {
     });
 
     it('handles nested objects recursively', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['address'],
-        properties: {
-          address: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['city', 'zip'],
-            properties: {
-              city: { type: JsonSchemaTypeName.String, default: 'NYC' },
-              zip: { type: JsonSchemaTypeName.String, default: '' },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        address: obj({
+          city: str({ default: 'NYC' }),
+          zip: str(),
+        }),
+      });
 
       const result = generateDefaultValue(schema);
 
@@ -151,61 +95,35 @@ describe('generateDefaultValue', () => {
 
   describe('array', () => {
     it('returns empty array without arrayItemCount', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
-      };
-
-      const result = generateDefaultValue(schema);
+      const result = generateDefaultValue(arr(str()));
 
       expect(result).toEqual([]);
     });
 
     it('returns empty array with arrayItemCount 0', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
-      };
-
-      const result = generateDefaultValue(schema, { arrayItemCount: 0 });
+      const result = generateDefaultValue(arr(str()), { arrayItemCount: 0 });
 
       expect(result).toEqual([]);
     });
 
     it('generates one element with arrayItemCount 1', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
-      };
-
-      const result = generateDefaultValue(schema, { arrayItemCount: 1 });
+      const result = generateDefaultValue(arr(str()), { arrayItemCount: 1 });
 
       expect(result).toEqual(['']);
     });
 
     it('generates multiple elements with arrayItemCount', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: 'item' },
-      };
-
-      const result = generateDefaultValue(schema, { arrayItemCount: 3 });
+      const result = generateDefaultValue(arr(str({ default: 'item' })), { arrayItemCount: 3 });
 
       expect(result).toEqual(['item', 'item', 'item']);
     });
 
     it('generates object items with defaults', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['id'],
-          properties: {
-            id: { type: JsonSchemaTypeName.String, default: '' },
-          },
-        },
-      };
+      const schema = arr(
+        obj({
+          id: str(),
+        }),
+      );
 
       const result = generateDefaultValue(schema, { arrayItemCount: 2 });
 
@@ -213,17 +131,11 @@ describe('generateDefaultValue', () => {
     });
 
     it('creates independent object instances', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['id'],
-          properties: {
-            id: { type: JsonSchemaTypeName.String, default: '' },
-          },
-        },
-      };
+      const schema = arr(
+        obj({
+          id: str(),
+        }),
+      );
 
       const result = generateDefaultValue(schema, { arrayItemCount: 2 }) as object[];
 
@@ -231,20 +143,9 @@ describe('generateDefaultValue', () => {
     });
 
     it('applies arrayItemCount to nested arrays', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['matrix'],
-        properties: {
-          matrix: {
-            type: JsonSchemaTypeName.Array,
-            items: {
-              type: JsonSchemaTypeName.Array,
-              items: { type: JsonSchemaTypeName.Number, default: 0 },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        matrix: arr(arr(num())),
+      });
 
       const result = generateDefaultValue(schema, { arrayItemCount: 2 });
 
@@ -263,15 +164,10 @@ describe('generateDefaultValue', () => {
 
       const result = generateDefaultValue(schema, {
         refSchemas: {
-          File: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['fileId', 'url'],
-            properties: {
-              fileId: { type: JsonSchemaTypeName.String, default: '' },
-              url: { type: JsonSchemaTypeName.String, default: '' },
-            },
-          },
+          File: obj({
+            fileId: str(),
+            url: str(),
+          }),
         },
       });
 
@@ -291,12 +187,7 @@ describe('generateDefaultValue', () => {
 
       const result = generateDefaultValue(schema, {
         refSchemas: {
-          File: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
+          File: obj({}),
         },
       });
 
@@ -304,25 +195,15 @@ describe('generateDefaultValue', () => {
     });
 
     it('handles nested refs', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['image'],
-        properties: {
-          image: { $ref: 'File' },
-        },
-      };
+      const schema = obj({
+        image: ref('File'),
+      });
 
       const result = generateDefaultValue(schema, {
         refSchemas: {
-          File: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['url'],
-            properties: {
-              url: { type: JsonSchemaTypeName.String, default: '' },
-            },
-          },
+          File: obj({
+            url: str(),
+          }),
         },
       });
 
@@ -332,22 +213,14 @@ describe('generateDefaultValue', () => {
     });
 
     it('handles array of refs', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { $ref: 'Tag' },
-      };
+      const schema = arr(ref('Tag'));
 
       const result = generateDefaultValue(schema, {
         arrayItemCount: 2,
         refSchemas: {
-          Tag: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['name'],
-            properties: {
-              name: { type: JsonSchemaTypeName.String, default: '' },
-            },
-          },
+          Tag: obj({
+            name: str(),
+          }),
         },
       });
 
@@ -369,7 +242,7 @@ describe('generateDefaultValue', () => {
     });
 
     it('returns empty string for string without default in schema', () => {
-      const schema = { type: JsonSchemaTypeName.String } as JsonSchema;
+      const schema = { type: 'string' } as JsonSchema;
 
       const result = generateDefaultValue(schema);
 
@@ -377,7 +250,7 @@ describe('generateDefaultValue', () => {
     });
 
     it('returns 0 for number without default in schema', () => {
-      const schema = { type: JsonSchemaTypeName.Number } as JsonSchema;
+      const schema = { type: 'number' } as JsonSchema;
 
       const result = generateDefaultValue(schema);
 
@@ -385,7 +258,7 @@ describe('generateDefaultValue', () => {
     });
 
     it('returns false for boolean without default in schema', () => {
-      const schema = { type: JsonSchemaTypeName.Boolean } as JsonSchema;
+      const schema = { type: 'boolean' } as JsonSchema;
 
       const result = generateDefaultValue(schema);
 
@@ -401,8 +274,8 @@ describe('generateDefaultValue', () => {
     });
 
     it('returns empty object for object without properties', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
+      const schema = {
+        type: 'object',
         additionalProperties: false,
         required: [],
       } as unknown as JsonSchema;
@@ -421,45 +294,21 @@ describe('generateDefaultValue', () => {
     });
 
     it('handles complex nested structure', () => {
-      const schema: JsonSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['user', 'tags', 'metadata'],
-        properties: {
-          user: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['name', 'contacts'],
-            properties: {
-              name: { type: JsonSchemaTypeName.String, default: '' },
-              contacts: {
-                type: JsonSchemaTypeName.Array,
-                items: {
-                  type: JsonSchemaTypeName.Object,
-                  additionalProperties: false,
-                  required: ['type', 'value'],
-                  properties: {
-                    type: { type: JsonSchemaTypeName.String, default: 'email' },
-                    value: { type: JsonSchemaTypeName.String, default: '' },
-                  },
-                },
-              },
-            },
-          },
-          tags: {
-            type: JsonSchemaTypeName.Array,
-            items: { type: JsonSchemaTypeName.String, default: '' },
-          },
-          metadata: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['active'],
-            properties: {
-              active: { type: JsonSchemaTypeName.Boolean, default: true },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        user: obj({
+          name: str(),
+          contacts: arr(
+            obj({
+              type: str({ default: 'email' }),
+              value: str(),
+            }),
+          ),
+        }),
+        tags: arr(str()),
+        metadata: obj({
+          active: bool({ default: true }),
+        }),
+      });
 
       const result = generateDefaultValue(schema, { arrayItemCount: 1 });
 

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.prefetch.spec.ts
@@ -1,37 +1,23 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import type { JsonObjectSchema } from '../../../types/schema.types.js';
 import { createForeignKeyResolver } from '../ForeignKeyResolverImpl.js';
 import type { ForeignKeyLoader, RowData } from '../types.js';
+import { obj, str, num } from '../../../mocks/schema.mocks.js';
 
-const createCategorySchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-  },
-});
+const createCategorySchema = () => obj({ name: str() });
 
-const createProductSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'categoryId'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
-  },
-});
+const createProductSchema = () =>
+  obj({
+    name: str(),
+    categoryId: str({ foreignKey: 'categories' }),
+  });
 
-const createProductWithMultipleFKSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'categoryId', 'brandId'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    categoryId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'categories' },
-    brandId: { type: JsonSchemaTypeName.String, default: '', foreignKey: 'brands' },
-  },
-});
+const createProductWithMultipleFKSchema = () =>
+  obj({
+    name: str(),
+    categoryId: str({ foreignKey: 'categories' }),
+    brandId: str({ foreignKey: 'brands' }),
+  });
 
 function createMockLoader(
   rowHandler?: (tableId: string, rowId: string) => Promise<{ schema: JsonObjectSchema; row: RowData }>,
@@ -306,15 +292,10 @@ describe('ForeignKeyResolver prefetch', () => {
     });
 
     it('prefetch skips schema without FK fields', async () => {
-      const schemaWithoutFK: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['name', 'count'],
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-          count: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schemaWithoutFK = obj({
+        name: str(),
+        count: num(),
+      });
 
       const resolver = createForeignKeyResolver({
         loader: mockLoader,

--- a/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
+++ b/src/model/foreign-key-resolver/__tests__/ForeignKeyResolver.spec.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect } from '@jest/globals';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import type { JsonObjectSchema } from '../../../types/schema.types.js';
 import { createForeignKeyResolver } from '../ForeignKeyResolverImpl.js';
 import { ForeignKeyNotFoundError } from '../errors.js';
 import type { ForeignKeyLoader, RowData } from '../types.js';
+import { obj, str } from '../../../mocks/schema.mocks.js';
 
-const createSimpleSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-  },
-});
+const createSimpleSchema = () => obj({ name: str() });
 
 function createMockLoader(overrides: Partial<ForeignKeyLoader> = {}): ForeignKeyLoader & {
   loadSchemaCallCount: number;

--- a/src/model/schema-formula/__tests__/FormulaDependencyIndex.spec.ts
+++ b/src/model/schema-formula/__tests__/FormulaDependencyIndex.spec.ts
@@ -1,9 +1,9 @@
 import type { JsonObjectSchema } from '../../../types/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
 import { createSchemaTree } from '../../../core/schema-tree/index.js';
 import { SchemaParser } from '../../schema-model/SchemaParser.js';
 import { ParsedFormula } from '../parsing/index.js';
 import { FormulaDependencyIndex } from '../store/index.js';
+import { obj, num } from '../../../mocks/schema.mocks.js';
 
 const createTree = (schema: JsonObjectSchema) => {
   const parser = new SchemaParser();
@@ -14,15 +14,10 @@ const createTree = (schema: JsonObjectSchema) => {
 describe('FormulaDependencyIndex', () => {
   describe('registerFormula / getDependents', () => {
     it('tracks simple dependency', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'total'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -39,16 +34,11 @@ describe('FormulaDependencyIndex', () => {
     });
 
     it('tracks multiple dependents', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'doubled', 'tripled'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          doubled: { type: JsonSchemaTypeName.Number, default: 0 },
-          tripled: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        doubled: num(),
+        tripled: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -69,15 +59,10 @@ describe('FormulaDependencyIndex', () => {
     });
 
     it('returns empty array for field with no dependents', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'quantity'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          quantity: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        quantity: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -91,15 +76,10 @@ describe('FormulaDependencyIndex', () => {
 
   describe('unregisterFormula', () => {
     it('removes dependency tracking', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'total'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -128,15 +108,10 @@ describe('FormulaDependencyIndex', () => {
 
   describe('hasDependents', () => {
     it('returns true when field has dependents', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'total'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -151,15 +126,10 @@ describe('FormulaDependencyIndex', () => {
     });
 
     it('returns false when field has no dependents', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'quantity'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          quantity: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        quantity: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -171,15 +141,10 @@ describe('FormulaDependencyIndex', () => {
 
   describe('getFormula / hasFormula', () => {
     it('returns formula for node with formula', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'total'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -193,14 +158,9 @@ describe('FormulaDependencyIndex', () => {
     });
 
     it('returns null for node without formula', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -213,15 +173,10 @@ describe('FormulaDependencyIndex', () => {
 
   describe('clear', () => {
     it('removes all formulas', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'total'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -244,16 +199,11 @@ describe('FormulaDependencyIndex', () => {
 
   describe('forEachFormula', () => {
     it('iterates over all formulas', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a', 'b', 'c'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-          b: { type: JsonSchemaTypeName.Number, default: 0 },
-          c: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+        b: num(),
+        c: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();
@@ -279,16 +229,11 @@ describe('FormulaDependencyIndex', () => {
 
   describe('re-registration', () => {
     it('updates dependencies when formula is re-registered', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a', 'b', 'total'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-          b: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+        b: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const index = new FormulaDependencyIndex();

--- a/src/model/schema-formula/__tests__/FormulaSerializer.spec.ts
+++ b/src/model/schema-formula/__tests__/FormulaSerializer.spec.ts
@@ -1,9 +1,9 @@
 import type { JsonObjectSchema } from '../../../types/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
 import { createSchemaTree } from '../../../core/schema-tree/index.js';
 import { SchemaParser } from '../../schema-model/SchemaParser.js';
 import { ParsedFormula } from '../parsing/index.js';
 import { FormulaSerializer } from '../serialization/index.js';
+import { obj, str, num, bool, arr } from '../../../mocks/schema.mocks.js';
 
 const createTree = (schema: JsonObjectSchema) => {
   const parser = new SchemaParser();
@@ -14,16 +14,11 @@ const createTree = (schema: JsonObjectSchema) => {
 describe('FormulaSerializer', () => {
   describe('toXFormula', () => {
     it('converts formula to XFormula format', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a', 'b', 'sum'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-          b: { type: JsonSchemaTypeName.Number, default: 0 },
-          sum: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+        b: num(),
+        sum: num(),
+      });
 
       const tree = createTree(schema);
       const sumNode = tree.root().property('sum');
@@ -41,14 +36,9 @@ describe('FormulaSerializer', () => {
   describe('serialize', () => {
     describe('literals', () => {
       it('serializes number literals', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['value'],
-          properties: {
-            value: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          value: num(),
+        });
 
         const tree = createTree(schema);
         const valueNode = tree.root().property('value');
@@ -59,14 +49,9 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes negative number literals', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['value'],
-          properties: {
-            value: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          value: num(),
+        });
 
         const tree = createTree(schema);
         const valueNode = tree.root().property('value');
@@ -77,14 +62,9 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes string literals', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['value'],
-          properties: {
-            value: { type: JsonSchemaTypeName.String, default: '' },
-          },
-        };
+        const schema = obj({
+          value: str(),
+        });
 
         const tree = createTree(schema);
         const valueNode = tree.root().property('value');
@@ -95,14 +75,9 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes boolean true', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['value'],
-          properties: {
-            value: { type: JsonSchemaTypeName.Boolean, default: false },
-          },
-        };
+        const schema = obj({
+          value: bool(),
+        });
 
         const tree = createTree(schema);
         const valueNode = tree.root().property('value');
@@ -113,14 +88,9 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes null', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['value'],
-          properties: {
-            value: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          value: num(),
+        });
 
         const tree = createTree(schema);
         const valueNode = tree.root().property('value');
@@ -132,16 +102,12 @@ describe('FormulaSerializer', () => {
     });
 
     describe('binary operations', () => {
-      const createMathSchema = (): JsonObjectSchema => ({
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a', 'b', 'sum'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-          b: { type: JsonSchemaTypeName.Number, default: 0 },
-          sum: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      });
+      const createMathSchema = () =>
+        obj({
+          a: num(),
+          b: num(),
+          sum: num(),
+        });
 
       it('serializes addition', () => {
         const tree = createTree(createMathSchema());
@@ -200,15 +166,10 @@ describe('FormulaSerializer', () => {
 
     describe('unary operations', () => {
       it('serializes negation', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['a', 'b'],
-          properties: {
-            a: { type: JsonSchemaTypeName.Number, default: 0 },
-            b: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          a: num(),
+          b: num(),
+        });
 
         const tree = createTree(schema);
         const bNode = tree.root().property('b');
@@ -219,15 +180,10 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes logical not', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['flag', 'result'],
-          properties: {
-            flag: { type: JsonSchemaTypeName.Boolean, default: false },
-            result: { type: JsonSchemaTypeName.Boolean, default: false },
-          },
-        };
+        const schema = obj({
+          flag: bool(),
+          result: bool(),
+        });
 
         const tree = createTree(schema);
         const resultNode = tree.root().property('result');
@@ -240,15 +196,10 @@ describe('FormulaSerializer', () => {
 
     describe('ternary operations', () => {
       it('serializes ternary operator', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['flag', 'result'],
-          properties: {
-            flag: { type: JsonSchemaTypeName.Boolean, default: false },
-            result: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          flag: bool(),
+          result: num(),
+        });
 
         const tree = createTree(schema);
         const resultNode = tree.root().property('result');
@@ -261,16 +212,11 @@ describe('FormulaSerializer', () => {
 
     describe('function calls', () => {
       it('serializes function with arguments', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['a', 'b', 'result'],
-          properties: {
-            a: { type: JsonSchemaTypeName.Number, default: 0 },
-            b: { type: JsonSchemaTypeName.Number, default: 0 },
-            result: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          a: num(),
+          b: num(),
+          result: num(),
+        });
 
         const tree = createTree(schema);
         const resultNode = tree.root().property('result');
@@ -283,15 +229,10 @@ describe('FormulaSerializer', () => {
 
     describe('identifiers and paths', () => {
       it('serializes simple identifier', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['a', 'b'],
-          properties: {
-            a: { type: JsonSchemaTypeName.Number, default: 0 },
-            b: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          a: num(),
+          b: num(),
+        });
 
         const tree = createTree(schema);
         const bNode = tree.root().property('b');
@@ -302,22 +243,12 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes member expression', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['nested', 'result'],
-          properties: {
-            nested: {
-              type: JsonSchemaTypeName.Object,
-              additionalProperties: false,
-              required: ['value'],
-              properties: {
-                value: { type: JsonSchemaTypeName.Number, default: 0 },
-              },
-            },
-            result: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          nested: obj({
+            value: num(),
+          }),
+          result: num(),
+        });
 
         const tree = createTree(schema);
         const resultNode = tree.root().property('result');
@@ -330,18 +261,10 @@ describe('FormulaSerializer', () => {
 
     describe('array access', () => {
       it('serializes wildcard expression', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['items', 'result'],
-          properties: {
-            items: {
-              type: JsonSchemaTypeName.Array,
-              items: { type: JsonSchemaTypeName.Number, default: 0 },
-            },
-            result: { type: JsonSchemaTypeName.Number, default: 0 },
-          },
-        };
+        const schema = obj({
+          items: arr(num()),
+          result: num(),
+        });
 
         const tree = createTree(schema);
         const resultNode = tree.root().property('result');
@@ -352,26 +275,15 @@ describe('FormulaSerializer', () => {
       });
 
       it('serializes formula referencing sibling fields in array item object', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['items'],
-          properties: {
-            items: {
-              type: JsonSchemaTypeName.Array,
-              items: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: ['price', 'quantity', 'total'],
-                properties: {
-                  price: { type: JsonSchemaTypeName.Number, default: 0 },
-                  quantity: { type: JsonSchemaTypeName.Number, default: 0 },
-                  total: { type: JsonSchemaTypeName.Number, default: 0 },
-                },
-              },
-            },
-          },
-        };
+        const schema = obj({
+          items: arr(
+            obj({
+              price: num(),
+              quantity: num(),
+              total: num(),
+            }),
+          ),
+        });
 
         const tree = createTree(schema);
         const itemsNode = tree.root().property('items');

--- a/src/model/schema-formula/__tests__/ParsedFormula.spec.ts
+++ b/src/model/schema-formula/__tests__/ParsedFormula.spec.ts
@@ -1,9 +1,9 @@
 import type { JsonObjectSchema } from '../../../types/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
 import { createSchemaTree } from '../../../core/schema-tree/index.js';
 import { SchemaParser } from '../../schema-model/SchemaParser.js';
 import { ParsedFormula } from '../parsing/index.js';
 import { FormulaError } from '../core/index.js';
+import { obj, num, arr } from '../../../mocks/schema.mocks.js';
 
 const createTree = (schema: JsonObjectSchema) => {
   const parser = new SchemaParser();
@@ -14,16 +14,11 @@ const createTree = (schema: JsonObjectSchema) => {
 describe('ParsedFormula', () => {
   describe('simple dependencies', () => {
     it('resolves sibling field dependencies', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'quantity', 'total'],
-        properties: {
-          price: { type: JsonSchemaTypeName.Number, default: 0 },
-          quantity: { type: JsonSchemaTypeName.Number, default: 0 },
-          total: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        quantity: num(),
+        total: num(),
+      });
 
       const tree = createTree(schema);
       const totalNode = tree.root().property('total');
@@ -40,15 +35,10 @@ describe('ParsedFormula', () => {
     });
 
     it('resolves single dependency', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a', 'b'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-          b: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+        b: num(),
+      });
 
       const tree = createTree(schema);
       const bNode = tree.root().property('b');
@@ -61,14 +51,9 @@ describe('ParsedFormula', () => {
     });
 
     it('handles formula with no dependencies (literal)', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['value'],
-        properties: {
-          value: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        value: num(),
+      });
 
       const tree = createTree(schema);
       const valueNode = tree.root().property('value');
@@ -82,23 +67,13 @@ describe('ParsedFormula', () => {
 
   describe('nested object dependencies', () => {
     it('resolves nested field dependencies', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['item'],
-        properties: {
-          item: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['price', 'discount', 'total'],
-            properties: {
-              price: { type: JsonSchemaTypeName.Number, default: 0 },
-              discount: { type: JsonSchemaTypeName.Number, default: 0 },
-              total: { type: JsonSchemaTypeName.Number, default: 0 },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        item: obj({
+          price: num(),
+          discount: num(),
+          total: num(),
+        }),
+      });
 
       const tree = createTree(schema);
       const itemNode = tree.root().property('item');
@@ -116,26 +91,15 @@ describe('ParsedFormula', () => {
 
   describe('array item dependencies', () => {
     it('resolves dependencies within array items', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['items'],
-        properties: {
-          items: {
-            type: JsonSchemaTypeName.Array,
-            items: {
-              type: JsonSchemaTypeName.Object,
-              additionalProperties: false,
-              required: ['price', 'qty', 'subtotal'],
-              properties: {
-                price: { type: JsonSchemaTypeName.Number, default: 0 },
-                qty: { type: JsonSchemaTypeName.Number, default: 0 },
-                subtotal: { type: JsonSchemaTypeName.Number, default: 0 },
-              },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        items: arr(
+          obj({
+            price: num(),
+            qty: num(),
+            subtotal: num(),
+          }),
+        ),
+      });
 
       const tree = createTree(schema);
       const itemsNode = tree.root().property('items');
@@ -154,14 +118,9 @@ describe('ParsedFormula', () => {
 
   describe('error handling', () => {
     it('throws error for non-existent formula node', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+      });
 
       const tree = createTree(schema);
 
@@ -171,14 +130,9 @@ describe('ParsedFormula', () => {
     });
 
     it('throws error for unresolvable dependency', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+      });
 
       const tree = createTree(schema);
       const aNode = tree.root().property('a');
@@ -197,14 +151,9 @@ describe('ParsedFormula', () => {
     });
 
     it('throws error for self-reference', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['value'],
-        properties: {
-          value: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        value: num(),
+      });
 
       const tree = createTree(schema);
       const valueNode = tree.root().property('value');
@@ -223,16 +172,11 @@ describe('ParsedFormula', () => {
 
   describe('astPaths', () => {
     it('returns all dependency paths', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['a', 'b', 'c'],
-        properties: {
-          a: { type: JsonSchemaTypeName.Number, default: 0 },
-          b: { type: JsonSchemaTypeName.Number, default: 0 },
-          c: { type: JsonSchemaTypeName.Number, default: 0 },
-        },
-      };
+      const schema = obj({
+        a: num(),
+        b: num(),
+        c: num(),
+      });
 
       const tree = createTree(schema);
       const cNode = tree.root().property('c');

--- a/src/model/schema-model/__tests__/SchemaModel.dragDrop.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.dragDrop.spec.ts
@@ -7,25 +7,15 @@ import {
   findNodeIdByName,
   findNestedNodeId,
 } from './test-helpers.js';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
 
 describe('SchemaModel drag-drop operations', () => {
   describe('canMoveNode', () => {
     it('returns true for valid move to different object', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field', 'target'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        field: str(),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
       const targetId = findNodeIdByName(model, 'target');
@@ -73,26 +63,11 @@ describe('SchemaModel drag-drop operations', () => {
     });
 
     it('returns false when moving to descendant', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['outer'],
-        properties: {
-          outer: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['inner'],
-            properties: {
-              inner: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: [],
-                properties: {},
-              },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        outer: obj({
+          inner: obj({}),
+        }),
+      });
       const model = createSchemaModel(schema);
       const outerId = findNodeIdByName(model, 'outer');
       const innerId = findNestedNodeId(model, 'outer', 'inner');
@@ -117,27 +92,12 @@ describe('SchemaModel drag-drop operations', () => {
     });
 
     it('returns true when moving to different branch', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['branch1', 'branch2'],
-        properties: {
-          branch1: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['field'],
-            properties: {
-              field: { type: JsonSchemaTypeName.String, default: '' },
-            },
-          },
-          branch2: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        branch1: obj({
+          field: str(),
+        }),
+        branch2: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNestedNodeId(model, 'branch1', 'field');
       const branch2Id = findNodeIdByName(model, 'branch2');
@@ -147,31 +107,15 @@ describe('SchemaModel drag-drop operations', () => {
 
     describe('moving out of array items', () => {
       it('returns false when moving field from array items to object outside array', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['items', 'target'],
-          properties: {
-            items: {
-              type: JsonSchemaTypeName.Array,
-              items: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: ['name', 'value'],
-                properties: {
-                  name: { type: JsonSchemaTypeName.String, default: '' },
-                  value: { type: JsonSchemaTypeName.Number, default: 0 },
-                },
-              },
-            },
-            target: {
-              type: JsonSchemaTypeName.Object,
-              additionalProperties: false,
-              required: [],
-              properties: {},
-            },
-          },
-        };
+        const schema = obj({
+          items: arr(
+            obj({
+              name: str(),
+              value: num(),
+            }),
+          ),
+          target: obj({}),
+        });
         const model = createSchemaModel(schema);
         const itemsArray = findNodeIdByName(model, 'items');
         const itemsNode = model.nodeById(itemsArray!);
@@ -183,24 +127,13 @@ describe('SchemaModel drag-drop operations', () => {
       });
 
       it('returns false when moving field from array items to root', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['items'],
-          properties: {
-            items: {
-              type: JsonSchemaTypeName.Array,
-              items: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: ['field'],
-                properties: {
-                  field: { type: JsonSchemaTypeName.String, default: '' },
-                },
-              },
-            },
-          },
-        };
+        const schema = obj({
+          items: arr(
+            obj({
+              field: str(),
+            }),
+          ),
+        });
         const model = createSchemaModel(schema);
         const itemsArray = findNodeIdByName(model, 'items');
         const itemsNode = model.nodeById(itemsArray!);
@@ -212,31 +145,15 @@ describe('SchemaModel drag-drop operations', () => {
       });
 
       it('returns true when moving field within same array items', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['items'],
-          properties: {
-            items: {
-              type: JsonSchemaTypeName.Array,
-              items: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: ['nested'],
-                properties: {
-                  nested: {
-                    type: JsonSchemaTypeName.Object,
-                    additionalProperties: false,
-                    required: ['field'],
-                    properties: {
-                      field: { type: JsonSchemaTypeName.String, default: '' },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        };
+        const schema = obj({
+          items: arr(
+            obj({
+              nested: obj({
+                field: str(),
+              }),
+            }),
+          ),
+        });
         const model = createSchemaModel(schema);
         const itemsArray = findNodeIdByName(model, 'items');
         const itemsNode = model.nodeById(itemsArray!);
@@ -248,37 +165,16 @@ describe('SchemaModel drag-drop operations', () => {
       });
 
       it('returns false when moving field from nested array to outer object', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['outer', 'target'],
-          properties: {
-            outer: {
-              type: JsonSchemaTypeName.Object,
-              additionalProperties: false,
-              required: ['items'],
-              properties: {
-                items: {
-                  type: JsonSchemaTypeName.Array,
-                  items: {
-                    type: JsonSchemaTypeName.Object,
-                    additionalProperties: false,
-                    required: ['field'],
-                    properties: {
-                      field: { type: JsonSchemaTypeName.String, default: '' },
-                    },
-                  },
-                },
-              },
-            },
-            target: {
-              type: JsonSchemaTypeName.Object,
-              additionalProperties: false,
-              required: [],
-              properties: {},
-            },
-          },
-        };
+        const schema = obj({
+          outer: obj({
+            items: arr(
+              obj({
+                field: str(),
+              }),
+            ),
+          }),
+          target: obj({}),
+        });
         const model = createSchemaModel(schema);
         const outerNode = findNodeIdByName(model, 'outer');
         const itemsArray = model.nodeById(outerNode!).property('items');
@@ -290,33 +186,14 @@ describe('SchemaModel drag-drop operations', () => {
       });
 
       it('returns false when moving field between different arrays', () => {
-        const schema: JsonObjectSchema = {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['array1', 'array2'],
-          properties: {
-            array1: {
-              type: JsonSchemaTypeName.Array,
-              items: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: ['field1'],
-                properties: {
-                  field1: { type: JsonSchemaTypeName.String, default: '' },
-                },
-              },
-            },
-            array2: {
-              type: JsonSchemaTypeName.Array,
-              items: {
-                type: JsonSchemaTypeName.Object,
-                additionalProperties: false,
-                required: [],
-                properties: {},
-              },
-            },
-          },
-        };
+        const schema = obj({
+          array1: arr(
+            obj({
+              field1: str(),
+            }),
+          ),
+          array2: arr(obj({})),
+        });
         const model = createSchemaModel(schema);
         const array1Node = findNodeIdByName(model, 'array1');
         const array2Node = findNodeIdByName(model, 'array2');
@@ -331,20 +208,10 @@ describe('SchemaModel drag-drop operations', () => {
 
   describe('moveNode', () => {
     it('moves node to target object', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field', 'target'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        field: str(),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
       const targetId = findNodeIdByName(model, 'target');
@@ -367,20 +234,10 @@ describe('SchemaModel drag-drop operations', () => {
     });
 
     it('updates paths after move - canMoveNode returns false for current parent', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field', 'target'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        field: str(),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
       const targetId = findNodeIdByName(model, 'target');
@@ -393,20 +250,10 @@ describe('SchemaModel drag-drop operations', () => {
     });
 
     it('hasValidDropTarget updates correctly after move', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field', 'target'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        field: str(),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
       const targetId = findNodeIdByName(model, 'target');
@@ -434,20 +281,10 @@ describe('SchemaModel drag-drop operations', () => {
     });
 
     it('marks model as dirty after move', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field', 'target'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        field: str(),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
       const targetId = findNodeIdByName(model, 'target');
@@ -462,20 +299,10 @@ describe('SchemaModel drag-drop operations', () => {
 
   describe('hasValidDropTarget', () => {
     it('returns true when valid target exists', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field', 'target'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        field: str(),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
 
@@ -503,27 +330,12 @@ describe('SchemaModel drag-drop operations', () => {
     });
 
     it('returns true when nested object has sibling object', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['obj1', 'obj2'],
-        properties: {
-          obj1: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['field'],
-            properties: {
-              field: { type: JsonSchemaTypeName.String, default: '' },
-            },
-          },
-          obj2: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        obj1: obj({
+          field: str(),
+        }),
+        obj2: obj({}),
+      });
       const model = createSchemaModel(schema);
       const fieldId = findNestedNodeId(model, 'obj1', 'field');
 

--- a/src/model/schema-model/__tests__/SchemaModel.serializeFormula.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.serializeFormula.spec.ts
@@ -1,48 +1,21 @@
 import { describe, it, expect } from '@jest/globals';
 import { autorun } from 'mobx';
 import { createSchemaModel } from '../SchemaModelImpl.js';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+import { obj, num, str } from '../../../mocks/schema.mocks.js';
 import { findNodeIdByName, findNestedNodeId } from './test-helpers.js';
 
 describe('SchemaModel serializeFormula', () => {
-  const schemaWithFormulaInNested = (): JsonObjectSchema => ({
-    type: JsonSchemaTypeName.Object,
-    additionalProperties: false,
-    required: ['value', 'nested'],
-    properties: {
-      value: {
-        type: JsonSchemaTypeName.Number,
-        default: 0,
-      },
-      nested: {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['sum'],
-        properties: {
-          sum: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': {
-              version: 1,
-              expression: '../value + 2',
-            },
-          },
-        },
-      },
-    },
-  });
+  const schemaWithFormulaInNested = () =>
+    obj({
+      value: num(),
+      nested: obj({
+        sum: num({ readOnly: true, formula: '../value + 2' }),
+      }),
+    });
 
   describe('serializeFormula', () => {
     it('returns empty string for node without formula', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['field'],
-        properties: {
-          field: { type: JsonSchemaTypeName.String, default: '' },
-        },
-      };
+      const schema = obj({ field: str() });
       const model = createSchemaModel(schema);
       const fieldId = findNodeIdByName(model, 'field');
 
@@ -50,26 +23,10 @@ describe('SchemaModel serializeFormula', () => {
     });
 
     it('returns serialized formula for node with formula', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['price', 'total'],
-        properties: {
-          price: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-          },
-          total: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': {
-              version: 1,
-              expression: 'price * 2',
-            },
-          },
-        },
-      };
+      const schema = obj({
+        price: num(),
+        total: num({ readOnly: true, formula: 'price * 2' }),
+      });
       const model = createSchemaModel(schema);
       const totalId = findNodeIdByName(model, 'total');
 
@@ -77,32 +34,11 @@ describe('SchemaModel serializeFormula', () => {
     });
 
     it('updates relative path when node is moved', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['value', 'sum', 'target'],
-        properties: {
-          value: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-          },
-          sum: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': {
-              version: 1,
-              expression: 'value + 2',
-            },
-          },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        value: num(),
+        sum: num({ readOnly: true, formula: 'value + 2' }),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const sumId = findNodeIdByName(model, 'sum');
       const targetId = findNodeIdByName(model, 'target');
@@ -134,12 +70,7 @@ describe('SchemaModel serializeFormula', () => {
     });
 
     it('returns empty string for non-existent node', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: [],
-        properties: {},
-      };
+      const schema = obj({});
       const model = createSchemaModel(schema);
 
       expect(model.serializeFormula('non-existent')).toBe('');
@@ -148,32 +79,11 @@ describe('SchemaModel serializeFormula', () => {
 
   describe('serializeFormula reactivity', () => {
     it('autorun reacts to moveNode', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['value', 'sum', 'target'],
-        properties: {
-          value: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-          },
-          sum: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': {
-              version: 1,
-              expression: 'value + 2',
-            },
-          },
-          target: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: [],
-            properties: {},
-          },
-        },
-      };
+      const schema = obj({
+        value: num(),
+        sum: num({ readOnly: true, formula: 'value + 2' }),
+        target: obj({}),
+      });
       const model = createSchemaModel(schema);
       const sumId = findNodeIdByName(model, 'sum');
       const targetId = findNodeIdByName(model, 'target');

--- a/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../SchemaModelImpl.js';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+import { obj, num } from '../../../mocks/schema.mocks.js';
 import {
   emptySchema,
   simpleSchema,
@@ -109,20 +109,10 @@ describe('SchemaModel validation', () => {
     });
 
     it('captures formula parse error for invalid dependency at init time', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          value: { type: JsonSchemaTypeName.Number, default: 0 },
-          computed: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': { version: 1, expression: 'unknownField * 2' },
-          },
-        },
-        additionalProperties: false,
-        required: ['value', 'computed'],
-      };
+      const schema = obj({
+        value: num(),
+        computed: num({ readOnly: true, formula: 'unknownField * 2' }),
+      });
 
       const model = createSchemaModel(schema);
 
@@ -131,26 +121,11 @@ describe('SchemaModel validation', () => {
     });
 
     it('valid formulas still work when another formula has parse error', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          value: { type: JsonSchemaTypeName.Number, default: 10 },
-          validComputed: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': { version: 1, expression: 'value * 2' },
-          },
-          invalidComputed: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': { version: 1, expression: 'missingField + 1' },
-          },
-        },
-        additionalProperties: false,
-        required: ['value', 'validComputed', 'invalidComputed'],
-      };
+      const schema = obj({
+        value: num({ default: 10 }),
+        validComputed: num({ readOnly: true, formula: 'value * 2' }),
+        invalidComputed: num({ readOnly: true, formula: 'missingField + 1' }),
+      });
 
       const model = createSchemaModel(schema);
 
@@ -162,19 +137,9 @@ describe('SchemaModel validation', () => {
     });
 
     it('captures syntax error in formula expression', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          computed: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': { version: 1, expression: '+ + invalid syntax' },
-          },
-        },
-        additionalProperties: false,
-        required: ['computed'],
-      };
+      const schema = obj({
+        computed: num({ readOnly: true, formula: '+ + invalid syntax' }),
+      });
 
       const model = createSchemaModel(schema);
 
@@ -182,20 +147,10 @@ describe('SchemaModel validation', () => {
     });
 
     it('clears parse error when formula is updated', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          value: { type: JsonSchemaTypeName.Number, default: 0 },
-          computed: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-            readOnly: true,
-            'x-formula': { version: 1, expression: 'unknownField * 2' },
-          },
-        },
-        additionalProperties: false,
-        required: ['value', 'computed'],
-      };
+      const schema = obj({
+        value: num(),
+        computed: num({ readOnly: true, formula: 'unknownField * 2' }),
+      });
 
       const model = createSchemaModel(schema);
       expect(model.formulaErrors).toHaveLength(1);

--- a/src/model/schema-model/__tests__/SchemaModel.wrap.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.wrap.spec.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../SchemaModelImpl.js';
-import {
-  emptySchema,
-  simpleSchema,
-  arraySchema,
-  findNodeIdByName,
-} from './test-helpers.js';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/index.js';
+import { emptySchema, simpleSchema, arraySchema, findNodeIdByName } from './test-helpers.js';
+import { obj, str } from '../../../mocks/schema.mocks.js';
 
 describe('SchemaModel wrap operations', () => {
   describe('wrapInArray', () => {
@@ -26,24 +21,11 @@ describe('SchemaModel wrap operations', () => {
     });
 
     it('wraps object field in array', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['user'],
-        properties: {
-          user: {
-            type: JsonSchemaTypeName.Object,
-            additionalProperties: false,
-            required: ['name'],
-            properties: {
-              name: {
-                type: JsonSchemaTypeName.String,
-                default: '',
-              },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        user: obj({
+          name: str(),
+        }),
+      });
       const model = createSchemaModel(schema);
       const userId = findNodeIdByName(model, 'user');
 

--- a/src/model/schema-model/__tests__/SchemaParser.additional.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaParser.additional.spec.ts
@@ -2,24 +2,17 @@ import { describe, it, expect } from '@jest/globals';
 import { serializeAst } from '@revisium/formula';
 import { SchemaParser } from '../SchemaParser.js';
 import { createSchemaTree } from '../../../core/schema-tree/index.js';
-import type { JsonObjectSchema, JsonBooleanSchema } from '../../../types/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
+import type { JsonObjectSchema } from '../../../types/index.js';
+import { obj, str, num, bool, arr, ref } from '../../../mocks/schema.mocks.js';
 
 describe('SchemaParser additional coverage', () => {
   const parser = new SchemaParser();
 
   describe('$ref parsing', () => {
     it('parses schema with $ref', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['file'],
-        properties: {
-          file: {
-            $ref: 'File',
-          },
-        },
-      };
+      const schema = obj({
+        file: ref('File'),
+      });
 
       const node = parser.parse(schema);
 
@@ -29,19 +22,13 @@ describe('SchemaParser additional coverage', () => {
     });
 
     it('parses $ref with metadata', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['image'],
-        properties: {
-          image: {
-            $ref: 'Image',
-            title: 'Image File',
-            description: 'User avatar',
-            deprecated: true,
-          },
-        },
-      };
+      const schema = obj({
+        image: ref('Image', {
+          title: 'Image File',
+          description: 'User avatar',
+          deprecated: true,
+        }),
+      });
 
       const node = parser.parse(schema);
 
@@ -55,26 +42,10 @@ describe('SchemaParser additional coverage', () => {
 
   describe('boolean with formula', () => {
     it('parses boolean field with formula', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['count', 'isValid'],
-        properties: {
-          count: {
-            type: JsonSchemaTypeName.Number,
-            default: 0,
-          },
-          isValid: {
-            type: JsonSchemaTypeName.Boolean,
-            default: false,
-            readOnly: true,
-            'x-formula': {
-              version: 1,
-              expression: 'count > 0',
-            },
-          } as JsonBooleanSchema,
-        },
-      };
+      const schema = obj({
+        count: num(),
+        isValid: bool({ readOnly: true, formula: 'count > 0' }),
+      });
 
       const rootNode = parser.parse(schema);
       const tree = createSchemaTree(rootNode);
@@ -90,7 +61,7 @@ describe('SchemaParser additional coverage', () => {
   describe('unknown type error', () => {
     it('throws for unknown schema type', () => {
       const schema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         additionalProperties: false,
         required: ['field'],
         properties: {
@@ -107,27 +78,13 @@ describe('SchemaParser additional coverage', () => {
 
   describe('nested arrays', () => {
     it('parses nested array with object items', () => {
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['items'],
-        properties: {
-          items: {
-            type: JsonSchemaTypeName.Array,
-            items: {
-              type: JsonSchemaTypeName.Object,
-              additionalProperties: false,
-              required: ['name'],
-              properties: {
-                name: {
-                  type: JsonSchemaTypeName.String,
-                  default: '',
-                },
-              },
-            },
-          },
-        },
-      };
+      const schema = obj({
+        items: arr(
+          obj({
+            name: str(),
+          }),
+        ),
+      });
 
       const node = parser.parse(schema);
 

--- a/src/model/schema-model/__tests__/test-helpers.ts
+++ b/src/model/schema-model/__tests__/test-helpers.ts
@@ -1,121 +1,45 @@
 import type { JsonObjectSchema } from '../../../types/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
+import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
 import { createSchemaModel } from '../SchemaModelImpl.js';
 import type { SchemaModel } from '../types.js';
 
-export const emptySchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: [],
-  properties: {},
-});
+export const emptySchema = (): JsonObjectSchema => obj({});
 
-export const simpleSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'age'],
-  properties: {
-    name: {
-      type: JsonSchemaTypeName.String,
-      default: '',
-    },
-    age: {
-      type: JsonSchemaTypeName.Number,
-      default: 0,
-    },
-  },
-});
+export const simpleSchema = (): JsonObjectSchema =>
+  obj({
+    name: str(),
+    age: num(),
+  });
 
-export const nestedSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['user'],
-  properties: {
-    user: {
-      type: JsonSchemaTypeName.Object,
-      additionalProperties: false,
-      required: ['firstName', 'lastName'],
-      properties: {
-        firstName: {
-          type: JsonSchemaTypeName.String,
-          default: '',
-        },
-        lastName: {
-          type: JsonSchemaTypeName.String,
-          default: '',
-        },
-      },
-    },
-  },
-});
+export const nestedSchema = (): JsonObjectSchema =>
+  obj({
+    user: obj({
+      firstName: str(),
+      lastName: str(),
+    }),
+  });
 
-export const arraySchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['items'],
-  properties: {
-    items: {
-      type: JsonSchemaTypeName.Array,
-      items: {
-        type: JsonSchemaTypeName.String,
-        default: '',
-      },
-    },
-  },
-});
+export const arraySchema = (): JsonObjectSchema =>
+  obj({
+    items: arr(str()),
+  });
 
-export const schemaWithMetadata = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['field'],
-  properties: {
-    field: {
-      type: JsonSchemaTypeName.String,
-      default: '',
-      title: 'Field Title',
-      description: 'Field description',
-      deprecated: true,
-    },
-  },
-});
+export const schemaWithMetadata = (): JsonObjectSchema =>
+  obj({
+    field: str({ title: 'Field Title', description: 'Field description', deprecated: true }),
+  });
 
-export const schemaWithFormula = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['price', 'quantity', 'total'],
-  properties: {
-    price: {
-      type: JsonSchemaTypeName.Number,
-      default: 0,
-    },
-    quantity: {
-      type: JsonSchemaTypeName.Number,
-      default: 0,
-    },
-    total: {
-      type: JsonSchemaTypeName.Number,
-      default: 0,
-      readOnly: true,
-      'x-formula': {
-        version: 1,
-        expression: 'price * quantity',
-      },
-    },
-  },
-});
+export const schemaWithFormula = (): JsonObjectSchema =>
+  obj({
+    price: num(),
+    quantity: num(),
+    total: num({ readOnly: true, formula: 'price * quantity' }),
+  });
 
-export const schemaWithForeignKey = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['categoryId'],
-  properties: {
-    categoryId: {
-      type: JsonSchemaTypeName.String,
-      default: '',
-      foreignKey: 'categories',
-    },
-  },
-});
+export const schemaWithForeignKey = (): JsonObjectSchema =>
+  obj({
+    categoryId: str({ foreignKey: 'categories' }),
+  });
 
 export const createModel = (schema: JsonObjectSchema): SchemaModel => {
   return createSchemaModel(schema);

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -1,33 +1,20 @@
 import { describe, it, expect } from '@jest/globals';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { obj, str, num } from '../../../mocks/schema.mocks.js';
 import { createTableModel } from '../TableModelImpl.js';
 
-const createSimpleSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'age'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    age: { type: JsonSchemaTypeName.Number, default: 0 },
-  },
-});
+const createSimpleSchema = () =>
+  obj({
+    name: str(),
+    age: num(),
+  });
 
-const createNestedSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'address'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    address: {
-      type: JsonSchemaTypeName.Object,
-      additionalProperties: false,
-      required: ['city'],
-      properties: {
-        city: { type: JsonSchemaTypeName.String, default: '' },
-      },
-    },
-  },
-});
+const createNestedSchema = () =>
+  obj({
+    name: str(),
+    address: obj({
+      city: str(),
+    }),
+  });
 
 describe('TableModel', () => {
   describe('construction', () => {
@@ -168,15 +155,10 @@ describe('TableModel', () => {
     it('addRow without data uses schema defaults', () => {
       const table = createTableModel({
         tableId: 'users',
-        schema: {
-          type: JsonSchemaTypeName.Object,
-          additionalProperties: false,
-          required: ['name', 'status'],
-          properties: {
-            name: { type: JsonSchemaTypeName.String, default: 'Unknown' },
-            status: { type: JsonSchemaTypeName.String, default: 'active' },
-          },
-        },
+        schema: obj({
+          name: str({ default: 'Unknown' }),
+          status: str({ default: 'active' }),
+        }),
       });
 
       const row = table.addRow('user-1');

--- a/src/model/value-node/__tests__/ArrayValueNode.spec.ts
+++ b/src/model/value-node/__tests__/ArrayValueNode.spec.ts
@@ -1,22 +1,17 @@
 import type { JsonArraySchema, JsonSchema } from '../../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
 import {
   ArrayValueNode,
   StringValueNode,
   createNodeFactory,
   resetNodeIdCounter,
 } from '../index.js';
+import { str, arr } from '../../../mocks/schema.mocks.js';
 
 beforeEach(() => {
   resetNodeIdCounter();
 });
 
-const createSchema = (
-  items: JsonSchema = { type: JsonSchemaTypeName.String, default: '' },
-): JsonArraySchema => ({
-  type: JsonSchemaTypeName.Array,
-  items,
-});
+const createSchema = (items: JsonSchema = str()): JsonArraySchema => arr(items);
 
 describe('ArrayValueNode', () => {
   describe('construction', () => {
@@ -32,13 +27,13 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
 
@@ -56,7 +51,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -85,7 +80,7 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -102,13 +97,13 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
 
@@ -126,7 +121,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -141,13 +136,13 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
 
@@ -172,7 +167,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -189,7 +184,7 @@ describe('ArrayValueNode', () => {
       const existing = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -199,7 +194,7 @@ describe('ArrayValueNode', () => {
       const newItem = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       node.insertAt(0, newItem);
@@ -214,13 +209,13 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item3 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'c',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -231,7 +226,7 @@ describe('ArrayValueNode', () => {
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
       node.insertAt(1, item2);
@@ -245,7 +240,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -258,7 +253,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -271,7 +266,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -302,19 +297,19 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
       const item3 = new StringValueNode(
         undefined,
         '2',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'c',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -332,19 +327,19 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
       const item3 = new StringValueNode(
         undefined,
         '2',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'c',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -362,7 +357,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -384,7 +379,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -400,7 +395,7 @@ describe('ArrayValueNode', () => {
       const oldItem = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -410,7 +405,7 @@ describe('ArrayValueNode', () => {
       const newItem = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
       node.replaceAt(0, newItem);
@@ -426,7 +421,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
 
@@ -439,13 +434,13 @@ describe('ArrayValueNode', () => {
       const item1 = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const item2 = new StringValueNode(
         undefined,
         '1',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'b',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -475,10 +470,7 @@ describe('ArrayValueNode', () => {
 
     it('pushValue uses default value', () => {
       const factory = createNodeFactory();
-      const schema = createSchema({
-        type: JsonSchemaTypeName.String,
-        default: 'default',
-      });
+      const schema = createSchema(str({ default: 'default' }));
       const node = factory.createTree(schema, []) as ArrayValueNode;
 
       node.pushValue();
@@ -508,7 +500,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -522,7 +514,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -541,7 +533,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       node.push(item);
@@ -553,7 +545,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -570,7 +562,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -588,7 +580,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -607,7 +599,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -629,7 +621,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '', required: true },
+        str({ required: true }),
         '',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [
@@ -644,7 +636,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'a',
       );
       item.setFormulaWarning({
@@ -664,7 +656,7 @@ describe('ArrayValueNode', () => {
       const item = new StringValueNode(
         undefined,
         '0',
-        { type: JsonSchemaTypeName.String, default: '', required: true },
+        str({ required: true }),
         '',
       );
       const node = new ArrayValueNode(undefined, 'items', createSchema(), [

--- a/src/model/value-node/__tests__/BaseValueNode.spec.ts
+++ b/src/model/value-node/__tests__/BaseValueNode.spec.ts
@@ -1,5 +1,5 @@
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
 import { StringValueNode, resetNodeIdCounter } from '../index.js';
+import { str } from '../../../mocks/schema.mocks.js';
 
 beforeEach(() => {
   resetNodeIdCounter();
@@ -8,29 +8,14 @@ beforeEach(() => {
 describe('BaseValueNode', () => {
   describe('parent', () => {
     it('parent is null by default', () => {
-      const node = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'John',
-      );
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
 
       expect(node.parent).toBeNull();
     });
 
     it('parent can be set and read', () => {
-      const parent = new StringValueNode(
-        undefined,
-        'parent',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'Parent',
-      );
-      const child = new StringValueNode(
-        undefined,
-        'child',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'Child',
-      );
+      const parent = new StringValueNode(undefined, 'parent', str(), 'Parent');
+      const child = new StringValueNode(undefined, 'child', str(), 'Child');
 
       child.parent = parent;
 
@@ -40,45 +25,25 @@ describe('BaseValueNode', () => {
 
   describe('errors and warnings defaults', () => {
     it('errors is empty by default', () => {
-      const node = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'John',
-      );
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
 
       expect(node.errors).toHaveLength(0);
     });
 
     it('warnings is empty by default', () => {
-      const node = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'John',
-      );
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
 
       expect(node.warnings).toHaveLength(0);
     });
 
     it('isValid is true by default', () => {
-      const node = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'John',
-      );
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
 
       expect(node.isValid).toBe(true);
     });
 
     it('hasWarnings is false by default', () => {
-      const node = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'John',
-      );
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
 
       expect(node.hasWarnings).toBe(false);
     });
@@ -86,10 +51,7 @@ describe('BaseValueNode', () => {
 
   describe('schema', () => {
     it('returns schema passed to constructor', () => {
-      const schema = {
-        type: JsonSchemaTypeName.String as const,
-        default: 'test',
-      };
+      const schema = str({ default: 'test' });
       const node = new StringValueNode(undefined, 'name', schema);
 
       expect(node.schema).toBe(schema);

--- a/src/model/value-node/__tests__/BooleanValueNode.spec.ts
+++ b/src/model/value-node/__tests__/BooleanValueNode.spec.ts
@@ -1,18 +1,13 @@
 import type { JsonBooleanSchema } from '../../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
 import { BooleanValueNode, resetNodeIdCounter } from '../index.js';
+import { bool } from '../../../mocks/schema.mocks.js';
 
 beforeEach(() => {
   resetNodeIdCounter();
 });
 
-const createSchema = (
-  overrides: Partial<JsonBooleanSchema> = {},
-): JsonBooleanSchema => ({
-  type: JsonSchemaTypeName.Boolean,
-  default: false,
-  ...overrides,
-});
+const createSchema = (overrides: Partial<JsonBooleanSchema> = {}): JsonBooleanSchema =>
+  bool(overrides) as JsonBooleanSchema;
 
 describe('BooleanValueNode', () => {
   describe('construction', () => {

--- a/src/model/value-node/__tests__/ForeignKeyValueNode.spec.ts
+++ b/src/model/value-node/__tests__/ForeignKeyValueNode.spec.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import {
-  JsonSchemaTypeName,
-  type JsonObjectSchema,
-  type JsonStringSchema,
-} from '../../../types/schema.types.js';
+import type { JsonStringSchema } from '../../../types/schema.types.js';
 import { createForeignKeyResolver } from '../../foreign-key-resolver/ForeignKeyResolverImpl.js';
 import {
   ForeignKeyNotFoundError,
@@ -16,21 +12,14 @@ import {
   type ForeignKeyValueNode,
 } from '../ForeignKeyValueNode.js';
 import { StringValueNode } from '../StringValueNode.js';
+import { str, obj } from '../../../mocks/schema.mocks.js';
 
-const createFKSchema = (foreignKey: string): JsonStringSchema => ({
-  type: JsonSchemaTypeName.String,
-  default: '',
-  foreignKey,
-});
+const createFKSchema = (foreignKey: string): JsonStringSchema => str({ foreignKey });
 
-const createCategorySchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-  },
-});
+const createCategorySchema = () =>
+  obj({
+    name: str(),
+  });
 
 describe('ForeignKeyValueNode', () => {
   describe('constructor', () => {
@@ -42,7 +31,7 @@ describe('ForeignKeyValueNode', () => {
     });
 
     it('throws if schema has no foreignKey property', () => {
-      const schema: JsonStringSchema = { type: JsonSchemaTypeName.String, default: '' };
+      const schema = str();
 
       expect(() => new ForeignKeyValueNodeImpl(undefined, 'field', schema, 'value')).toThrow(
         'ForeignKeyValueNode requires a schema with foreignKey property',
@@ -74,7 +63,7 @@ describe('ForeignKeyValueNode', () => {
     });
 
     it('returns false for StringValueNode without foreignKey', () => {
-      const schema: JsonStringSchema = { type: JsonSchemaTypeName.String, default: '' };
+      const schema = str();
       const node = new StringValueNode(undefined, 'name', schema, 'value');
 
       expect(isForeignKeyValueNode(node)).toBe(false);

--- a/src/model/value-node/__tests__/NumberValueNode.spec.ts
+++ b/src/model/value-node/__tests__/NumberValueNode.spec.ts
@@ -1,18 +1,13 @@
 import type { JsonNumberSchema } from '../../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
 import { NumberValueNode, resetNodeIdCounter } from '../index.js';
+import { num } from '../../../mocks/schema.mocks.js';
 
 beforeEach(() => {
   resetNodeIdCounter();
 });
 
-const createSchema = (
-  overrides: Partial<JsonNumberSchema> = {},
-): JsonNumberSchema => ({
-  type: JsonSchemaTypeName.Number,
-  default: 0,
-  ...overrides,
-});
+const createSchema = (overrides: Partial<JsonNumberSchema> = {}): JsonNumberSchema =>
+  num(overrides) as JsonNumberSchema;
 
 describe('NumberValueNode', () => {
   describe('construction', () => {

--- a/src/model/value-node/__tests__/ObjectValueNode.spec.ts
+++ b/src/model/value-node/__tests__/ObjectValueNode.spec.ts
@@ -1,24 +1,18 @@
 import type { JsonObjectSchema } from '../../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
 import {
   ObjectValueNode,
   StringValueNode,
   NumberValueNode,
   resetNodeIdCounter,
 } from '../index.js';
+import { obj, str, num } from '../../../mocks/schema.mocks.js';
 
 beforeEach(() => {
   resetNodeIdCounter();
 });
 
-const createSchema = (
-  properties: JsonObjectSchema['properties'] = {},
-): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  properties,
-  additionalProperties: false,
-  required: Object.keys(properties),
-});
+const createSchema = (properties: JsonObjectSchema['properties'] = {}): JsonObjectSchema =>
+  obj(properties);
 
 describe('ObjectValueNode', () => {
   describe('construction', () => {
@@ -34,13 +28,13 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const ageNode = new NumberValueNode(
         undefined,
         'age',
-        { type: JsonSchemaTypeName.Number, default: 0 },
+        num(),
         25,
       );
 
@@ -58,7 +52,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
 
@@ -87,7 +81,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
 
@@ -104,13 +98,13 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const ageNode = new NumberValueNode(
         undefined,
         'age',
-        { type: JsonSchemaTypeName.Number, default: 0 },
+        num(),
         25,
       );
 
@@ -128,7 +122,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
 
@@ -151,7 +145,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
 
@@ -175,7 +169,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
 
@@ -189,7 +183,7 @@ describe('ObjectValueNode', () => {
       const oldNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -199,7 +193,7 @@ describe('ObjectValueNode', () => {
       const newNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'Jane',
       );
       node.addChild(newNode);
@@ -215,7 +209,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -242,7 +236,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -256,7 +250,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -275,7 +269,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       node.addChild(nameNode);
@@ -287,7 +281,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -304,7 +298,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -322,7 +316,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -341,7 +335,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -362,7 +356,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '', required: true },
+        str({ required: true }),
         '',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -377,7 +371,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       nameNode.setFormulaWarning({
@@ -398,7 +392,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '', required: true },
+        str({ required: true }),
         '',
       );
       const node = new ObjectValueNode(undefined, 'user', createSchema(), [
@@ -412,7 +406,7 @@ describe('ObjectValueNode', () => {
       const nameNode = new StringValueNode(
         undefined,
         'name',
-        { type: JsonSchemaTypeName.String, default: '' },
+        str(),
         'John',
       );
       nameNode.setFormulaWarning({

--- a/src/model/value-node/__tests__/Reactivity.spec.ts
+++ b/src/model/value-node/__tests__/Reactivity.spec.ts
@@ -1,5 +1,4 @@
-import type { JsonArraySchema, JsonObjectSchema } from '../../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
+import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
 import { StringValueNode, resetNodeIdCounter } from '../index.js';
 import { NumberValueNode } from '../NumberValueNode.js';
 import { ObjectValueNode } from '../ObjectValueNode.js';
@@ -13,12 +12,7 @@ beforeEach(() => {
 describe('Value nodes with reactivity', () => {
   describe('StringValueNode', () => {
     it('initializes and works correctly', () => {
-      const node = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'value',
-      );
+      const node = new StringValueNode(undefined, 'name', str(), 'value');
 
       expect(node.value).toBe('value');
     });
@@ -26,12 +20,7 @@ describe('Value nodes with reactivity', () => {
 
   describe('NumberValueNode', () => {
     it('initializes and works correctly', () => {
-      const node = new NumberValueNode(
-        undefined,
-        'count',
-        { type: JsonSchemaTypeName.Number, default: 0 },
-        42,
-      );
+      const node = new NumberValueNode(undefined, 'count', num(), 42);
 
       expect(node.value).toBe(42);
     });
@@ -39,47 +28,17 @@ describe('Value nodes with reactivity', () => {
 
   describe('ObjectValueNode', () => {
     it('manages children correctly', () => {
-      const child = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'test',
-      );
+      const child = new StringValueNode(undefined, 'name', str(), 'test');
 
-      const node = new ObjectValueNode(
-        undefined,
-        'root',
-        {
-          type: JsonSchemaTypeName.Object,
-          properties: {},
-          additionalProperties: false,
-          required: [],
-        },
-        [child],
-      );
+      const node = new ObjectValueNode(undefined, 'root', obj({}), [child]);
 
       expect(node.children).toHaveLength(1);
       expect(node.child('name')).toBe(child);
     });
 
     it('revert restores children', () => {
-      const child = new StringValueNode(
-        undefined,
-        'name',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'test',
-      );
-      const node = new ObjectValueNode(
-        undefined,
-        'root',
-        {
-          type: JsonSchemaTypeName.Object,
-          properties: {},
-          additionalProperties: false,
-          required: [],
-        },
-        [child],
-      );
+      const child = new StringValueNode(undefined, 'name', str(), 'test');
+      const node = new ObjectValueNode(undefined, 'root', obj({}), [child]);
       node.commit();
 
       node.removeChild('name');
@@ -91,17 +50,9 @@ describe('Value nodes with reactivity', () => {
 
   describe('ArrayValueNode', () => {
     it('manages items correctly', () => {
-      const item = new StringValueNode(
-        undefined,
-        '0',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'a',
-      );
+      const item = new StringValueNode(undefined, '0', str(), 'a');
 
-      const schema: JsonArraySchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
-      };
+      const schema = arr(str());
       const node = new ArrayValueNode(undefined, 'items', schema, [item]);
 
       expect(node.length).toBe(1);
@@ -109,16 +60,8 @@ describe('Value nodes with reactivity', () => {
     });
 
     it('revert restores items', () => {
-      const item = new StringValueNode(
-        undefined,
-        '0',
-        { type: JsonSchemaTypeName.String, default: '' },
-        'a',
-      );
-      const schema: JsonArraySchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
-      };
+      const item = new StringValueNode(undefined, '0', str(), 'a');
+      const schema = arr(str());
       const node = new ArrayValueNode(undefined, 'items', schema, [item]);
       node.commit();
 
@@ -134,18 +77,10 @@ describe('Value nodes with reactivity', () => {
     it('creates nodes correctly', () => {
       const factory = createNodeFactory();
 
-      const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-          tags: {
-            type: JsonSchemaTypeName.Array,
-            items: { type: JsonSchemaTypeName.String, default: '' },
-          },
-        },
-        additionalProperties: false,
-        required: ['name', 'tags'],
-      };
+      const schema = obj({
+        name: str(),
+        tags: arr(str()),
+      });
 
       const node = factory.create('root', schema, { name: 'test', tags: ['a', 'b'] });
 
@@ -163,20 +98,11 @@ describe('Value nodes with reactivity', () => {
     it('propagates factory to nested arrays', () => {
       const factory = createNodeFactory();
 
-      const schema: JsonArraySchema = {
-        type: JsonSchemaTypeName.Array,
-        items: {
-          type: JsonSchemaTypeName.Object,
-          properties: {
-            values: {
-              type: JsonSchemaTypeName.Array,
-              items: { type: JsonSchemaTypeName.Number, default: 0 },
-            },
-          },
-          additionalProperties: false,
-          required: ['values'],
-        },
-      };
+      const schema = arr(
+        obj({
+          values: arr(num()),
+        }),
+      );
 
       const node = factory.create('root', schema, [{ values: [1, 2] }]);
 

--- a/src/model/value-node/__tests__/StringValueNode.spec.ts
+++ b/src/model/value-node/__tests__/StringValueNode.spec.ts
@@ -1,18 +1,13 @@
 import type { JsonStringSchema } from '../../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../../types/schema.types.js';
 import { StringValueNode, resetNodeIdCounter } from '../index.js';
+import { str } from '../../../mocks/schema.mocks.js';
 
 beforeEach(() => {
   resetNodeIdCounter();
 });
 
-const createSchema = (
-  overrides: Partial<JsonStringSchema> = {},
-): JsonStringSchema => ({
-  type: JsonSchemaTypeName.String,
-  default: '',
-  ...overrides,
-});
+const createSchema = (overrides: Partial<JsonStringSchema> = {}): JsonStringSchema =>
+  str(overrides) as JsonStringSchema;
 
 describe('StringValueNode', () => {
   describe('construction', () => {

--- a/src/model/value-tree/__tests__/ValueTree.spec.ts
+++ b/src/model/value-tree/__tests__/ValueTree.spec.ts
@@ -1,53 +1,30 @@
 import { describe, it, expect } from '@jest/globals';
-import { JsonSchemaTypeName, type JsonObjectSchema } from '../../../types/schema.types.js';
+import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
 import { createNodeFactory } from '../../value-node/NodeFactory.js';
 import { ValueTree } from '../ValueTree.js';
 
-const createSimpleSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'age'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    age: { type: JsonSchemaTypeName.Number, default: 0 },
-  },
-});
+const createSimpleSchema = () =>
+  obj({
+    name: str(),
+    age: num(),
+  });
 
-const createNestedSchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['name', 'address'],
-  properties: {
-    name: { type: JsonSchemaTypeName.String, default: '' },
-    address: {
-      type: JsonSchemaTypeName.Object,
-      additionalProperties: false,
-      required: ['city'],
-      properties: {
-        city: { type: JsonSchemaTypeName.String, default: '' },
-      },
-    },
-  },
-});
+const createNestedSchema = () =>
+  obj({
+    name: str(),
+    address: obj({
+      city: str(),
+    }),
+  });
 
-const createArraySchema = (): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: ['items'],
-  properties: {
-    items: {
-      type: JsonSchemaTypeName.Array,
-      items: {
-        type: JsonSchemaTypeName.Object,
-        additionalProperties: false,
-        required: ['name'],
-        properties: {
-          name: { type: JsonSchemaTypeName.String, default: '' },
-        },
-      },
-    },
-  },
-});
+const createArraySchema = () =>
+  obj({
+    items: arr(
+      obj({
+        name: str(),
+      }),
+    ),
+  });
 
 function createTree(schema: unknown, data: unknown): ValueTree {
   const factory = createNodeFactory();
@@ -277,5 +254,4 @@ describe('ValueTree', () => {
       expect(tree.getPatches()).toEqual([]);
     });
   });
-
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored tests to use concise schema helpers instead of ad‑hoc JSON schema objects. Tests are shorter and easier to read, with no runtime behavior changes.

- **Refactors**
  - Added obj, str, num, bool, arr, ref helpers in schema.mocks (supports optional formula -> x-formula).
  - Replaced inline schema setup across serializer, validator, model, formula, and value-node tests.
  - Simplified type imports and removed repetitive boilerplate.

<sup>Written for commit 2586c1fba0a48c67f961a61af5d605f658b0172f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

