### PR TITLE
fix: ref resolving

### DIFF
--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -43,12 +43,10 @@ export class ArrayNode extends BaseNode {
   }
 
   clone(): SchemaNode {
-    return new ArrayNode(
-      this.id(),
-      this.name(),
-      this._items.clone(),
-      { metadata: this.metadata(), ref: this._ref },
-    );
+    return new ArrayNode(this.id(), this.name(), this._items.clone(), {
+      metadata: this.metadata(),
+      ref: this._ref,
+    });
   }
 
   setItems(node: SchemaNode): void {
@@ -64,7 +62,7 @@ export function createArrayNode(
 ): SchemaNode {
   const opts: ArrayNodeOptions =
     'title' in options || 'description' in options || 'deprecated' in options
-      ? { metadata: options as NodeMetadata }
+      ? { metadata: options }
       : (options as ArrayNodeOptions);
   return new ArrayNode(id, name, items, opts);
 }

--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -2,6 +2,7 @@ import type { SchemaNode, NodeType, NodeMetadata } from './types.js';
 import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
 import { makeObservable } from '../reactivity/index.js';
+import { normalizeNodeOptions } from './utils.js';
 
 export interface ArrayNodeOptions {
   metadata?: NodeMetadata;
@@ -15,8 +16,9 @@ export class ArrayNode extends BaseNode {
     id: string,
     name: string,
     items: SchemaNode,
-    options: ArrayNodeOptions = {},
+    optionsOrMetadata: ArrayNodeOptions | NodeMetadata = {},
   ) {
+    const options = normalizeNodeOptions(optionsOrMetadata);
     super(id, name, options.metadata ?? EMPTY_METADATA, options.ref);
     this._items = items;
     this.initBaseObservable();
@@ -60,9 +62,5 @@ export function createArrayNode(
   items: SchemaNode,
   options: ArrayNodeOptions | NodeMetadata = {},
 ): SchemaNode {
-  const opts: ArrayNodeOptions =
-    'title' in options || 'description' in options || 'deprecated' in options
-      ? { metadata: options }
-      : (options as ArrayNodeOptions);
-  return new ArrayNode(id, name, items, opts);
+  return new ArrayNode(id, name, items, options);
 }

--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -3,6 +3,11 @@ import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
 import { makeObservable } from '../reactivity/index.js';
 
+export interface ArrayNodeOptions {
+  metadata?: NodeMetadata;
+  ref?: string;
+}
+
 export class ArrayNode extends BaseNode {
   private _items: SchemaNode;
 
@@ -10,9 +15,9 @@ export class ArrayNode extends BaseNode {
     id: string,
     name: string,
     items: SchemaNode,
-    metadata: NodeMetadata = EMPTY_METADATA,
+    options: ArrayNodeOptions = {},
   ) {
-    super(id, name, metadata);
+    super(id, name, options.metadata ?? EMPTY_METADATA, options.ref);
     this._items = items;
     this.initBaseObservable();
     makeObservable(this, {
@@ -42,7 +47,7 @@ export class ArrayNode extends BaseNode {
       this.id(),
       this.name(),
       this._items.clone(),
-      this.metadata(),
+      { metadata: this.metadata(), ref: this._ref },
     );
   }
 
@@ -55,7 +60,11 @@ export function createArrayNode(
   id: string,
   name: string,
   items: SchemaNode,
-  metadata: NodeMetadata = EMPTY_METADATA,
+  options: ArrayNodeOptions | NodeMetadata = {},
 ): SchemaNode {
-  return new ArrayNode(id, name, items, metadata);
+  const opts: ArrayNodeOptions =
+    'title' in options || 'description' in options || 'deprecated' in options
+      ? { metadata: options as NodeMetadata }
+      : (options as ArrayNodeOptions);
+  return new ArrayNode(id, name, items, opts);
 }

--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -6,14 +6,17 @@ import { makeObservable } from '../reactivity/index.js';
 export abstract class BaseNode implements SchemaNode {
   protected _name: string;
   protected _metadata: NodeMetadata;
+  protected _ref: string | undefined;
 
   constructor(
     private readonly _id: string,
     name: string,
     metadata: NodeMetadata = EMPTY_METADATA,
+    ref?: string,
   ) {
     this._name = name;
     this._metadata = metadata;
+    this._ref = ref;
   }
 
   protected initBaseObservable(): void {
@@ -52,7 +55,7 @@ export abstract class BaseNode implements SchemaNode {
   }
 
   isRef(): boolean {
-    return false;
+    return this._ref !== undefined;
   }
 
   isNull(): boolean {
@@ -72,7 +75,7 @@ export abstract class BaseNode implements SchemaNode {
   }
 
   ref(): string | undefined {
-    return undefined;
+    return this._ref;
   }
 
   formula(): Formula | undefined {

--- a/src/core/schema-node/BooleanNode.ts
+++ b/src/core/schema-node/BooleanNode.ts
@@ -5,6 +5,7 @@ export interface BooleanNodeOptions {
   readonly defaultValue?: boolean;
   readonly formula?: Formula;
   readonly metadata?: NodeMetadata;
+  readonly ref?: string;
 }
 
 export class BooleanNode extends PrimitiveNode {
@@ -30,6 +31,7 @@ export class BooleanNode extends PrimitiveNode {
       defaultValue: this._defaultValue as boolean | undefined,
       formula: this._formula,
       metadata: this._metadata,
+      ref: this._ref,
     };
   }
 }

--- a/src/core/schema-node/NumberNode.ts
+++ b/src/core/schema-node/NumberNode.ts
@@ -5,6 +5,7 @@ export interface NumberNodeOptions {
   readonly defaultValue?: number;
   readonly formula?: Formula;
   readonly metadata?: NodeMetadata;
+  readonly ref?: string;
 }
 
 export class NumberNode extends PrimitiveNode {
@@ -30,6 +31,7 @@ export class NumberNode extends PrimitiveNode {
       defaultValue: this._defaultValue as number | undefined,
       formula: this._formula,
       metadata: this._metadata,
+      ref: this._ref,
     };
   }
 }

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -4,6 +4,11 @@ import { BaseNode } from './BaseNode.js';
 import { NULL_NODE } from './NullNode.js';
 import { makeObservable } from '../reactivity/index.js';
 
+export interface ObjectNodeOptions {
+  metadata?: NodeMetadata;
+  ref?: string;
+}
+
 export class ObjectNode extends BaseNode {
   private _children: SchemaNode[];
 
@@ -11,9 +16,9 @@ export class ObjectNode extends BaseNode {
     id: string,
     name: string,
     children: readonly SchemaNode[] = [],
-    metadata: NodeMetadata = EMPTY_METADATA,
+    options: ObjectNodeOptions = {},
   ) {
-    super(id, name, metadata);
+    super(id, name, options.metadata ?? EMPTY_METADATA, options.ref);
     this._children = [...children];
     this.initBaseObservable();
     makeObservable(this, {
@@ -45,7 +50,7 @@ export class ObjectNode extends BaseNode {
       this.id(),
       this.name(),
       this._children.map((child) => child.clone()),
-      this.metadata(),
+      { metadata: this.metadata(), ref: this._ref },
     );
   }
 
@@ -76,7 +81,11 @@ export function createObjectNode(
   id: string,
   name: string,
   children: readonly SchemaNode[] = [],
-  metadata: NodeMetadata = EMPTY_METADATA,
+  options: ObjectNodeOptions | NodeMetadata = {},
 ): SchemaNode {
-  return new ObjectNode(id, name, children, metadata);
+  const opts: ObjectNodeOptions =
+    'title' in options || 'description' in options || 'deprecated' in options
+      ? { metadata: options as NodeMetadata }
+      : (options as ObjectNodeOptions);
+  return new ObjectNode(id, name, children, opts);
 }

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -85,7 +85,7 @@ export function createObjectNode(
 ): SchemaNode {
   const opts: ObjectNodeOptions =
     'title' in options || 'description' in options || 'deprecated' in options
-      ? { metadata: options as NodeMetadata }
+      ? { metadata: options }
       : (options as ObjectNodeOptions);
   return new ObjectNode(id, name, children, opts);
 }

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -3,6 +3,7 @@ import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
 import { NULL_NODE } from './NullNode.js';
 import { makeObservable } from '../reactivity/index.js';
+import { normalizeNodeOptions } from './utils.js';
 
 export interface ObjectNodeOptions {
   metadata?: NodeMetadata;
@@ -16,8 +17,9 @@ export class ObjectNode extends BaseNode {
     id: string,
     name: string,
     children: readonly SchemaNode[] = [],
-    options: ObjectNodeOptions = {},
+    optionsOrMetadata: ObjectNodeOptions | NodeMetadata = {},
   ) {
+    const options = normalizeNodeOptions(optionsOrMetadata);
     super(id, name, options.metadata ?? EMPTY_METADATA, options.ref);
     this._children = [...children];
     this.initBaseObservable();
@@ -83,9 +85,5 @@ export function createObjectNode(
   children: readonly SchemaNode[] = [],
   options: ObjectNodeOptions | NodeMetadata = {},
 ): SchemaNode {
-  const opts: ObjectNodeOptions =
-    'title' in options || 'description' in options || 'deprecated' in options
-      ? { metadata: options }
-      : (options as ObjectNodeOptions);
-  return new ObjectNode(id, name, children, opts);
+  return new ObjectNode(id, name, children, options);
 }

--- a/src/core/schema-node/PrimitiveNode.ts
+++ b/src/core/schema-node/PrimitiveNode.ts
@@ -8,6 +8,7 @@ export interface PrimitiveNodeOptions {
   readonly foreignKey?: string;
   readonly formula?: Formula;
   readonly metadata?: NodeMetadata;
+  readonly ref?: string;
 }
 
 export abstract class PrimitiveNode extends BaseNode {
@@ -20,7 +21,7 @@ export abstract class PrimitiveNode extends BaseNode {
     name: string,
     options: PrimitiveNodeOptions = {},
   ) {
-    super(id, name, options.metadata ?? EMPTY_METADATA);
+    super(id, name, options.metadata ?? EMPTY_METADATA, options.ref);
     this._defaultValue = options.defaultValue;
     this._foreignKey = options.foreignKey;
     this._formula = options.formula;

--- a/src/core/schema-node/README.md
+++ b/src/core/schema-node/README.md
@@ -37,13 +37,34 @@ type NodeType = 'object' | 'array' | 'string' | 'number' | 'boolean' | 'ref' | '
 
 |Type|Factory|Description|
 |---|---|---|
-|ObjectNode|`createObjectNode(id, name, children?, metadata?)`|Container with named properties|
-|ArrayNode|`createArrayNode(id, name, items, metadata?)`|Array with item schema|
+|ObjectNode|`createObjectNode(id, name, children?, options?)`|Container with named properties|
+|ArrayNode|`createArrayNode(id, name, items, options?)`|Array with item schema|
 |StringNode|`createStringNode(id, name, options?)`|String with default, foreignKey, formula|
 |NumberNode|`createNumberNode(id, name, options?)`|Number with default, formula|
 |BooleanNode|`createBooleanNode(id, name, options?)`|Boolean with default, formula|
-|RefNode|`createRefNode(id, name, ref, metadata?)`|Schema reference ($ref)|
+|RefNode|`createRefNode(id, name, ref, metadata?)`|Unresolved schema reference ($ref)|
 |NULL_NODE|singleton|Null object for safe chaining|
+
+## Ref Support
+
+Any node type can have a `$ref` marker. This is used when a `$ref` schema is resolved:
+
+```typescript
+// Resolved $ref to object schema
+const file = createObjectNode('file-id', 'avatar', [
+  createStringNode('url-id', 'url'),
+], { ref: 'File' });
+
+file.isObject();  // true
+file.isRef();     // true (has $ref marker)
+file.ref();       // 'File'
+
+// Unresolved $ref (RefNode)
+const unknown = createRefNode('ref-id', 'data', 'Unknown');
+unknown.nodeType();  // 'ref'
+unknown.isRef();     // true
+unknown.ref();       // 'Unknown'
+```
 
 ## Usage
 

--- a/src/core/schema-node/RefNode.ts
+++ b/src/core/schema-node/RefNode.ts
@@ -3,19 +3,16 @@ import { EMPTY_METADATA } from './types.js';
 import { BaseNode } from './BaseNode.js';
 
 export class RefNode extends BaseNode {
-  private readonly _ref: string;
-
   constructor(
     id: string,
     name: string,
     ref: string,
     metadata: NodeMetadata = EMPTY_METADATA,
   ) {
-    super(id, name, metadata);
+    super(id, name, metadata, ref);
     if (!ref) {
       throw new Error('RefNode requires a non-empty ref');
     }
-    this._ref = ref;
     this.initBaseObservable();
   }
 
@@ -23,16 +20,12 @@ export class RefNode extends BaseNode {
     return 'ref';
   }
 
-  isRef(): boolean {
-    return true;
-  }
-
-  ref(): string | undefined {
-    return this._ref;
-  }
-
   clone(): SchemaNode {
-    return new RefNode(this.id(), this.name(), this._ref, this.metadata());
+    const ref = this.ref();
+    if (!ref) {
+      throw new Error('RefNode must have a ref value');
+    }
+    return new RefNode(this.id(), this.name(), ref, this.metadata());
   }
 }
 

--- a/src/core/schema-node/StringNode.ts
+++ b/src/core/schema-node/StringNode.ts
@@ -9,6 +9,7 @@ export interface StringNodeOptions {
   readonly formula?: Formula;
   readonly metadata?: NodeMetadata;
   readonly contentMediaType?: ContentMediaType;
+  readonly ref?: string;
 }
 
 export class StringNode extends PrimitiveNode {
@@ -51,6 +52,7 @@ export class StringNode extends PrimitiveNode {
       formula: this._formula,
       metadata: this._metadata,
       contentMediaType: this._contentMediaType,
+      ref: this._ref,
     };
   }
 }

--- a/src/core/schema-node/utils.ts
+++ b/src/core/schema-node/utils.ts
@@ -1,0 +1,21 @@
+import type { NodeMetadata } from './types.js';
+
+export interface NodeOptionsWithMetadata {
+  metadata?: NodeMetadata;
+  ref?: string;
+}
+
+export function isNodeMetadata(
+  value: NodeOptionsWithMetadata | NodeMetadata,
+): value is NodeMetadata {
+  return 'title' in value || 'description' in value || 'deprecated' in value;
+}
+
+export function normalizeNodeOptions<T extends NodeOptionsWithMetadata>(
+  options: T | NodeMetadata,
+): T {
+  if (isNodeMetadata(options)) {
+    return { metadata: options } as T;
+  }
+  return options;
+}

--- a/src/core/schema-node/utils.ts
+++ b/src/core/schema-node/utils.ts
@@ -8,6 +8,9 @@ export interface NodeOptionsWithMetadata {
 export function isNodeMetadata(
   value: NodeOptionsWithMetadata | NodeMetadata,
 ): value is NodeMetadata {
+  if ('ref' in value || 'metadata' in value) {
+    return false;
+  }
   return 'title' in value || 'description' in value || 'deprecated' in value;
 }
 

--- a/src/core/schema-serializer/README.md
+++ b/src/core/schema-serializer/README.md
@@ -212,15 +212,22 @@ const result = serializer.serializeTree(tree);
 
 ### Ref Fields
 
+Any node with a `ref()` value is serialized as `{ $ref: ... }`:
+
 ```typescript
-const root = createObjectNode('root', 'root', [
+// Unresolved ref (RefNode)
+const root1 = createObjectNode('root', 'root', [
   createRefNode('file-id', 'avatar', 'File'),
 ]);
-const tree = createSchemaTree(root);
 
-const result = serializer.serializeTree(tree);
+// Resolved ref (ObjectNode with ref marker)
+const root2 = createObjectNode('root', 'root', [
+  createObjectNode('file-id', 'avatar', [
+    createStringNode('url-id', 'url'),
+  ], { ref: 'File' }),
+]);
 
-// Result:
+// Both serialize to:
 // {
 //   type: 'object',
 //   properties: {
@@ -230,6 +237,8 @@ const result = serializer.serializeTree(tree);
 //   required: ['avatar']
 // }
 ```
+
+This enables `$ref` resolution at parsing time while preserving original schema structure on serialization.
 
 ## Output Types
 

--- a/src/core/schema-serializer/SchemaSerializer.ts
+++ b/src/core/schema-serializer/SchemaSerializer.ts
@@ -42,16 +42,17 @@ export class SchemaSerializer {
       throw new Error('Cannot serialize null node');
     }
 
+    const ref = node.ref();
+    if (ref) {
+      return this.serializeRef(node, ref);
+    }
+
     if (node.isObject()) {
       return this.serializeObject(node);
     }
 
     if (node.isArray()) {
       return this.serializeArray(node);
-    }
-
-    if (node.isRef()) {
-      return this.serializeRef(node);
     }
 
     return this.serializePrimitive(node);
@@ -93,12 +94,7 @@ export class SchemaSerializer {
     return this.addMetadata(result, node);
   }
 
-  private serializeRef(node: SchemaNode): JsonRefSchema {
-    const ref = node.ref();
-    if (!ref) {
-      throw new Error('Ref node must have a ref value');
-    }
-
+  private serializeRef(node: SchemaNode, ref: string): JsonRefSchema {
     const result: JsonRefSchema = {
       $ref: ref,
     };

--- a/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
+++ b/src/core/schema-serializer/__tests__/SchemaSerializer.spec.ts
@@ -581,39 +581,6 @@ describe('SchemaSerializer', () => {
       }).toThrow('Array node must have items');
     });
 
-    it('throws when ref has no ref value', () => {
-      const mockRefNode = {
-        id: () => 'ref-id',
-        name: () => 'ref',
-        nodeType: () => 'ref' as const,
-        metadata: () => ({}),
-        isObject: () => false,
-        isArray: () => false,
-        isPrimitive: () => false,
-        isRef: () => true,
-        isNull: () => false,
-        property: () => ({ isNull: () => true }),
-        properties: () => [],
-        items: () => ({ isNull: () => true }),
-        ref: () => undefined,
-        formula: () => undefined,
-        hasFormula: () => false,
-        defaultValue: () => undefined,
-        foreignKey: () => undefined,
-        clone: () => mockRefNode,
-      };
-
-      const mockTree = createSchemaTree(
-        createObjectNode('root', 'root', [
-          createStringNode('dummy', 'dummy'),
-        ]),
-      );
-
-      expect(() => {
-        serializer.serializeNode(mockRefNode as unknown as ReturnType<typeof createObjectNode>, mockTree);
-      }).toThrow('Ref node must have a ref value');
-    });
-
     it('throws for unknown primitive type', () => {
       const mockNode = {
         id: () => 'unknown-id',

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -29,14 +29,14 @@ export class SchemaModelImpl implements SchemaModel {
   private readonly _refSchemas: RefSchemas | undefined;
 
   constructor(schema: JsonObjectSchema, options?: SchemaModelOptions) {
+    this._refSchemas = options?.refSchemas;
     const parser = new SchemaParser();
-    const rootNode = parser.parse(schema);
+    const rootNode = parser.parse(schema, this._refSchemas);
     this._currentTree = createSchemaTree(rootNode);
     parser.parseFormulas(this._currentTree);
     this._formulaParseErrors = parser.parseErrors;
     this._buildFormulaIndex();
     this._baseTree = this._currentTree.clone();
-    this._refSchemas = options?.refSchemas;
 
     makeAutoObservable(this, {
       _patchBuilder: false,

--- a/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../SchemaModelImpl.js';
+import { obj, str } from '../../../mocks/schema.mocks.js';
 import {
   emptySchema,
   simpleSchema,
@@ -209,6 +210,68 @@ describe('SchemaModel patches', () => {
       model.revert();
 
       expect(model.isDirty).toBe(false);
+    });
+  });
+
+  describe('patches with refSchemas', () => {
+    const fileSchema = obj({
+      fileId: str(),
+      url: str(),
+    });
+
+    it('patch value contains $ref not resolved schema', () => {
+      const schema = obj({
+        name: str(),
+      });
+
+      const model = createSchemaModel(schema, {
+        refSchemas: { File: fileSchema },
+      });
+
+      const avatar = model.addField(model.root.id(), 'avatar', 'object');
+      const avatarNode = model.nodeById(avatar.id());
+      expect(avatarNode.isObject()).toBe(true);
+
+      model.removeField(avatar.id());
+
+      expect(model.patches).toMatchSnapshot();
+    });
+
+    it('removing ref field generates patch with $ref value', () => {
+      const schema = obj({
+        name: str(),
+        avatar: { $ref: 'File' } as { $ref: string },
+      });
+
+      const model = createSchemaModel(schema, {
+        refSchemas: { File: fileSchema },
+      });
+
+      const avatarId = findNodeIdByName(model, 'avatar');
+      model.removeField(avatarId!);
+
+      const patches = model.patches;
+      expect(patches).toHaveLength(1);
+      expect(patches[0]?.patch.op).toBe('remove');
+      expect(patches[0]?.patch.path).toBe('/properties/avatar');
+    });
+
+    it('renaming ref field generates move patch', () => {
+      const schema = obj({
+        avatar: { $ref: 'File' } as { $ref: string },
+      });
+
+      const model = createSchemaModel(schema, {
+        refSchemas: { File: fileSchema },
+      });
+
+      const avatarId = findNodeIdByName(model, 'avatar');
+      model.renameField(avatarId!, 'image');
+
+      const patches = model.patches;
+      expect(patches).toHaveLength(1);
+      expect(patches[0]?.patch.op).toBe('move');
+      expect(patches[0]?.patch.path).toBe('/properties/image');
     });
   });
 });

--- a/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
@@ -219,7 +219,7 @@ describe('SchemaModel patches', () => {
       url: str(),
     });
 
-    it('patch value contains $ref not resolved schema', () => {
+    it('adding and removing regular field works with refSchemas option', () => {
       const schema = obj({
         name: str(),
       });

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
@@ -263,4 +263,4 @@ exports[`SchemaModel patches getPatches returns replace patch for type change 1`
 ]
 `;
 
-exports[`SchemaModel patches patches with refSchemas patch value contains $ref not resolved schema 1`] = `[]`;
+exports[`SchemaModel patches patches with refSchemas adding and removing regular field works with refSchemas option 1`] = `[]`;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
@@ -262,3 +262,5 @@ exports[`SchemaModel patches getPatches returns replace patch for type change 1`
   },
 ]
 `;
+
+exports[`SchemaModel patches patches with refSchemas patch value contains $ref not resolved schema 1`] = `[]`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds consistent $ref resolution and serialization across all schema nodes. Resolved refs now build full node trees but serialize back to $ref, fixing incorrect ref handling.

- **New Features**
  - Parser: added refSchemas option to resolve $ref to object/array/primitive nodes and mark them with ref().
  - Nodes: BaseNode now stores ref; ObjectNode/ArrayNode factories accept options with metadata/ref; PrimitiveNode options include ref; RefNode simplified to use BaseNode ref.
  - Serializer: any node with ref() serializes as { $ref: ... }.
  - Updated docs and tests to cover ref resolution and serialization.

- **Migration**
  - createObjectNode/createArrayNode now accept either a metadata param or an options object. Prefer { metadata } or { metadata, ref }.
  - isRef() returns true for any node with a ref marker, not just RefNode.

<sup>Written for commit 928858cde36a602be889ea130a5609054ca35b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

