### PR TITLE
feat: added tests

### DIFF
--- a/src/core/schema-diff/ChangeCoalescer.ts
+++ b/src/core/schema-diff/ChangeCoalescer.ts
@@ -108,6 +108,10 @@ export class ChangeCoalescer {
         }
       }
 
+      if (change.type === 'moved' && other.type === 'added') {
+        continue;
+      }
+
       const otherPath = this.getChangePath(other);
 
       if (path.isChildOf(otherPath)) {

--- a/src/core/schema-diff/README.md
+++ b/src/core/schema-diff/README.md
@@ -76,13 +76,34 @@ const changes = diff.collectChanges();
 // Will have 'modified' change with baseNode (string) and currentNode (number)
 ```
 
+## Move Into New Parent
+
+When a field is moved into a newly added parent object:
+
+```typescript
+// Initial: { value, sum }
+// Action: add nested object, move sum into it
+
+// ChangeCollector detects:
+// - nested: 'added'
+// - sum: 'moved' (path changed from /properties/sum to /properties/nested/properties/sum)
+
+// ChangeCoalescer keeps both:
+// - 'moved' changes are NOT filtered out when parent is 'added'
+// - This ensures separate add + move patches are generated
+```
+
+This enables proper JSON Patch generation:
+1. `add /properties/nested` - empty object
+2. `move /properties/sum → /properties/nested/properties/sum`
+
 ## Components
 
 | Component | Responsibility |
 |-----------|----------------|
 | `SchemaDiff` | Main facade, manages base/current trees |
 | `ChangeCollector` | Traverses trees, collects all raw changes |
-| `ChangeCoalescer` | Filters to top-level changes only |
+| `ChangeCoalescer` | Filters to top-level changes only (except moved into added) |
 | `NodePathIndex` | Tracks base paths and node replacements |
 | `areNodesEqual` | Deep equality comparison of nodes (including formulas) |
 | `areNodesContentEqual` | Equality without comparing names (for move+modify detection) |

--- a/src/model/schema-formula/README.md
+++ b/src/model/schema-formula/README.md
@@ -135,7 +135,9 @@ const indirectChanges = detector.detectIndirectChanges(renamedNodeIds);
 
 ## Integration with SchemaModel
 
-SchemaModel uses schema-formula internally:
+SchemaModel uses schema-formula internally. Formula paths are automatically updated when nodes are moved or renamed:
+
+### Rename Formula Dependency
 
 ```typescript
 const model = createSchemaModel({
@@ -155,10 +157,32 @@ const model = createSchemaModel({
 // Rename price → cost
 model.renameField(priceId, 'cost');
 
-// getPatches() includes indirect formula change:
+// model.patches includes:
 // 1. move patch for price → cost
-// 2. replace patch for total (formula changed to 'cost * quantity')
-const patches = model.getPatches();
+// 2. replace patch for total (formula: 'price * quantity' → 'cost * quantity')
+```
+
+### Move Formula Field Into Nested Object
+
+```typescript
+// Schema: { value, sum: formula('value + 2'), nested: {} }
+model.moveNode(sumId, nestedId);
+
+// model.patches includes:
+// 1. move patch: /properties/sum → /properties/nested/properties/sum
+//    with formulaChange: { from: 'value + 2', to: '../value + 2' }
+// 2. replace patch for nested.sum (serialized formula updated)
+```
+
+### Move Formula Dependency Into Nested Object
+
+```typescript
+// Schema: { value, sum: formula('value + 2'), nested: {} }
+model.moveNode(valueId, nestedId);
+
+// model.patches includes:
+// 1. move patch: /properties/value → /properties/nested/properties/value
+// 2. replace patch for sum (formula: 'value + 2' → 'nested.value + 2')
 ```
 
 ## Supported Expression Syntax

--- a/src/model/schema-model/__tests__/SchemaModel.addMovePatch.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.addMovePatch.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import { obj, num } from '../../../mocks/schema.mocks.js';
+import { findNodeIdByName } from './test-helpers.js';
+
+describe('SchemaModel add + move patch generation', () => {
+  describe('move field into newly created parent', () => {
+    it('generates add + move when moving field into new parent', () => {
+      const model = createSchemaModel(
+        obj({
+          value: num(),
+          sum: num(),
+        }),
+      );
+
+      const rootId = model.root.id();
+      model.addField(rootId, 'nested', 'object');
+
+      const sumId = findNodeIdByName(model, 'sum');
+      const nestedId = findNodeIdByName(model, 'nested');
+      model.moveNode(sumId!, nestedId!);
+
+      expect(model.patches).toMatchSnapshot();
+    });
+
+    it('generates add + move for multiple fields moved into new parent', () => {
+      const model = createSchemaModel(
+        obj({
+          a: num(),
+          b: num(),
+          c: num(),
+        }),
+      );
+
+      const rootId = model.root.id();
+      model.addField(rootId, 'group', 'object');
+
+      const aId = findNodeIdByName(model, 'a');
+      const bId = findNodeIdByName(model, 'b');
+      const groupId = findNodeIdByName(model, 'group');
+
+      model.moveNode(aId!, groupId!);
+      model.moveNode(bId!, groupId!);
+
+      expect(model.patches).toMatchSnapshot();
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/SchemaModel.addMovePatch.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.addMovePatch.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../SchemaModelImpl.js';
 import { obj, num } from '../../../mocks/schema.mocks.js';
-import { findNodeIdByName } from './test-helpers.js';
+import { findNodeIdByName, findNestedNodeId } from './test-helpers.js';
 
 describe('SchemaModel add + move patch generation', () => {
   describe('move field into newly created parent', () => {
@@ -41,6 +41,51 @@ describe('SchemaModel add + move patch generation', () => {
 
       model.moveNode(aId!, groupId!);
       model.moveNode(bId!, groupId!);
+
+      expect(model.patches).toMatchSnapshot();
+    });
+  });
+
+  describe('add + move + remove moved field', () => {
+    it('generates only add patch when moved field is then removed', () => {
+      const model = createSchemaModel(
+        obj({
+          value: num(),
+          sum: num(),
+        }),
+      );
+
+      const rootId = model.root.id();
+      model.addField(rootId, 'nested', 'object');
+
+      const sumId = findNodeIdByName(model, 'sum');
+      const nestedId = findNodeIdByName(model, 'nested');
+      model.moveNode(sumId!, nestedId!);
+
+      const movedSumId = findNestedNodeId(model, 'nested', 'sum');
+      model.removeField(movedSumId!);
+
+      expect(model.patches).toMatchSnapshot();
+    });
+  });
+
+  describe('add + move + remove new parent', () => {
+    it('generates only remove patch when new parent with moved children is removed', () => {
+      const model = createSchemaModel(
+        obj({
+          value: num(),
+          sum: num(),
+        }),
+      );
+
+      const rootId = model.root.id();
+      model.addField(rootId, 'nested', 'object');
+
+      const sumId = findNodeIdByName(model, 'sum');
+      const nestedId = findNodeIdByName(model, 'nested');
+      model.moveNode(sumId!, nestedId!);
+
+      model.removeField(nestedId!);
 
       expect(model.patches).toMatchSnapshot();
     });

--- a/src/model/schema-model/__tests__/SchemaModel.formulaMovePatches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.formulaMovePatches.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from '@jest/globals';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import { obj, num } from '../../../mocks/schema.mocks.js';
+import { findNodeIdByName } from './test-helpers.js';
+
+describe('SchemaModel formula move patches', () => {
+  describe('move formula field into nested object', () => {
+    const createSchemaWithFormulaAndNested = () =>
+      obj({
+        value: num(),
+        sum: num({ readOnly: true, formula: 'value + 2' }),
+        nested: obj({}),
+      });
+
+    it('generates move + replace when formula field moved to new parent', () => {
+      const model = createSchemaModel(createSchemaWithFormulaAndNested());
+      const sumId = findNodeIdByName(model, 'sum');
+      const nestedId = findNodeIdByName(model, 'nested');
+
+      model.moveNode(sumId!, nestedId!);
+
+      expect(model.patches).toMatchSnapshot();
+    });
+  });
+
+  describe('move formula dependency', () => {
+    const createSchemaWithFormulaAndNested = () =>
+      obj({
+        value: num(),
+        sum: num({ readOnly: true, formula: 'value + 2' }),
+        nested: obj({}),
+      });
+
+    it('generates replace for formula when dependency is moved', () => {
+      const model = createSchemaModel(createSchemaWithFormulaAndNested());
+      const valueId = findNodeIdByName(model, 'value');
+      const nestedId = findNodeIdByName(model, 'nested');
+
+      model.moveNode(valueId!, nestedId!);
+
+      expect(model.patches).toMatchSnapshot();
+    });
+  });
+
+  describe('rename formula dependency', () => {
+    const schemaWithFormula = () =>
+      obj({
+        price: num(),
+        quantity: num(),
+        total: num({ readOnly: true, formula: 'price * quantity' }),
+      });
+
+    it('generates replace for formula when referenced field is renamed', () => {
+      const model = createSchemaModel(schemaWithFormula());
+      const priceId = findNodeIdByName(model, 'price');
+
+      model.renameField(priceId!, 'cost');
+
+      expect(model.patches).toMatchSnapshot();
+    });
+  });
+});

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.addMovePatch.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.addMovePatch.spec.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SchemaModel add + move patch generation add + move + remove moved field generates only add patch when moved field is then removed 1`] = `
+[
+  {
+    "fieldName": "nested",
+    "metadataChanges": [],
+    "patch": {
+      "op": "add",
+      "path": "/properties/nested",
+      "value": {
+        "additionalProperties": false,
+        "properties": {},
+        "required": [],
+        "type": "object",
+      },
+    },
+  },
+  {
+    "fieldName": "sum",
+    "metadataChanges": [],
+    "patch": {
+      "op": "remove",
+      "path": "/properties/sum",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel add + move patch generation add + move + remove new parent generates only remove patch when new parent with moved children is removed 1`] = `
+[
+  {
+    "fieldName": "sum",
+    "metadataChanges": [],
+    "patch": {
+      "op": "remove",
+      "path": "/properties/sum",
+    },
+  },
+]
+`;
+
 exports[`SchemaModel add + move patch generation move field into newly created parent generates add + move for multiple fields moved into new parent 1`] = `
 [
   {

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.addMovePatch.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.addMovePatch.spec.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel add + move patch generation move field into newly created parent generates add + move for multiple fields moved into new parent 1`] = `
+[
+  {
+    "fieldName": "group",
+    "metadataChanges": [],
+    "patch": {
+      "op": "add",
+      "path": "/properties/group",
+      "value": {
+        "additionalProperties": false,
+        "properties": {},
+        "required": [],
+        "type": "object",
+      },
+    },
+  },
+  {
+    "fieldName": "group.a",
+    "formulaChange": undefined,
+    "isRename": undefined,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/a",
+      "op": "move",
+      "path": "/properties/group/properties/a",
+    },
+  },
+  {
+    "fieldName": "group.b",
+    "formulaChange": undefined,
+    "isRename": undefined,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/b",
+      "op": "move",
+      "path": "/properties/group/properties/b",
+    },
+  },
+]
+`;
+
+exports[`SchemaModel add + move patch generation move field into newly created parent generates add + move when moving field into new parent 1`] = `
+[
+  {
+    "fieldName": "nested",
+    "metadataChanges": [],
+    "patch": {
+      "op": "add",
+      "path": "/properties/nested",
+      "value": {
+        "additionalProperties": false,
+        "properties": {},
+        "required": [],
+        "type": "object",
+      },
+    },
+  },
+  {
+    "fieldName": "nested.sum",
+    "formulaChange": undefined,
+    "isRename": undefined,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/sum",
+      "op": "move",
+      "path": "/properties/nested/properties/sum",
+    },
+  },
+]
+`;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.formulaMovePatches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.formulaMovePatches.spec.ts.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel formula move patches move formula dependency generates replace for formula when dependency is moved 1`] = `
+[
+  {
+    "fieldName": "nested.value",
+    "formulaChange": undefined,
+    "isRename": undefined,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/value",
+      "op": "move",
+      "path": "/properties/nested/properties/value",
+    },
+  },
+  {
+    "contentMediaTypeChange": undefined,
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "sum",
+    "foreignKeyChange": undefined,
+    "formulaChange": {
+      "fromFormula": "value + 2",
+      "fromVersion": 1,
+      "toFormula": "nested.value + 2",
+      "toVersion": 1,
+    },
+    "metadataChanges": [
+      "formula",
+    ],
+    "patch": {
+      "op": "replace",
+      "path": "/properties/sum",
+      "value": {
+        "default": 0,
+        "readOnly": true,
+        "type": "number",
+        "x-formula": {
+          "expression": "nested.value + 2",
+          "version": 1,
+        },
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`SchemaModel formula move patches move formula field into nested object generates move + replace when formula field moved to new parent 1`] = `
+[
+  {
+    "fieldName": "nested.sum",
+    "formulaChange": {
+      "fromFormula": "value + 2",
+      "fromVersion": 1,
+      "toFormula": "../value + 2",
+      "toVersion": 1,
+    },
+    "isRename": undefined,
+    "metadataChanges": [
+      "formula",
+    ],
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/sum",
+      "op": "move",
+      "path": "/properties/nested/properties/sum",
+    },
+  },
+  {
+    "contentMediaTypeChange": undefined,
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": 0,
+    },
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "nested.sum",
+    "foreignKeyChange": undefined,
+    "formulaChange": {
+      "fromFormula": undefined,
+      "fromVersion": undefined,
+      "toFormula": "../value + 2",
+      "toVersion": 1,
+    },
+    "metadataChanges": [
+      "formula",
+      "default",
+    ],
+    "patch": {
+      "op": "replace",
+      "path": "/properties/nested/properties/sum",
+      "value": {
+        "default": 0,
+        "readOnly": true,
+        "type": "number",
+        "x-formula": {
+          "expression": "../value + 2",
+          "version": 1,
+        },
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`SchemaModel formula move patches rename formula dependency generates replace for formula when referenced field is renamed 1`] = `
+[
+  {
+    "fieldName": "cost",
+    "formulaChange": undefined,
+    "isRename": true,
+    "metadataChanges": [],
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/price",
+      "op": "move",
+      "path": "/properties/cost",
+    },
+  },
+  {
+    "contentMediaTypeChange": undefined,
+    "defaultChange": undefined,
+    "deprecatedChange": undefined,
+    "descriptionChange": undefined,
+    "fieldName": "total",
+    "foreignKeyChange": undefined,
+    "formulaChange": {
+      "fromFormula": "price * quantity",
+      "fromVersion": 1,
+      "toFormula": "cost * quantity",
+      "toVersion": 1,
+    },
+    "metadataChanges": [
+      "formula",
+    ],
+    "patch": {
+      "op": "replace",
+      "path": "/properties/total",
+      "value": {
+        "default": 0,
+        "readOnly": true,
+        "type": "number",
+        "x-formula": {
+          "expression": "cost * quantity",
+          "version": 1,
+        },
+      },
+    },
+    "typeChange": undefined,
+  },
+]
+`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes schema diff to preserve move changes when a field is moved into a newly added parent, so patches emit add + move and formulas update correctly. Adds targeted tests and docs to lock this behavior.

- **Bug Fixes**
  - ChangeCoalescer now keeps a 'moved' change when the related parent is 'added'.
  - Patch outcomes: add + move when moving into a new parent; only add when the moved field is then removed; only remove when the new parent with moved children is removed.
  - Formula handling: moving or renaming fields updates formula paths and emits replace patches for dependents.
  - Updated schema-diff and schema-formula READMEs; added Jest tests and snapshots for these scenarios.

<sup>Written for commit ece47bb542636c7206c957573f28fa5a14efef4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

