### PR TITLE
feat: ref schemas

### DIFF
--- a/src/model/schema-model/index.ts
+++ b/src/model/schema-model/index.ts
@@ -1,4 +1,4 @@
-export type { SchemaModel, FieldType, ReplaceResult } from './types.js';
+export type { SchemaModel, FieldType, ReplaceResult, SchemaModelOptions } from './types.js';
 export { createSchemaModel } from './SchemaModelImpl.js';
 export { SchemaParser } from './SchemaParser.js';
 export { NodeFactory } from './NodeFactory.js';

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -1,9 +1,15 @@
 import type { NodeMetadata, SchemaNode } from '../../core/schema-node/index.js';
 import type { Path } from '../../core/path/index.js';
 import type { SchemaPatch, JsonPatch } from '../../core/schema-patch/index.js';
-import type { JsonObjectSchema } from '../../types/index.js';
+import type { JsonObjectSchema, JsonSchema } from '../../types/index.js';
 import type { SchemaValidationError } from '../../core/validation/schema/types.js';
 import type { TreeFormulaValidationError } from '../../core/validation/formula/types.js';
+
+export type RefSchemas = Record<string, JsonSchema>;
+
+export interface SchemaModelOptions {
+  refSchemas?: RefSchemas;
+}
 
 export type FieldType =
   | 'string'
@@ -57,6 +63,7 @@ export interface SchemaModel {
 
   readonly plainSchema: JsonObjectSchema;
   readonly nodeCount: number;
+  readonly refSchemas: RefSchemas | undefined;
 
   generateDefaultValue(options?: { arrayItemCount?: number }): unknown;
 }

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -23,7 +23,7 @@ export class TableModelImpl implements TableModel {
     this._tableId = options.tableId;
     this._baseTableId = options.tableId;
     this._jsonSchema = options.schema;
-    this._schema = createSchemaModel(options.schema);
+    this._schema = createSchemaModel(options.schema, { refSchemas: options.refSchemas });
     this._fkResolver = options.fkResolver;
     this._refSchemas = options.refSchemas;
     this._rows = observable.array<RowModel>();

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -459,5 +459,29 @@ describe('TableModel', () => {
 
       expect(row.getPlainValue()).toEqual({ name: '', avatar: {} });
     });
+
+    it('schema.generateDefaultValue is consistent with addRow default values', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSchemaWithRef(),
+        refSchemas: { File: fileSchema },
+      });
+
+      const row = table.addRow('user-1');
+      const schemaDefault = table.schema.generateDefaultValue();
+
+      expect(row.getPlainValue()).toEqual(schemaDefault);
+    });
+
+    it('schema.refSchemas matches table.refSchemas', () => {
+      const refSchemas = { File: fileSchema };
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSchemaWithRef(),
+        refSchemas,
+      });
+
+      expect(table.schema.refSchemas).toBe(refSchemas);
+    });
   });
 });

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -384,4 +384,80 @@ describe('TableModel', () => {
       expect(row.getValue('address.city')).toBe('NYC');
     });
   });
+
+  describe('refSchemas support', () => {
+    const fileSchema = obj({
+      fileId: str(),
+      url: str(),
+      fileName: str(),
+    });
+
+    const createSchemaWithRef = () =>
+      obj({
+        name: str(),
+        avatar: { $ref: 'File' } as { $ref: string },
+      });
+
+    it('stores refSchemas in table', () => {
+      const refSchemas = { File: fileSchema };
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSchemaWithRef(),
+        refSchemas,
+      });
+
+      expect(table.refSchemas).toBe(refSchemas);
+    });
+
+    it('refSchemas is undefined when not provided', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSimpleSchema(),
+      });
+
+      expect(table.refSchemas).toBeUndefined();
+    });
+
+    it('resolves ref schema when creating row with data', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSchemaWithRef(),
+        refSchemas: { File: fileSchema },
+      });
+
+      const row = table.addRow('user-1', {
+        name: 'John',
+        avatar: { fileId: 'f1', url: '/img.png', fileName: 'img.png' },
+      });
+
+      expect(row.getValue('avatar.fileId')).toBe('f1');
+      expect(row.getValue('avatar.url')).toBe('/img.png');
+      expect(row.getValue('avatar.fileName')).toBe('img.png');
+    });
+
+    it('generates default values for ref schema when creating row without data', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSchemaWithRef(),
+        refSchemas: { File: fileSchema },
+      });
+
+      const row = table.addRow('user-1');
+
+      expect(row.getValue('avatar.fileId')).toBe('');
+      expect(row.getValue('avatar.url')).toBe('');
+      expect(row.getValue('avatar.fileName')).toBe('');
+    });
+
+    it('returns empty object for ref when refSchemas not provided', () => {
+      const table = createTableModel({
+        tableId: 'users',
+        schema: createSchemaWithRef(),
+      });
+
+      const row = table.addRow('user-1');
+
+      expect(row.getPlainValue()).toEqual({ name: '', avatar: {} });
+    });
+  });
 });

--- a/src/model/table/index.ts
+++ b/src/model/table/index.ts
@@ -1,3 +1,3 @@
 export * from './row/index.js';
-export type { TableModel, TableModelOptions, RowData } from './types.js';
+export type { TableModel, TableModelOptions, RowData, RefSchemas } from './types.js';
 export { TableModelImpl, createTableModel } from './TableModelImpl.js';

--- a/src/model/table/types.ts
+++ b/src/model/table/types.ts
@@ -2,6 +2,9 @@ import type { SchemaModel } from '../schema-model/types.js';
 import type { JsonObjectSchema } from '../../types/schema.types.js';
 import type { ForeignKeyResolver } from '../foreign-key-resolver/ForeignKeyResolver.js';
 import type { RowModel } from './row/types.js';
+import type { RefSchemas } from '../value-node/NodeFactory.js';
+
+export type { RefSchemas };
 
 export interface RowData {
   rowId: string;
@@ -13,10 +16,12 @@ export interface TableModelOptions {
   schema: JsonObjectSchema;
   rows?: RowData[];
   fkResolver?: ForeignKeyResolver;
+  refSchemas?: RefSchemas;
 }
 
 export interface TableModel {
   readonly fk: ForeignKeyResolver | undefined;
+  readonly refSchemas: RefSchemas | undefined;
   readonly tableId: string;
   readonly baseTableId: string;
   readonly isRenamed: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add refSchemas support across SchemaModel and TableModel to resolve $ref fields in rows and when generating defaults. This keeps $ref objects structured instead of empty objects.

- New Features
  - Add optional refSchemas to TableModelOptions and SchemaModelOptions.
  - Expose refSchemas getters on TableModel and SchemaModel.
  - Pass refSchemas to NodeFactory and generateDefaultValue to resolve $ref on row creation and defaults; fallback to {} when missing.
  - Export RefSchemas type and add tests for resolution and defaults in schema and table.

<sup>Written for commit e42cc68ad27c13c692219bdbf2de93d6e46debe1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

