### PR TITLE
chore: refactor reactivity

### DIFF
--- a/src/core/reactivity/mobx-provider.ts
+++ b/src/core/reactivity/mobx-provider.ts
@@ -69,7 +69,7 @@ export function createMobxProvider(mobx: MobXModule): ReactivityProvider {
     makeAutoObservable: <T extends object>(
       target: T,
       overrides?: Record<string, unknown>,
-    ) => mobx.makeAutoObservable(target, overrides),
+    ) => mobx.makeAutoObservable(target, overrides ? convertAnnotations(mobx, overrides) : {}),
     isObservable: mobx.isObservable,
     observable: {
       map: <K, V>() => mobx.observable.map<K, V>(),

--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -14,12 +14,9 @@ export class ArrayNode extends BaseNode {
   ) {
     super(id, name, metadata);
     this._items = items;
+    this.initBaseObservable();
     makeObservable(this, {
-      _name: 'observable',
-      _metadata: 'observable.ref',
       _items: 'observable.ref',
-      setName: 'action',
-      setMetadata: 'action',
       setItems: 'action',
     });
   }

--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -1,6 +1,7 @@
 import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
 import { EMPTY_METADATA } from './types.js';
 import { NULL_NODE } from './NullNode.js';
+import { makeObservable } from '../reactivity/index.js';
 
 export abstract class BaseNode implements SchemaNode {
   protected _name: string;
@@ -13,6 +14,15 @@ export abstract class BaseNode implements SchemaNode {
   ) {
     this._name = name;
     this._metadata = metadata;
+  }
+
+  protected initBaseObservable(): void {
+    makeObservable(this, {
+      _name: 'observable',
+      _metadata: 'observable.ref',
+      setName: 'action',
+      setMetadata: 'action',
+    });
   }
 
   id(): string {

--- a/src/core/schema-node/BooleanNode.ts
+++ b/src/core/schema-node/BooleanNode.ts
@@ -1,6 +1,5 @@
 import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
 import { PrimitiveNode } from './PrimitiveNode.js';
-import { makeObservable } from '../reactivity/index.js';
 
 export interface BooleanNodeOptions {
   readonly defaultValue?: boolean;
@@ -15,18 +14,7 @@ export class BooleanNode extends PrimitiveNode {
     options: BooleanNodeOptions = {},
   ) {
     super(id, name, options);
-    makeObservable(this, {
-      _name: 'observable',
-      _metadata: 'observable.ref',
-      _formula: 'observable.ref',
-      _defaultValue: 'observable',
-      _foreignKey: 'observable',
-      setName: 'action',
-      setMetadata: 'action',
-      setFormula: 'action',
-      setDefaultValue: 'action',
-      setForeignKey: 'action',
-    });
+    this.initPrimitiveObservable();
   }
 
   nodeType(): NodeType {

--- a/src/core/schema-node/NumberNode.ts
+++ b/src/core/schema-node/NumberNode.ts
@@ -1,6 +1,5 @@
 import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
 import { PrimitiveNode } from './PrimitiveNode.js';
-import { makeObservable } from '../reactivity/index.js';
 
 export interface NumberNodeOptions {
   readonly defaultValue?: number;
@@ -15,18 +14,7 @@ export class NumberNode extends PrimitiveNode {
     options: NumberNodeOptions = {},
   ) {
     super(id, name, options);
-    makeObservable(this, {
-      _name: 'observable',
-      _metadata: 'observable.ref',
-      _formula: 'observable.ref',
-      _defaultValue: 'observable',
-      _foreignKey: 'observable',
-      setName: 'action',
-      setMetadata: 'action',
-      setFormula: 'action',
-      setDefaultValue: 'action',
-      setForeignKey: 'action',
-    });
+    this.initPrimitiveObservable();
   }
 
   nodeType(): NodeType {

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -15,12 +15,9 @@ export class ObjectNode extends BaseNode {
   ) {
     super(id, name, metadata);
     this._children = [...children];
+    this.initBaseObservable();
     makeObservable(this, {
-      _name: 'observable',
-      _metadata: 'observable.ref',
       _children: 'observable.shallow',
-      setName: 'action',
-      setMetadata: 'action',
       addChild: 'action',
       removeChild: 'action',
       replaceChild: 'action',

--- a/src/core/schema-node/PrimitiveNode.ts
+++ b/src/core/schema-node/PrimitiveNode.ts
@@ -1,6 +1,7 @@
 import type { SchemaNode, NodeType, NodeMetadata, Formula } from './types.js';
 import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
+import { makeObservable } from '../reactivity/index.js';
 
 export interface PrimitiveNodeOptions {
   readonly defaultValue?: unknown;
@@ -23,6 +24,21 @@ export abstract class PrimitiveNode extends BaseNode {
     this._defaultValue = options.defaultValue;
     this._foreignKey = options.foreignKey;
     this._formula = options.formula;
+  }
+
+  protected initPrimitiveObservable(): void {
+    makeObservable(this, {
+      _name: 'observable',
+      _metadata: 'observable.ref',
+      _formula: 'observable.ref',
+      _defaultValue: 'observable',
+      _foreignKey: 'observable',
+      setName: 'action',
+      setMetadata: 'action',
+      setFormula: 'action',
+      setDefaultValue: 'action',
+      setForeignKey: 'action',
+    });
   }
 
   abstract nodeType(): NodeType;

--- a/src/core/schema-node/RefNode.ts
+++ b/src/core/schema-node/RefNode.ts
@@ -1,7 +1,6 @@
 import type { SchemaNode, NodeType, NodeMetadata } from './types.js';
 import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
-import { makeObservable } from '../reactivity/index.js';
 
 export class RefNode extends BaseNode {
   private readonly _ref: string;
@@ -17,12 +16,7 @@ export class RefNode extends BaseNode {
       throw new Error('RefNode requires a non-empty ref');
     }
     this._ref = ref;
-    makeObservable(this, {
-      _name: 'observable',
-      _metadata: 'observable.ref',
-      setName: 'action',
-      setMetadata: 'action',
-    });
+    this.initBaseObservable();
   }
 
   nodeType(): NodeType {

--- a/src/core/schema-node/StringNode.ts
+++ b/src/core/schema-node/StringNode.ts
@@ -21,18 +21,9 @@ export class StringNode extends PrimitiveNode {
   ) {
     super(id, name, options);
     this._contentMediaType = options.contentMediaType;
+    this.initPrimitiveObservable();
     makeObservable(this, {
-      _name: 'observable',
-      _metadata: 'observable.ref',
-      _formula: 'observable.ref',
-      _defaultValue: 'observable',
-      _foreignKey: 'observable',
       _contentMediaType: 'observable',
-      setName: 'action',
-      setMetadata: 'action',
-      setFormula: 'action',
-      setDefaultValue: 'action',
-      setForeignKey: 'action',
       setContentMediaType: 'action',
     });
   }

--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -3,7 +3,7 @@ import { NULL_NODE } from '../schema-node/index.js';
 import type { Path } from '../path/index.js';
 import type { SchemaTree } from './types.js';
 import { TreeNodeIndex } from './TreeNodeIndex.js';
-import { makeObservable } from '../reactivity/index.js';
+import { makeAutoObservable } from '../reactivity/index.js';
 
 export class SchemaTreeImpl implements SchemaTree {
   private readonly index = new TreeNodeIndex();
@@ -14,14 +14,10 @@ export class SchemaTreeImpl implements SchemaTree {
     this._rootNode = rootNode;
     this.index.rebuild(rootNode);
 
-    makeObservable(this, {
+    makeAutoObservable(this, {
+      index: false,
+      _replacements: false,
       _rootNode: 'observable.ref',
-      addChildTo: 'action',
-      removeNodeAt: 'action',
-      renameNode: 'action',
-      moveNode: 'action',
-      setNodeAt: 'action',
-      replaceRoot: 'action',
     });
   }
 

--- a/src/core/schema-tree/TreeNodeIndex.ts
+++ b/src/core/schema-tree/TreeNodeIndex.ts
@@ -2,16 +2,16 @@ import type { SchemaNode } from '../schema-node/index.js';
 import { NULL_NODE } from '../schema-node/index.js';
 import type { Path } from '../path/index.js';
 import { EMPTY_PATH } from '../path/index.js';
-import { observable, makeObservable } from '../reactivity/index.js';
+import { observable, makeAutoObservable } from '../reactivity/index.js';
 
 export class TreeNodeIndex {
   private readonly nodeIndex: Map<string, SchemaNode> = observable.map();
   private readonly pathIndex: Map<string, Path> = observable.map();
 
   constructor() {
-    makeObservable(this, {
-      rebuild: 'action',
-      nodeCount: 'computed',
+    makeAutoObservable(this, {
+      nodeIndex: false,
+      pathIndex: false,
     });
   }
 

--- a/src/model/data-model/DataModelImpl.ts
+++ b/src/model/data-model/DataModelImpl.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable } from '../../core/reactivity/index.js';
+import { makeAutoObservable, observable } from '../../core/reactivity/index.js';
 import type { JsonObjectSchema } from '../../types/schema.types.js';
 import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
 import { createForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolverImpl.js';
@@ -23,16 +23,10 @@ export class DataModelImpl implements DataModel {
       this._ownsFkResolver = true;
     }
 
-    makeObservable(this, {
-      _tables: 'observable',
-      tables: 'computed',
-      tableIds: 'computed',
-      isDirty: 'computed',
-      addTable: 'action',
-      removeTable: 'action',
-      renameTable: 'action',
-      commit: 'action',
-      revert: 'action',
+    makeAutoObservable(this, {
+      _tables: false,
+      _fk: false,
+      _ownsFkResolver: false,
     });
   }
 

--- a/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
+++ b/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable, runInAction } from '../../core/reactivity/index.js';
+import { makeAutoObservable, observable, runInAction } from '../../core/reactivity/index.js';
 import {
   JsonSchemaTypeName,
   type JsonObjectSchema,
@@ -39,15 +39,15 @@ export class ForeignKeyResolverImpl implements ForeignKeyResolver {
     this._pendingTableLoads = new Map();
     this._pendingRowLoads = new Map();
 
-    makeObservable(this, {
-      _schemaCache: 'observable',
-      _tableCache: 'observable',
-      _prefetchEnabled: 'observable',
-      isPrefetchEnabled: 'computed',
-      addSchema: 'action',
-      addTable: 'action',
-      addRow: 'action',
-      setPrefetch: 'action',
+    makeAutoObservable(this, {
+      _schemaCache: false,
+      _tableCache: false,
+      _loadingTables: false,
+      _loadingRows: false,
+      _pendingTableLoads: false,
+      _pendingRowLoads: false,
+      _disposed: false,
+      loader: false,
     });
   }
 

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -5,7 +5,7 @@ import type { Path, PathSegment } from '../../core/path/index.js';
 import { PatchBuilder, type SchemaPatch, type JsonPatch } from '../../core/schema-patch/index.js';
 import { SchemaSerializer } from '../../core/schema-serializer/index.js';
 import type { JsonObjectSchema } from '../../types/index.js';
-import { makeObservable } from '../../core/reactivity/index.js';
+import { makeAutoObservable } from '../../core/reactivity/index.js';
 import type { SchemaModel, FieldType, ReplaceResult } from './types.js';
 import { SchemaParser } from './SchemaParser.js';
 import { NodeFactory } from './NodeFactory.js';
@@ -36,33 +36,14 @@ export class SchemaModelImpl implements SchemaModel {
     this._buildFormulaIndex();
     this._baseTree = this._currentTree.clone();
 
-    makeObservable(this, {
+    makeAutoObservable(this, {
+      _patchBuilder: false,
+      _serializer: false,
+      _nodeFactory: false,
+      _formulaIndex: false,
       _currentTree: 'observable.ref',
       _baseTree: 'observable.ref',
       _formulaParseErrors: 'observable.ref',
-      root: 'computed',
-      isDirty: 'computed',
-      isValid: 'computed',
-      patches: 'computed',
-      jsonPatches: 'computed',
-      plainSchema: 'computed',
-      validationErrors: 'computed',
-      formulaErrors: 'computed',
-      nodeCount: 'computed',
-      addField: 'action',
-      removeField: 'action',
-      renameField: 'action',
-      changeFieldType: 'action',
-      updateMetadata: 'action',
-      updateFormula: 'action',
-      updateForeignKey: 'action',
-      updateDefaultValue: 'action',
-      wrapInArray: 'action',
-      wrapRootInArray: 'action',
-      replaceRoot: 'action',
-      moveNode: 'action',
-      markAsSaved: 'action',
-      revert: 'action',
     });
   }
 

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable } from '../../core/reactivity/index.js';
+import { makeAutoObservable, observable } from '../../core/reactivity/index.js';
 import type { JsonObjectSchema, JsonSchema } from '../../types/schema.types.js';
 import { generateDefaultValue } from '../default-value/index.js';
 import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
@@ -32,20 +32,11 @@ export class TableModelImpl implements TableModel {
       }
     }
 
-    makeObservable(this, {
-      _tableId: 'observable',
-      _baseTableId: 'observable',
-      tableId: 'computed',
-      baseTableId: 'computed',
-      isRenamed: 'computed',
-      rows: 'computed',
-      rowCount: 'computed',
-      isDirty: 'computed',
-      rename: 'action',
-      addRow: 'action',
-      removeRow: 'action',
-      commit: 'action',
-      revert: 'action',
+    makeAutoObservable(this, {
+      _schema: false,
+      _rows: false,
+      _jsonSchema: false,
+      _fkResolver: false,
     });
   }
 

--- a/src/model/table/row/RowModelImpl.ts
+++ b/src/model/table/row/RowModelImpl.ts
@@ -1,4 +1,4 @@
-import { makeObservable } from '../../../core/reactivity/index.js';
+import { makeAutoObservable } from '../../../core/reactivity/index.js';
 import type { Diagnostic } from '../../../core/validation/types.js';
 import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
 import type { ValueNode } from '../../value-node/types.js';
@@ -13,14 +13,10 @@ export class RowModelImpl implements RowModel {
     private readonly _rowId: string,
     private readonly _tree: ValueTreeLike,
   ) {
-    makeObservable(this, {
+    makeAutoObservable(this, {
+      _rowId: false,
+      _tree: false,
       _tableModel: 'observable.ref',
-      index: 'computed',
-      prev: 'computed',
-      next: 'computed',
-      isDirty: 'computed',
-      isValid: 'computed',
-      errors: 'computed',
     });
   }
 

--- a/src/model/value-tree/ValueTree.ts
+++ b/src/model/value-tree/ValueTree.ts
@@ -1,4 +1,4 @@
-import { makeObservable } from '../../core/reactivity/index.js';
+import { makeAutoObservable } from '../../core/reactivity/index.js';
 import type { Diagnostic } from '../../core/validation/types.js';
 import { parseValuePath } from '../../core/value-path/ValuePathParser.js';
 import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
@@ -7,12 +7,8 @@ import type { ValueTreeLike } from './types.js';
 
 export class ValueTree implements ValueTreeLike {
   constructor(private readonly _root: ValueNode) {
-    makeObservable(this, {
-      isDirty: 'computed',
-      isValid: 'computed',
-      errors: 'computed',
-      commit: 'action',
-      revert: 'action',
+    makeAutoObservable(this, {
+      _root: false,
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized MobX usage across schema and model layers by switching to makeAutoObservable and centralizing common annotations. This reduces boilerplate and unnecessary reactions, improving performance and maintainability.

- **Refactors**
  - Replaced makeObservable with makeAutoObservable in core models and trees; explicitly excluded internal caches/indexes/loaders from observation.
  - Added initBaseObservable and initPrimitiveObservable to consolidate node setup; applied to Array, Object, Ref, String, Boolean, and Number nodes.
  - Kept targeted observables where needed (e.g., _items, _children, _rootNode) to preserve reactivity.
  - Updated mobx-provider to convert overrides for makeAutoObservable using convertAnnotations for consistent annotation handling.

<sup>Written for commit d94c3a7a12577b9906a56d805bca9ddf70e8b6b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

