### PR TITLE
feat: replace and transformation

### DIFF
--- a/src/core/schema-node/ArrayNode.ts
+++ b/src/core/schema-node/ArrayNode.ts
@@ -51,6 +51,13 @@ export class ArrayNode extends BaseNode {
     });
   }
 
+  cloneWithId(newId: string): SchemaNode {
+    return new ArrayNode(newId, this.name(), this._items.clone(), {
+      metadata: this.metadata(),
+      ref: this._ref,
+    });
+  }
+
   setItems(node: SchemaNode): void {
     this._items = node;
   }

--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -99,6 +99,7 @@ export abstract class BaseNode implements SchemaNode {
   }
 
   abstract clone(): SchemaNode;
+  abstract cloneWithId(newId: string): SchemaNode;
 
   setName(name: string): void {
     this._name = name;

--- a/src/core/schema-node/BooleanNode.ts
+++ b/src/core/schema-node/BooleanNode.ts
@@ -26,6 +26,10 @@ export class BooleanNode extends PrimitiveNode {
     return new BooleanNode(this.id(), this.name(), this.cloneOptions());
   }
 
+  cloneWithId(newId: string): SchemaNode {
+    return new BooleanNode(newId, this.name(), this.cloneOptions());
+  }
+
   private cloneOptions(): BooleanNodeOptions {
     return {
       defaultValue: this._defaultValue as boolean | undefined,

--- a/src/core/schema-node/NullNode.ts
+++ b/src/core/schema-node/NullNode.ts
@@ -74,6 +74,10 @@ class NullNodeImpl implements SchemaNode {
     return this;
   }
 
+  cloneWithId(_newId: string): SchemaNode {
+    return this;
+  }
+
   setName(_name: string): void {
     // No-op for null
   }

--- a/src/core/schema-node/NumberNode.ts
+++ b/src/core/schema-node/NumberNode.ts
@@ -26,6 +26,10 @@ export class NumberNode extends PrimitiveNode {
     return new NumberNode(this.id(), this.name(), this.cloneOptions());
   }
 
+  cloneWithId(newId: string): SchemaNode {
+    return new NumberNode(newId, this.name(), this.cloneOptions());
+  }
+
   private cloneOptions(): NumberNodeOptions {
     return {
       defaultValue: this._defaultValue as number | undefined,

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -56,6 +56,15 @@ export class ObjectNode extends BaseNode {
     );
   }
 
+  cloneWithId(newId: string): SchemaNode {
+    return new ObjectNode(
+      newId,
+      this.name(),
+      this._children.map((child) => child.clone()),
+      { metadata: this.metadata(), ref: this._ref },
+    );
+  }
+
   addChild(node: SchemaNode): void {
     this._children.push(node);
   }

--- a/src/core/schema-node/RefNode.ts
+++ b/src/core/schema-node/RefNode.ts
@@ -27,6 +27,14 @@ export class RefNode extends BaseNode {
     }
     return new RefNode(this.id(), this.name(), ref, this.metadata());
   }
+
+  cloneWithId(newId: string): SchemaNode {
+    const ref = this.ref();
+    if (!ref) {
+      throw new Error('RefNode must have a ref value');
+    }
+    return new RefNode(newId, this.name(), ref, this.metadata());
+  }
 }
 
 export function createRefNode(

--- a/src/core/schema-node/StringNode.ts
+++ b/src/core/schema-node/StringNode.ts
@@ -45,6 +45,10 @@ export class StringNode extends PrimitiveNode {
     return new StringNode(this.id(), this.name(), this.cloneOptions());
   }
 
+  cloneWithId(newId: string): SchemaNode {
+    return new StringNode(newId, this.name(), this.cloneOptions());
+  }
+
   private cloneOptions(): StringNodeOptions {
     return {
       defaultValue: this._defaultValue as string | undefined,

--- a/src/core/schema-node/types.ts
+++ b/src/core/schema-node/types.ts
@@ -43,6 +43,7 @@ export interface SchemaNode {
   contentMediaType(): string | undefined;
 
   clone(): SchemaNode;
+  cloneWithId(newId: string): SchemaNode;
 
   setName(name: string): void;
   setMetadata(metadata: NodeMetadata): void;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -6,6 +6,7 @@ export * from './default-value/index.js';
 export * from './foreign-key-resolver/index.js';
 export * from './data-model/index.js';
 export * from './schema-formula/index.js';
+export * from './type-transformer/index.js';
 
 export {
   ValueType,

--- a/src/model/schema-model/__tests__/SchemaModel.changeFieldType.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.changeFieldType.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from '@jest/globals';
+import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
+import { createSchemaModel } from '../SchemaModelImpl.js';
+import type { JsonSchema } from '../../../types/index.js';
+import type { RefSchemas } from '../types.js';
+
+const customRefSchemas: RefSchemas = {
+  'urn:custom:schema': obj({
+    id: str(),
+    value: num(),
+  }) as unknown as JsonSchema,
+};
+
+describe('SchemaModel.changeFieldType', () => {
+  describe('simple type changes', () => {
+    it('changes string to number', () => {
+      const model = createSchemaModel(obj({ field: str() }));
+      const fieldId = model.root.property('field').id();
+
+      const newNode = model.changeFieldType(fieldId, 'number');
+
+      expect(newNode.nodeType()).toBe('number');
+      expect(newNode.defaultValue()).toBe(0);
+    });
+
+    it('changes number to boolean', () => {
+      const model = createSchemaModel(obj({ field: num() }));
+      const fieldId = model.root.property('field').id();
+
+      const newNode = model.changeFieldType(fieldId, 'boolean');
+
+      expect(newNode.nodeType()).toBe('boolean');
+      expect(newNode.defaultValue()).toBe(false);
+    });
+  });
+
+  describe('primitive to array transformation', () => {
+    it('wraps string in array<string>', () => {
+      const model = createSchemaModel(obj({ tags: str({ default: 'test' }) }));
+      const fieldId = model.root.property('tags').id();
+
+      const newNode = model.changeFieldType(fieldId, 'array');
+
+      expect(newNode.nodeType()).toBe('array');
+      expect(newNode.items().nodeType()).toBe('string');
+      expect(newNode.items().defaultValue()).toBe('test');
+    });
+
+    it('wraps number in array<number>', () => {
+      const model = createSchemaModel(obj({ scores: num({ default: 100 }) }));
+      const fieldId = model.root.property('scores').id();
+
+      const newNode = model.changeFieldType(fieldId, 'array');
+
+      expect(newNode.nodeType()).toBe('array');
+      expect(newNode.items().nodeType()).toBe('number');
+      expect(newNode.items().defaultValue()).toBe(100);
+    });
+  });
+
+  describe('object to array transformation', () => {
+    it('wraps object in array<object>', () => {
+      const model = createSchemaModel(obj({ item: obj({ name: str() }) }));
+      const fieldId = model.root.property('item').id();
+
+      const newNode = model.changeFieldType(fieldId, 'array');
+
+      expect(newNode.nodeType()).toBe('array');
+      expect(newNode.items().nodeType()).toBe('object');
+      expect(newNode.items().property('name').nodeType()).toBe('string');
+    });
+  });
+
+  describe('array to primitive (matching items)', () => {
+    it('extracts string from array<string>', () => {
+      const model = createSchemaModel(obj({ tags: arr(str()) }));
+      const fieldId = model.root.property('tags').id();
+
+      const newNode = model.changeFieldType(fieldId, 'string');
+
+      expect(newNode.nodeType()).toBe('string');
+    });
+
+    it('extracts number from array<number>', () => {
+      const model = createSchemaModel(obj({ scores: arr(num()) }));
+      const fieldId = model.root.property('scores').id();
+
+      const newNode = model.changeFieldType(fieldId, 'number');
+
+      expect(newNode.nodeType()).toBe('number');
+    });
+  });
+
+  describe('spec object with options', () => {
+    it('applies default value from spec', () => {
+      const model = createSchemaModel(obj({ field: num() }));
+      const fieldId = model.root.property('field').id();
+
+      const newNode = model.changeFieldType(fieldId, { type: 'string', default: 'N/A' });
+
+      expect(newNode.nodeType()).toBe('string');
+      expect(newNode.defaultValue()).toBe('N/A');
+    });
+
+    it('applies metadata from spec', () => {
+      const model = createSchemaModel(obj({ field: str() }));
+      const fieldId = model.root.property('field').id();
+
+      const newNode = model.changeFieldType(fieldId, {
+        type: 'number',
+        title: 'Price',
+        description: 'Item price',
+        deprecated: true,
+      });
+
+      expect(newNode.metadata().title).toBe('Price');
+      expect(newNode.metadata().description).toBe('Item price');
+      expect(newNode.metadata().deprecated).toBe(true);
+    });
+
+    it('applies foreignKey for string type', () => {
+      const model = createSchemaModel(obj({ field: num() }));
+      const fieldId = model.root.property('field').id();
+
+      const newNode = model.changeFieldType(fieldId, {
+        type: 'string',
+        foreignKey: 'users.id',
+      });
+
+      expect(newNode.foreignKey()).toBe('users.id');
+    });
+  });
+
+  describe('$ref transformation', () => {
+    it('creates ref node without refSchemas', () => {
+      const model = createSchemaModel(obj({ avatar: str() }));
+      const fieldId = model.root.property('avatar').id();
+
+      const newNode = model.changeFieldType(fieldId, {
+        $ref: 'urn:jsonschema:io:revisium:file-schema:1.0.0',
+      });
+
+      expect(newNode.nodeType()).toBe('ref');
+      expect(newNode.ref()).toBe('urn:jsonschema:io:revisium:file-schema:1.0.0');
+    });
+
+    it('resolves ref with refSchemas', () => {
+      const model = createSchemaModel(obj({ data: str() }), { refSchemas: customRefSchemas });
+      const fieldId = model.root.property('data').id();
+
+      const newNode = model.changeFieldType(fieldId, { $ref: 'urn:custom:schema' });
+
+      expect(newNode.nodeType()).toBe('object');
+      expect(newNode.isRef()).toBe(true);
+      expect(newNode.properties()).toHaveLength(2);
+      expect(newNode.property('id').nodeType()).toBe('string');
+      expect(newNode.property('value').nodeType()).toBe('number');
+    });
+  });
+
+  describe('plainSchema serialization', () => {
+    it('serializes $ref correctly', () => {
+      const model = createSchemaModel(obj({ data: str() }), { refSchemas: customRefSchemas });
+      const fieldId = model.root.property('data').id();
+
+      model.changeFieldType(fieldId, { $ref: 'urn:custom:schema' });
+
+      expect(model.plainSchema.properties.data).toEqual({ $ref: 'urn:custom:schema' });
+    });
+  });
+
+  describe('patch tracking', () => {
+    it('tracks replacement correctly', () => {
+      const model = createSchemaModel(obj({ field: str() }));
+      const fieldId = model.root.property('field').id();
+
+      model.changeFieldType(fieldId, 'number');
+
+      expect(model.isDirty).toBe(true);
+      expect(model.patches).toHaveLength(1);
+      expect(model.patches[0]?.patch.op).toBe('replace');
+    });
+  });
+});

--- a/src/model/schema-model/index.ts
+++ b/src/model/schema-model/index.ts
@@ -1,4 +1,4 @@
-export type { SchemaModel, FieldType, ReplaceResult, SchemaModelOptions } from './types.js';
+export type { SchemaModel, FieldType, FieldTypeSpec, ReplaceResult, SchemaModelOptions } from './types.js';
 export { createSchemaModel } from './SchemaModelImpl.js';
 export { SchemaParser } from './SchemaParser.js';
 export { NodeFactory } from './NodeFactory.js';

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -4,11 +4,13 @@ import type { SchemaPatch, JsonPatch } from '../../core/schema-patch/index.js';
 import type { JsonObjectSchema, JsonSchema } from '../../types/index.js';
 import type { SchemaValidationError } from '../../core/validation/schema/types.js';
 import type { TreeFormulaValidationError } from '../../core/validation/formula/types.js';
+import type { TypeTransformer, FieldTypeSpec } from '../type-transformer/index.js';
 
 export type RefSchemas = Record<string, JsonSchema>;
 
 export interface SchemaModelOptions {
   refSchemas?: RefSchemas;
+  customTransformers?: TypeTransformer[];
 }
 
 export type FieldType =
@@ -17,6 +19,8 @@ export type FieldType =
   | 'boolean'
   | 'object'
   | 'array';
+
+export type { FieldTypeSpec };
 
 export interface ReplaceResult {
   replacedNodeId: string;
@@ -31,7 +35,7 @@ export interface SchemaModel {
   addField(parentId: string, name: string, type: FieldType): SchemaNode;
   removeField(nodeId: string): boolean;
   renameField(nodeId: string, newName: string): void;
-  changeFieldType(nodeId: string, newType: FieldType): SchemaNode;
+  changeFieldType(nodeId: string, newType: FieldTypeSpec): SchemaNode;
   updateMetadata(nodeId: string, meta: Partial<NodeMetadata>): void;
   updateFormula(nodeId: string, expression: string | undefined): void;
   updateForeignKey(nodeId: string, foreignKey: string | undefined): void;

--- a/src/model/type-transformer/README.md
+++ b/src/model/type-transformer/README.md
@@ -1,0 +1,151 @@
+# type-transformer
+
+Pluggable type transformation system for schema field type changes.
+
+## Dependencies
+
+```
+core/schema-node  ← SchemaNode, createArrayNode, createRefNode, etc.
+model/schema-model ← RefSchemas, SchemaParser
+mocks/schema.mocks ← obj, ref (for schema construction)
+nanoid            ← ID generation
+```
+
+## API
+
+```typescript
+type FieldTypeSpec = SimpleFieldType | FieldSchemaSpec;
+
+type SimpleFieldType = 'string' | 'number' | 'boolean' | 'object' | 'array';
+
+interface FieldSchemaSpec {
+  type?: SimpleFieldType;
+  $ref?: string;
+  default?: unknown;
+  title?: string;
+  description?: string;
+  deprecated?: boolean;
+  foreignKey?: string;
+  'x-formula'?: { expression: string };
+}
+
+interface TypeTransformer {
+  canTransform(ctx: TransformContext): boolean;
+  transform(ctx: TransformContext): TransformResult;
+}
+
+interface TransformContext {
+  sourceNode: SchemaNode;
+  targetSpec: FieldSchemaSpec;
+  refSchemas?: RefSchemas;
+}
+
+interface TransformResult {
+  node: SchemaNode;
+}
+```
+
+## Usage
+
+### Basic usage
+
+```typescript
+import { createTypeTransformChain } from './type-transformer';
+
+const chain = createTypeTransformChain();
+
+// Simple type change
+const result = chain.transform(stringNode, 'number');
+
+// With spec object
+const result = chain.transform(stringNode, {
+  type: 'number',
+  default: 0,
+  title: 'Price',
+});
+
+// $ref transformation
+const result = chain.transform(stringNode, {
+  $ref: 'urn:jsonschema:io:revisium:file-schema:1.0.0',
+});
+```
+
+### With refSchemas
+
+```typescript
+const chain = createTypeTransformChain({
+  refSchemas: {
+    'urn:custom:schema': {
+      type: 'object',
+      properties: { id: { type: 'string', default: '' } },
+      additionalProperties: false,
+      required: ['id'],
+    },
+  },
+});
+
+// Creates resolved object node with isRef() === true
+const result = chain.transform(stringNode, { $ref: 'urn:custom:schema' });
+```
+
+### Custom transformers
+
+```typescript
+import { TypeTransformer, TransformContext, TransformResult } from './type-transformer';
+
+class MyCustomTransformer implements TypeTransformer {
+  canTransform(ctx: TransformContext): boolean {
+    // Return true if this transformer should handle the transformation
+    return ctx.sourceNode.nodeType() === 'string' && ctx.targetSpec.type === 'number';
+  }
+
+  transform(ctx: TransformContext): TransformResult {
+    // Create and return transformed node
+    return { node: createNumberNode(nanoid(), ctx.sourceNode.name(), { defaultValue: 0 }) };
+  }
+}
+
+const chain = createTypeTransformChain({
+  customTransformers: [new MyCustomTransformer()],
+});
+```
+
+## Built-in Transformers
+
+| Transformer | Source | Target | Behavior |
+|-------------|--------|--------|----------|
+| `PrimitiveToArrayTransformer` | primitive | array | Wraps primitive in array (string → array\<string\>) |
+| `ObjectToArrayTransformer` | object | array | Wraps object in array (object → array\<object\>) |
+| `ArrayToItemsTypeTransformer` | array | primitive | Extracts items if types match (array\<string\> → string) |
+| `RefTransformer` | any | $ref | Creates ref node, resolves if refSchemas provided |
+| `DefaultTransformer` | any | type | Creates new node with default values (fallback) |
+
+## Transformer Priority
+
+Transformers are evaluated in order:
+1. Custom transformers (first match wins)
+2. `PrimitiveToArrayTransformer`
+3. `ObjectToArrayTransformer`
+4. `ArrayToItemsTypeTransformer`
+5. `RefTransformer`
+6. `DefaultTransformer` (fallback)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    TypeTransformChain                       │
+│                                                             │
+│  transform(sourceNode, spec) → TransformResult              │
+│                                                             │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │              Transformer Pipeline                    │   │
+│  │                                                      │   │
+│  │  [Custom] → [Primitive→Array] → [Object→Array] →     │   │
+│  │  [Array→Items] → [Ref] → [Default]                   │   │
+│  │                                                      │   │
+│  │  First transformer where canTransform() === true     │   │
+│  │  handles the transformation                          │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```

--- a/src/model/type-transformer/TypeTransformChain.ts
+++ b/src/model/type-transformer/TypeTransformChain.ts
@@ -1,0 +1,66 @@
+import type { SchemaNode } from '../../core/schema-node/index.js';
+import type {
+  TypeTransformer,
+  TransformContext,
+  TransformResult,
+  FieldTypeSpec,
+  FieldSchemaSpec,
+  SimpleFieldType,
+} from './types.js';
+import type { RefSchemas } from '../schema-model/types.js';
+import {
+  PrimitiveToArrayTransformer,
+  ObjectToArrayTransformer,
+  ArrayToItemsTypeTransformer,
+  RefTransformer,
+  DefaultTransformer,
+} from './transformers/index.js';
+
+export interface TypeTransformChainOptions {
+  refSchemas?: RefSchemas;
+  customTransformers?: TypeTransformer[];
+}
+
+export class TypeTransformChain {
+  private readonly _transformers: TypeTransformer[];
+  private readonly _refSchemas: RefSchemas | undefined;
+
+  constructor(options: TypeTransformChainOptions = {}) {
+    this._refSchemas = options.refSchemas;
+    this._transformers = [
+      ...(options.customTransformers ?? []),
+      new PrimitiveToArrayTransformer(),
+      new ObjectToArrayTransformer(),
+      new ArrayToItemsTypeTransformer(),
+      new RefTransformer(),
+      new DefaultTransformer(),
+    ];
+  }
+
+  transform(sourceNode: SchemaNode, spec: FieldTypeSpec): TransformResult {
+    const normalizedSpec = this.normalizeSpec(spec);
+    const ctx: TransformContext = {
+      sourceNode,
+      targetSpec: normalizedSpec,
+      refSchemas: this._refSchemas,
+    };
+
+    const transformer = this._transformers.find((t) => t.canTransform(ctx));
+    if (!transformer) {
+      throw new Error(`No transformer found for spec: ${JSON.stringify(spec)}`);
+    }
+
+    return transformer.transform(ctx);
+  }
+
+  private normalizeSpec(spec: FieldTypeSpec): FieldSchemaSpec {
+    if (typeof spec === 'string') {
+      return { type: spec as SimpleFieldType };
+    }
+    return spec;
+  }
+}
+
+export function createTypeTransformChain(options?: TypeTransformChainOptions): TypeTransformChain {
+  return new TypeTransformChain(options);
+}

--- a/src/model/type-transformer/__tests__/TypeTransformChain.spec.ts
+++ b/src/model/type-transformer/__tests__/TypeTransformChain.spec.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from '@jest/globals';
+import { TypeTransformChain, createTypeTransformChain } from '../TypeTransformChain.js';
+import {
+  obj,
+  str,
+  num,
+  bool,
+  arr,
+  createModel,
+  getFieldNode,
+  customRefSchemas,
+} from './test-helpers.js';
+
+describe('TypeTransformChain', () => {
+  describe('primitive to primitive', () => {
+    it('transforms string to number', () => {
+      const model = createModel(obj({ field: str({ default: 'hello' }) }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'number');
+
+      expect(result.node.nodeType()).toBe('number');
+      expect(result.node.name()).toBe('field');
+      expect(result.node.defaultValue()).toBe(0);
+    });
+
+    it('transforms number to string', () => {
+      const model = createModel(obj({ field: num({ default: 42 }) }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'string');
+
+      expect(result.node.nodeType()).toBe('string');
+      expect(result.node.name()).toBe('field');
+      expect(result.node.defaultValue()).toBe('');
+    });
+
+    it('transforms boolean to string', () => {
+      const model = createModel(obj({ field: bool({ default: true }) }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'string');
+
+      expect(result.node.nodeType()).toBe('string');
+      expect(result.node.name()).toBe('field');
+    });
+  });
+
+  describe('primitive to array', () => {
+    it('wraps string in array<string>', () => {
+      const model = createModel(obj({ tags: str({ default: 'value' }) }));
+      const source = getFieldNode(model, 'tags');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'array');
+
+      expect(result.node.nodeType()).toBe('array');
+      expect(result.node.name()).toBe('tags');
+      expect(result.node.items().nodeType()).toBe('string');
+      expect(result.node.items().name()).toBe('items');
+    });
+
+    it('wraps number in array<number>', () => {
+      const model = createModel(obj({ scores: num({ default: 100 }) }));
+      const source = getFieldNode(model, 'scores');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'array');
+
+      expect(result.node.nodeType()).toBe('array');
+      expect(result.node.name()).toBe('scores');
+      expect(result.node.items().nodeType()).toBe('number');
+    });
+
+    it('wraps boolean in array<boolean>', () => {
+      const model = createModel(obj({ flags: bool({ default: true }) }));
+      const source = getFieldNode(model, 'flags');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'array');
+
+      expect(result.node.nodeType()).toBe('array');
+      expect(result.node.items().nodeType()).toBe('boolean');
+    });
+  });
+
+  describe('object to array', () => {
+    it('wraps object in array<object>', () => {
+      const model = createModel(
+        obj({
+          item: obj({ name: str() }),
+        }),
+      );
+      const source = getFieldNode(model, 'item');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'array');
+
+      expect(result.node.nodeType()).toBe('array');
+      expect(result.node.name()).toBe('item');
+      expect(result.node.items().nodeType()).toBe('object');
+      expect(result.node.items().properties()).toHaveLength(1);
+      expect(result.node.items().property('name').nodeType()).toBe('string');
+    });
+  });
+
+  describe('array to primitive (matching items type)', () => {
+    it('extracts string from array<string>', () => {
+      const model = createModel(obj({ tags: arr(str()) }));
+      const source = getFieldNode(model, 'tags');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'string');
+
+      expect(result.node.nodeType()).toBe('string');
+      expect(result.node.name()).toBe('tags');
+    });
+
+    it('extracts number from array<number>', () => {
+      const model = createModel(obj({ scores: arr(num()) }));
+      const source = getFieldNode(model, 'scores');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'number');
+
+      expect(result.node.nodeType()).toBe('number');
+      expect(result.node.name()).toBe('scores');
+    });
+
+    it('does not extract mismatched type', () => {
+      const model = createModel(obj({ tags: arr(str()) }));
+      const source = getFieldNode(model, 'tags');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'number');
+
+      expect(result.node.nodeType()).toBe('number');
+      expect(result.node.defaultValue()).toBe(0);
+    });
+  });
+
+  describe('with spec object', () => {
+    it('applies default value from spec', () => {
+      const model = createModel(obj({ field: num() }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, { type: 'string', default: 'N/A' });
+
+      expect(result.node.nodeType()).toBe('string');
+      expect(result.node.defaultValue()).toBe('N/A');
+    });
+
+    it('applies metadata from spec', () => {
+      const model = createModel(obj({ field: str() }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, {
+        type: 'number',
+        title: 'Price',
+        description: 'Item price',
+        deprecated: true,
+      });
+
+      expect(result.node.metadata().title).toBe('Price');
+      expect(result.node.metadata().description).toBe('Item price');
+      expect(result.node.metadata().deprecated).toBe(true);
+    });
+
+    it('applies foreignKey for string type', () => {
+      const model = createModel(obj({ field: num() }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, {
+        type: 'string',
+        foreignKey: 'users.id',
+      });
+
+      expect(result.node.foreignKey()).toBe('users.id');
+    });
+  });
+
+  describe('$ref transformation', () => {
+    it('creates ref node without refSchemas', () => {
+      const model = createModel(obj({ avatar: str() }));
+      const source = getFieldNode(model, 'avatar');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, {
+        $ref: 'urn:jsonschema:io:revisium:file-schema:1.0.0',
+      });
+
+      expect(result.node.nodeType()).toBe('ref');
+      expect(result.node.name()).toBe('avatar');
+      expect(result.node.ref()).toBe('urn:jsonschema:io:revisium:file-schema:1.0.0');
+    });
+
+    it('creates ref node with metadata', () => {
+      const model = createModel(obj({ avatar: str() }));
+      const source = getFieldNode(model, 'avatar');
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, {
+        $ref: 'urn:jsonschema:io:revisium:file-schema:1.0.0',
+        title: 'Avatar',
+        description: 'User profile picture',
+        deprecated: true,
+      });
+
+      expect(result.node.metadata().title).toBe('Avatar');
+      expect(result.node.metadata().description).toBe('User profile picture');
+      expect(result.node.metadata().deprecated).toBe(true);
+    });
+
+    it('resolves ref with refSchemas', () => {
+      const model = createModel(obj({ data: str() }));
+      const source = getFieldNode(model, 'data');
+      const chain = new TypeTransformChain({ refSchemas: customRefSchemas });
+
+      const result = chain.transform(source, { $ref: 'urn:custom:schema' });
+
+      expect(result.node.nodeType()).toBe('object');
+      expect(result.node.name()).toBe('data');
+      expect(result.node.isRef()).toBe(true);
+      expect(result.node.properties()).toHaveLength(2);
+      expect(result.node.property('id').nodeType()).toBe('string');
+      expect(result.node.property('value').nodeType()).toBe('number');
+    });
+  });
+
+  describe('new node id', () => {
+    it('creates node with new id', () => {
+      const model = createModel(obj({ field: str() }));
+      const source = getFieldNode(model, 'field');
+      const originalId = source.id();
+      const chain = new TypeTransformChain();
+
+      const result = chain.transform(source, 'number');
+
+      expect(result.node.id()).not.toBe(originalId);
+    });
+  });
+
+  describe('factory function', () => {
+    it('creates chain with createTypeTransformChain', () => {
+      const chain = createTypeTransformChain();
+      const model = createModel(obj({ field: str() }));
+      const source = getFieldNode(model, 'field');
+
+      const result = chain.transform(source, 'number');
+
+      expect(result.node.nodeType()).toBe('number');
+    });
+
+    it('creates chain with options', () => {
+      const chain = createTypeTransformChain({ refSchemas: customRefSchemas });
+      const model = createModel(obj({ data: str() }));
+      const source = getFieldNode(model, 'data');
+
+      const result = chain.transform(source, { $ref: 'urn:custom:schema' });
+
+      expect(result.node.isRef()).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('throws error for invalid spec without type or $ref', () => {
+      const model = createModel(obj({ field: str() }));
+      const source = getFieldNode(model, 'field');
+      const chain = new TypeTransformChain();
+
+      expect(() => chain.transform(source, {} as never)).toThrow('No transformer found');
+    });
+  });
+});

--- a/src/model/type-transformer/__tests__/test-helpers.ts
+++ b/src/model/type-transformer/__tests__/test-helpers.ts
@@ -1,0 +1,33 @@
+import { obj, str, num, bool, arr, ref } from '../../../mocks/schema.mocks.js';
+import type { JsonObjectSchema, JsonSchema } from '../../../types/index.js';
+import { createSchemaModel } from '../../schema-model/SchemaModelImpl.js';
+import type { SchemaModel, RefSchemas } from '../../schema-model/types.js';
+import type { SchemaNode } from '../../../core/schema-node/index.js';
+
+export { obj, str, num, bool, arr, ref };
+
+export const createModel = (
+  schema: JsonObjectSchema,
+  refSchemas?: RefSchemas,
+): SchemaModel => {
+  return createSchemaModel(schema, { refSchemas });
+};
+
+export const getFieldNode = (model: SchemaModel, name: string): SchemaNode => {
+  return model.root.property(name);
+};
+
+export const getNestedFieldNode = (
+  model: SchemaModel,
+  parentName: string,
+  childName: string,
+): SchemaNode => {
+  return model.root.property(parentName).property(childName);
+};
+
+export const customRefSchemas: RefSchemas = {
+  'urn:custom:schema': obj({
+    id: str(),
+    value: num(),
+  }) as unknown as JsonSchema,
+};

--- a/src/model/type-transformer/__tests__/transformers.spec.ts
+++ b/src/model/type-transformer/__tests__/transformers.spec.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from '@jest/globals';
+import { PrimitiveToArrayTransformer } from '../transformers/PrimitiveToArrayTransformer.js';
+import { ObjectToArrayTransformer } from '../transformers/ObjectToArrayTransformer.js';
+import { ArrayToItemsTypeTransformer } from '../transformers/ArrayToItemsTypeTransformer.js';
+import { RefTransformer } from '../transformers/RefTransformer.js';
+import { DefaultTransformer } from '../transformers/DefaultTransformer.js';
+import type { TransformContext, PrimitiveTypeName } from '../types.js';
+import { obj, str, num, arr, createModel, getFieldNode } from './test-helpers.js';
+
+describe('PrimitiveToArrayTransformer', () => {
+  const transformer = new PrimitiveToArrayTransformer();
+
+  describe('canTransform', () => {
+    it('returns true for primitive to array', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'array' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(true);
+    });
+
+    it('returns false for object to array', () => {
+      const model = createModel(obj({ field: obj({}) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'array' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+
+    it('returns false for primitive to non-array', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'number' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+  });
+
+  describe('transform', () => {
+    it('preserves source type in items', () => {
+      const model = createModel(obj({ scores: num({ default: 100 }) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'scores'),
+        targetSpec: { type: 'array' },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.items().nodeType()).toBe('number');
+      expect(result.node.items().defaultValue()).toBe(100);
+    });
+  });
+});
+
+describe('ObjectToArrayTransformer', () => {
+  const transformer = new ObjectToArrayTransformer();
+
+  describe('canTransform', () => {
+    it('returns true for object to array', () => {
+      const model = createModel(obj({ field: obj({}) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'array' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(true);
+    });
+
+    it('returns false for primitive to array', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'array' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+  });
+
+  describe('transform', () => {
+    it('preserves object structure in items', () => {
+      const model = createModel(obj({ item: obj({ name: str() }) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'item'),
+        targetSpec: { type: 'array' },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.items().nodeType()).toBe('object');
+      expect(result.node.items().property('name').nodeType()).toBe('string');
+    });
+  });
+});
+
+describe('ArrayToItemsTypeTransformer', () => {
+  const transformer = new ArrayToItemsTypeTransformer();
+
+  describe('canTransform', () => {
+    it('returns true when array items type matches target', () => {
+      const model = createModel(obj({ tags: arr(str()) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'tags'),
+        targetSpec: { type: 'string' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(true);
+    });
+
+    it('returns false when types do not match', () => {
+      const model = createModel(obj({ tags: arr(str()) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'tags'),
+        targetSpec: { type: 'number' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+
+    it('returns false for non-array source', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'string' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+
+    it('returns false for composite target types', () => {
+      const model = createModel(obj({ tags: arr(str()) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'tags'),
+        targetSpec: { type: 'object' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+  });
+
+  describe('transform', () => {
+    it('extracts items node with correct name', () => {
+      const model = createModel(obj({ scores: arr(num()) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'scores'),
+        targetSpec: { type: 'number' },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.nodeType()).toBe('number');
+      expect(result.node.name()).toBe('scores');
+    });
+  });
+});
+
+describe('RefTransformer', () => {
+  const transformer = new RefTransformer();
+
+  describe('canTransform', () => {
+    it('returns true when $ref is present', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { $ref: 'urn:test:schema' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(true);
+    });
+
+    it('returns false when $ref is absent', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'string' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+  });
+
+  describe('transform', () => {
+    it('creates unresolved ref node when schema not found', () => {
+      const model = createModel(obj({ avatar: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'avatar'),
+        targetSpec: { $ref: 'urn:unknown:schema' },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.nodeType()).toBe('ref');
+      expect(result.node.ref()).toBe('urn:unknown:schema');
+    });
+  });
+});
+
+describe('DefaultTransformer', () => {
+  const transformer = new DefaultTransformer();
+
+  describe('canTransform', () => {
+    it('returns true when type is present', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'number' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(true);
+    });
+
+    it('returns false when only $ref is present', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { $ref: 'urn:test' },
+      };
+
+      expect(transformer.canTransform(ctx)).toBe(false);
+    });
+  });
+
+  describe('transform', () => {
+    it.each<[PrimitiveTypeName, string | number | boolean]>([
+      ['string', ''],
+      ['number', 0],
+      ['boolean', false],
+    ])('creates %s with default value %p', (type, expectedDefault) => {
+      const model = createModel(obj({ field: num() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.nodeType()).toBe(type);
+      expect(result.node.defaultValue()).toBe(expectedDefault);
+    });
+
+    it('creates empty object', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'object' },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.nodeType()).toBe('object');
+      expect(result.node.properties()).toHaveLength(0);
+    });
+
+    it('creates array with string items by default', () => {
+      const model = createModel(obj({ field: obj({}) }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'array' },
+      };
+
+      const result = transformer.transform(ctx);
+
+      expect(result.node.nodeType()).toBe('array');
+      expect(result.node.items().nodeType()).toBe('string');
+    });
+
+    it('throws error for unknown type', () => {
+      const model = createModel(obj({ field: str() }));
+      const ctx: TransformContext = {
+        sourceNode: getFieldNode(model, 'field'),
+        targetSpec: { type: 'unknown' as never },
+      };
+
+      expect(() => transformer.transform(ctx)).toThrow('Unknown field type: unknown');
+    });
+  });
+});

--- a/src/model/type-transformer/index.ts
+++ b/src/model/type-transformer/index.ts
@@ -1,0 +1,21 @@
+export type {
+  TypeTransformer,
+  TransformContext,
+  TransformResult,
+  FieldTypeSpec,
+  FieldSchemaSpec,
+  SimpleFieldType,
+  PrimitiveTypeName,
+  CompositeTypeName,
+} from './types.js';
+
+export { TypeTransformChain, createTypeTransformChain } from './TypeTransformChain.js';
+export type { TypeTransformChainOptions } from './TypeTransformChain.js';
+
+export {
+  PrimitiveToArrayTransformer,
+  ObjectToArrayTransformer,
+  ArrayToItemsTypeTransformer,
+  RefTransformer,
+  DefaultTransformer,
+} from './transformers/index.js';

--- a/src/model/type-transformer/transformers/ArrayToItemsTypeTransformer.ts
+++ b/src/model/type-transformer/transformers/ArrayToItemsTypeTransformer.ts
@@ -1,0 +1,29 @@
+import { nanoid } from 'nanoid';
+import type { TypeTransformer, TransformContext, TransformResult, PrimitiveTypeName } from '../types.js';
+
+export class ArrayToItemsTypeTransformer implements TypeTransformer {
+  canTransform(ctx: TransformContext): boolean {
+    const { sourceNode, targetSpec } = ctx;
+    if (!sourceNode.isArray()) {
+      return false;
+    }
+    const targetType = targetSpec.type;
+    if (!targetType || !this.isPrimitiveType(targetType)) {
+      return false;
+    }
+    const items = sourceNode.items();
+    return items.nodeType() === targetType;
+  }
+
+  transform(ctx: TransformContext): TransformResult {
+    const { sourceNode } = ctx;
+    const items = sourceNode.items();
+    const newNode = items.cloneWithId(nanoid());
+    newNode.setName(sourceNode.name());
+    return { node: newNode };
+  }
+
+  private isPrimitiveType(type: string): type is PrimitiveTypeName {
+    return type === 'string' || type === 'number' || type === 'boolean';
+  }
+}

--- a/src/model/type-transformer/transformers/DefaultTransformer.ts
+++ b/src/model/type-transformer/transformers/DefaultTransformer.ts
@@ -1,0 +1,81 @@
+import { nanoid } from 'nanoid';
+import {
+  createObjectNode,
+  createArrayNode,
+  createStringNode,
+  createNumberNode,
+  createBooleanNode,
+} from '../../../core/schema-node/index.js';
+import type { SchemaNode, NodeMetadata } from '../../../core/schema-node/index.js';
+import type { TypeTransformer, TransformContext, TransformResult, SimpleFieldType } from '../types.js';
+
+export class DefaultTransformer implements TypeTransformer {
+  canTransform(ctx: TransformContext): boolean {
+    return ctx.targetSpec.type !== undefined;
+  }
+
+  transform(ctx: TransformContext): TransformResult {
+    const { sourceNode, targetSpec } = ctx;
+    const type = targetSpec.type!;
+    const metadata = this.extractMetadata(targetSpec);
+    const node = this.createNode(sourceNode.name(), type, targetSpec, metadata);
+    return { node };
+  }
+
+  private createNode(
+    name: string,
+    type: SimpleFieldType,
+    spec: TransformContext['targetSpec'],
+    metadata?: NodeMetadata,
+  ): SchemaNode {
+    switch (type) {
+      case 'string':
+        return createStringNode(nanoid(), name, {
+          defaultValue: spec.default as string ?? '',
+          foreignKey: spec.foreignKey,
+          metadata,
+        });
+      case 'number':
+        return createNumberNode(nanoid(), name, {
+          defaultValue: spec.default as number ?? 0,
+          metadata,
+        });
+      case 'boolean':
+        return createBooleanNode(nanoid(), name, {
+          defaultValue: spec.default as boolean ?? false,
+          metadata,
+        });
+      case 'object':
+        return createObjectNode(nanoid(), name, [], { metadata });
+      case 'array':
+        return this.createArrayNode(name, metadata);
+      default:
+        throw new Error(`Unknown field type: ${type}`);
+    }
+  }
+
+  private createArrayNode(name: string, metadata?: NodeMetadata): SchemaNode {
+    const items = createStringNode(nanoid(), 'items', { defaultValue: '' });
+    return createArrayNode(nanoid(), name, items, { metadata });
+  }
+
+  private extractMetadata(spec: TransformContext['targetSpec']): NodeMetadata | undefined {
+    const meta: { title?: string; description?: string; deprecated?: boolean } = {};
+    let hasValue = false;
+
+    if (spec.title) {
+      meta.title = spec.title;
+      hasValue = true;
+    }
+    if (spec.description) {
+      meta.description = spec.description;
+      hasValue = true;
+    }
+    if (spec.deprecated) {
+      meta.deprecated = spec.deprecated;
+      hasValue = true;
+    }
+
+    return hasValue ? meta : undefined;
+  }
+}

--- a/src/model/type-transformer/transformers/ObjectToArrayTransformer.ts
+++ b/src/model/type-transformer/transformers/ObjectToArrayTransformer.ts
@@ -1,0 +1,18 @@
+import { nanoid } from 'nanoid';
+import { createArrayNode } from '../../../core/schema-node/index.js';
+import type { TypeTransformer, TransformContext, TransformResult } from '../types.js';
+
+export class ObjectToArrayTransformer implements TypeTransformer {
+  canTransform(ctx: TransformContext): boolean {
+    const { sourceNode, targetSpec } = ctx;
+    return sourceNode.isObject() && targetSpec.type === 'array';
+  }
+
+  transform(ctx: TransformContext): TransformResult {
+    const { sourceNode } = ctx;
+    const itemsNode = sourceNode.cloneWithId(nanoid());
+    itemsNode.setName('items');
+    const arrayNode = createArrayNode(nanoid(), sourceNode.name(), itemsNode);
+    return { node: arrayNode };
+  }
+}

--- a/src/model/type-transformer/transformers/PrimitiveToArrayTransformer.ts
+++ b/src/model/type-transformer/transformers/PrimitiveToArrayTransformer.ts
@@ -1,0 +1,18 @@
+import { nanoid } from 'nanoid';
+import { createArrayNode } from '../../../core/schema-node/index.js';
+import type { TypeTransformer, TransformContext, TransformResult } from '../types.js';
+
+export class PrimitiveToArrayTransformer implements TypeTransformer {
+  canTransform(ctx: TransformContext): boolean {
+    const { sourceNode, targetSpec } = ctx;
+    return sourceNode.isPrimitive() && targetSpec.type === 'array';
+  }
+
+  transform(ctx: TransformContext): TransformResult {
+    const { sourceNode } = ctx;
+    const itemsNode = sourceNode.cloneWithId(nanoid());
+    itemsNode.setName('items');
+    const arrayNode = createArrayNode(nanoid(), sourceNode.name(), itemsNode);
+    return { node: arrayNode };
+  }
+}

--- a/src/model/type-transformer/transformers/RefTransformer.ts
+++ b/src/model/type-transformer/transformers/RefTransformer.ts
@@ -1,0 +1,51 @@
+import { nanoid } from 'nanoid';
+import { createRefNode } from '../../../core/schema-node/index.js';
+import { obj, ref } from '../../../mocks/schema.mocks.js';
+import type { TypeTransformer, TransformContext, TransformResult } from '../types.js';
+import { SchemaParser } from '../../schema-model/SchemaParser.js';
+
+export class RefTransformer implements TypeTransformer {
+  canTransform(ctx: TransformContext): boolean {
+    return ctx.targetSpec.$ref !== undefined;
+  }
+
+  transform(ctx: TransformContext): TransformResult {
+    const { sourceNode, targetSpec, refSchemas } = ctx;
+    const refUri = targetSpec.$ref!;
+
+    const resolvedSchema = refSchemas?.[refUri];
+    if (resolvedSchema) {
+      const parser = new SchemaParser();
+      const wrapperSchema = obj({ temp: ref(refUri) });
+      const resolvedNode = parser.parse(wrapperSchema, refSchemas);
+      const tempNode = resolvedNode.property('temp');
+      const newNode = tempNode.cloneWithId(nanoid());
+      newNode.setName(sourceNode.name());
+      return { node: newNode };
+    }
+
+    const metadata = this.extractMetadata(targetSpec);
+    const node = createRefNode(nanoid(), sourceNode.name(), refUri, metadata);
+    return { node };
+  }
+
+  private extractMetadata(spec: TransformContext['targetSpec']): { title?: string; description?: string; deprecated?: boolean } | undefined {
+    const meta: { title?: string; description?: string; deprecated?: boolean } = {};
+    let hasValue = false;
+
+    if (spec.title) {
+      meta.title = spec.title;
+      hasValue = true;
+    }
+    if (spec.description) {
+      meta.description = spec.description;
+      hasValue = true;
+    }
+    if (spec.deprecated) {
+      meta.deprecated = spec.deprecated;
+      hasValue = true;
+    }
+
+    return hasValue ? meta : undefined;
+  }
+}

--- a/src/model/type-transformer/transformers/index.ts
+++ b/src/model/type-transformer/transformers/index.ts
@@ -1,0 +1,5 @@
+export { PrimitiveToArrayTransformer } from './PrimitiveToArrayTransformer.js';
+export { ObjectToArrayTransformer } from './ObjectToArrayTransformer.js';
+export { ArrayToItemsTypeTransformer } from './ArrayToItemsTypeTransformer.js';
+export { RefTransformer } from './RefTransformer.js';
+export { DefaultTransformer } from './DefaultTransformer.js';

--- a/src/model/type-transformer/types.ts
+++ b/src/model/type-transformer/types.ts
@@ -1,0 +1,34 @@
+import type { SchemaNode } from '../../core/schema-node/index.js';
+import type { RefSchemas } from '../schema-model/types.js';
+
+export type PrimitiveTypeName = 'string' | 'number' | 'boolean';
+export type CompositeTypeName = 'object' | 'array';
+export type SimpleFieldType = PrimitiveTypeName | CompositeTypeName;
+
+export interface FieldSchemaSpec {
+  type?: SimpleFieldType;
+  $ref?: string;
+  default?: unknown;
+  title?: string;
+  description?: string;
+  deprecated?: boolean;
+  foreignKey?: string;
+  'x-formula'?: { expression: string };
+}
+
+export type FieldTypeSpec = SimpleFieldType | FieldSchemaSpec;
+
+export interface TransformContext {
+  sourceNode: SchemaNode;
+  targetSpec: FieldSchemaSpec;
+  refSchemas?: RefSchemas;
+}
+
+export interface TransformResult {
+  node: SchemaNode;
+}
+
+export interface TypeTransformer {
+  canTransform(ctx: TransformContext): boolean;
+  transform(ctx: TransformContext): TransformResult;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a pluggable type transformation pipeline and upgrades changeFieldType to support smart conversions and $ref resolution, making field type changes more flexible and safer.

- **New Features**
  - changeFieldType now accepts FieldTypeSpec (string or spec object with type, $ref, defaults, metadata, foreignKey).
  - Added TypeTransformChain with built-in transformers: primitive→array, object→array, array→items, $ref, and a default fallback.
  - Supports refSchemas for resolving $ref into object nodes marked as isRef.
  - Allows custom transformers via SchemaModelOptions.customTransformers; type-transformer API is exported.
  - Added cloneWithId to schema nodes to preserve names/metadata during transformations.
  - Updated docs and comprehensive tests for transformers and changeFieldType.

- **Migration**
  - No breaking changes: existing changeFieldType('string' | 'number' | ...) calls still work.
  - To resolve $ref URIs, pass refSchemas in SchemaModel options.
  - To customize behavior, provide customTransformers in SchemaModel options.

<sup>Written for commit 0c2087f994168649826479d3d8b6682412738129. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

