### PR TITLE
feat: insert at

### DIFF
--- a/src/core/schema-node/BaseNode.ts
+++ b/src/core/schema-node/BaseNode.ts
@@ -113,6 +113,10 @@ export abstract class BaseNode implements SchemaNode {
     // No-op by default
   }
 
+  insertChild(_index: number, _node: SchemaNode): void {
+    // No-op by default
+  }
+
   removeChild(_name: string): boolean {
     return false;
   }

--- a/src/core/schema-node/NullNode.ts
+++ b/src/core/schema-node/NullNode.ts
@@ -90,6 +90,10 @@ class NullNodeImpl implements SchemaNode {
     // No-op for null
   }
 
+  insertChild(_index: number, _node: SchemaNode): void {
+    // No-op for null
+  }
+
   removeChild(_name: string): boolean {
     return false;
   }

--- a/src/core/schema-node/ObjectNode.ts
+++ b/src/core/schema-node/ObjectNode.ts
@@ -26,6 +26,7 @@ export class ObjectNode extends BaseNode {
     makeObservable(this, {
       _children: 'observable.shallow',
       addChild: 'action',
+      insertChild: 'action',
       removeChild: 'action',
       replaceChild: 'action',
     });
@@ -67,6 +68,13 @@ export class ObjectNode extends BaseNode {
 
   addChild(node: SchemaNode): void {
     this._children.push(node);
+  }
+
+  insertChild(index: number, node: SchemaNode): void {
+    if (index < 0 || index > this._children.length) {
+      throw new Error(`Index out of bounds: ${index}`);
+    }
+    this._children.splice(index, 0, node);
   }
 
   removeChild(name: string): boolean {

--- a/src/core/schema-node/README.md
+++ b/src/core/schema-node/README.md
@@ -151,5 +151,5 @@ root.setName('newName'); // Triggers autorun
 | All nodes | `_name`, `_metadata` (ref) | `setName`, `setMetadata` |
 | Primitive | + `_formula` (ref), `_defaultValue`, `_foreignKey` | + `setFormula`, `setDefaultValue`, `setForeignKey` |
 | StringNode | + `_contentMediaType` | + `setContentMediaType` |
-| ObjectNode | + `_children` (shallow) | + `addChild`, `removeChild`, `replaceChild` |
+| ObjectNode | + `_children` (shallow) | + `addChild`, `insertChild`, `removeChild`, `replaceChild` |
 | ArrayNode | + `_items` (ref) | + `setItems` |

--- a/src/core/schema-node/__tests__/NullNode.spec.ts
+++ b/src/core/schema-node/__tests__/NullNode.spec.ts
@@ -90,5 +90,10 @@ describe('NULL_NODE', () => {
       NULL_NODE.setForeignKey('users');
       expect(NULL_NODE.foreignKey()).toBeUndefined();
     });
+
+    it('insertChild does nothing', () => {
+      NULL_NODE.insertChild(0, NULL_NODE);
+      expect(NULL_NODE.properties()).toHaveLength(0);
+    });
   });
 });

--- a/src/core/schema-node/__tests__/ObjectNode.spec.ts
+++ b/src/core/schema-node/__tests__/ObjectNode.spec.ts
@@ -186,5 +186,74 @@ describe('ObjectNode', () => {
 
       expect(node.foreignKey()).toBeUndefined();
     });
+
+    describe('insertChild', () => {
+      it('inserts at beginning', () => {
+        const child1 = createStringNode('str-1', 'name');
+        const child2 = createNumberNode('num-1', 'age');
+        const node = createObjectNode('obj-1', 'user', [child1, child2]);
+        const newChild = createStringNode('str-2', 'email');
+
+        node.insertChild(0, newChild);
+
+        expect(node.properties()).toHaveLength(3);
+        expect(node.properties()[0]).toBe(newChild);
+        expect(node.properties()[1]).toBe(child1);
+        expect(node.properties()[2]).toBe(child2);
+      });
+
+      it('inserts in middle', () => {
+        const child1 = createStringNode('str-1', 'name');
+        const child2 = createNumberNode('num-1', 'age');
+        const node = createObjectNode('obj-1', 'user', [child1, child2]);
+        const newChild = createStringNode('str-2', 'email');
+
+        node.insertChild(1, newChild);
+
+        expect(node.properties()).toHaveLength(3);
+        expect(node.properties()[0]).toBe(child1);
+        expect(node.properties()[1]).toBe(newChild);
+        expect(node.properties()[2]).toBe(child2);
+      });
+
+      it('inserts at end', () => {
+        const child1 = createStringNode('str-1', 'name');
+        const child2 = createNumberNode('num-1', 'age');
+        const node = createObjectNode('obj-1', 'user', [child1, child2]);
+        const newChild = createStringNode('str-2', 'email');
+
+        node.insertChild(2, newChild);
+
+        expect(node.properties()).toHaveLength(3);
+        expect(node.properties()[0]).toBe(child1);
+        expect(node.properties()[1]).toBe(child2);
+        expect(node.properties()[2]).toBe(newChild);
+      });
+
+      it('inserts into empty children', () => {
+        const node = createObjectNode('obj-1', 'user');
+        const newChild = createStringNode('str-1', 'name');
+
+        node.insertChild(0, newChild);
+
+        expect(node.properties()).toHaveLength(1);
+        expect(node.properties()[0]).toBe(newChild);
+      });
+
+      it('throws for negative index', () => {
+        const node = createObjectNode('obj-1', 'user');
+        const newChild = createStringNode('str-1', 'name');
+
+        expect(() => node.insertChild(-1, newChild)).toThrow('Index out of bounds: -1');
+      });
+
+      it('throws for index greater than length', () => {
+        const child = createStringNode('str-1', 'name');
+        const node = createObjectNode('obj-1', 'user', [child]);
+        const newChild = createStringNode('str-2', 'email');
+
+        expect(() => node.insertChild(2, newChild)).toThrow('Index out of bounds: 2');
+      });
+    });
   });
 });

--- a/src/core/schema-node/types.ts
+++ b/src/core/schema-node/types.ts
@@ -48,6 +48,7 @@ export interface SchemaNode {
   setName(name: string): void;
   setMetadata(metadata: NodeMetadata): void;
   addChild(node: SchemaNode): void;
+  insertChild(index: number, node: SchemaNode): void;
   removeChild(name: string): boolean;
   replaceChild(name: string, node: SchemaNode): boolean;
   setItems(node: SchemaNode): void;

--- a/src/core/schema-tree/README.md
+++ b/src/core/schema-tree/README.md
@@ -13,6 +13,9 @@ interface SchemaTree {
   nodeIds(): IterableIterator<string>;
   countNodes(): number;
   clone(): SchemaTree;
+
+  addChildTo(parentId: string, node: SchemaNode): void;
+  insertChildAt(parentId: string, index: number, node: SchemaNode): void;
 }
 ```
 

--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -94,6 +94,20 @@ export class SchemaTreeImpl implements SchemaTree {
     this.rebuildIndex();
   }
 
+  insertChildAt(parentId: string, index: number, node: SchemaNode): void {
+    const parent = this.nodeById(parentId);
+    if (parent.isNull()) {
+      return;
+    }
+
+    if (parent.isArray()) {
+      throw new Error('Cannot add child to array node. Use setItems instead.');
+    }
+
+    parent.insertChild(index, node);
+    this.rebuildIndex();
+  }
+
   removeNodeAt(path: Path): boolean {
     if (path.isEmpty()) {
       return false;

--- a/src/core/schema-tree/__tests__/SchemaTree.spec.ts
+++ b/src/core/schema-tree/__tests__/SchemaTree.spec.ts
@@ -329,6 +329,69 @@ describe('SchemaTree mutations', () => {
     });
   });
 
+  describe('insertChildAt', () => {
+    it('inserts child at index in object node', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const ageNode = createNumberNode('age-id', 'age');
+      const root = createObjectNode('root-id', 'root', [nameNode, ageNode]);
+      const tree = createSchemaTree(root);
+      const newNode = createStringNode('new-id', 'email');
+
+      tree.insertChildAt('root-id', 0, newNode);
+
+      expect(tree.nodeById('new-id')).toBe(newNode);
+      expect(tree.pathOf('new-id').asJsonPointer()).toBe('/properties/email');
+      expect(tree.root().properties()[0]).toBe(newNode);
+      expect(tree.root().properties()[1]).toBe(nameNode);
+      expect(tree.root().properties()[2]).toBe(ageNode);
+    });
+
+    it('inserts child at end', () => {
+      const nameNode = createStringNode('name-id', 'name');
+      const root = createObjectNode('root-id', 'root', [nameNode]);
+      const tree = createSchemaTree(root);
+      const newNode = createStringNode('new-id', 'email');
+
+      tree.insertChildAt('root-id', 1, newNode);
+
+      expect(tree.root().properties()[0]).toBe(nameNode);
+      expect(tree.root().properties()[1]).toBe(newNode);
+    });
+
+    it('does nothing when parent not found', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+      const newNode = createStringNode('new-id', 'newField');
+
+      tree.insertChildAt('unknown-id', 0, newNode);
+
+      expect(tree.nodeById('new-id')).toBe(NULL_NODE);
+    });
+
+    it('throws error when inserting into array node', () => {
+      const itemNode = createStringNode('item-id', 'item');
+      const arrayNode = createArrayNode('array-id', 'items', itemNode);
+      const root = createObjectNode('root-id', 'root', [arrayNode]);
+      const tree = createSchemaTree(root);
+      const newNode = createStringNode('new-id', 'newField');
+
+      expect(() => tree.insertChildAt('array-id', 0, newNode)).toThrow(
+        'Cannot add child to array node. Use setItems instead.',
+      );
+    });
+
+    it('rebuilds index after insert', () => {
+      const root = createObjectNode('root-id', 'root');
+      const tree = createSchemaTree(root);
+      const newNode = createStringNode('new-id', 'field');
+
+      tree.insertChildAt('root-id', 0, newNode);
+
+      expect(tree.countNodes()).toBe(2);
+      expect(tree.nodeById('new-id')).toBe(newNode);
+    });
+  });
+
   describe('removeNodeAt', () => {
     it('removes node at path', () => {
       const nameNode = createStringNode('name-id', 'name');

--- a/src/core/schema-tree/types.ts
+++ b/src/core/schema-tree/types.ts
@@ -13,6 +13,7 @@ export interface SchemaTree {
   replacements(): IterableIterator<[string, string]>;
 
   addChildTo(parentId: string, node: SchemaNode): void;
+  insertChildAt(parentId: string, index: number, node: SchemaNode): void;
   removeNodeAt(path: Path): boolean;
   renameNode(nodeId: string, newName: string): void;
   moveNode(nodeId: string, newParentId: string): void;

--- a/src/model/schema-model/README.md
+++ b/src/model/schema-model/README.md
@@ -62,8 +62,11 @@ const path = model.pathOf('node-id');
 ### Mutations
 
 ```typescript
-// Add field
+// Add field (appends to end)
 const newField = model.addField(parentId, 'email', 'string');
+
+// Insert field at specific position
+const inserted = model.insertFieldAt(parentId, 0, 'id', 'string');
 
 // Remove field
 model.removeField(nodeId);
@@ -232,12 +235,14 @@ See `core/schema-node/README.md` for the full list of observable fields per node
 
 ## Field Types
 
-Supported field types for `addField`:
+Supported field types for `addField` and `insertFieldAt`:
 - `'string'` - String field with default `''`
 - `'number'` - Number field with default `0`
 - `'boolean'` - Boolean field with default `false`
 - `'object'` - Empty object
 - `'array'` - Array with string items
+
+`insertFieldAt(parentId, index, name, type)` inserts at a specific position (`0` = beginning, `length` = end). Returns `NULL_NODE` if parent is not an object or index is out of bounds.
 
 ## changeFieldType API
 

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -1,4 +1,5 @@
 import type { SchemaNode, NodeMetadata } from '../../core/schema-node/index.js';
+import { NULL_NODE } from '../../core/schema-node/index.js';
 import type { SchemaTree } from '../../core/schema-tree/index.js';
 import { createSchemaTree } from '../../core/schema-tree/index.js';
 import type { Path, PathSegment } from '../../core/path/index.js';
@@ -72,6 +73,16 @@ export class SchemaModelImpl implements SchemaModel {
   addField(parentId: string, name: string, type: FieldType): SchemaNode {
     const node = this._nodeFactory.createNode(name, type);
     this._currentTree.addChildTo(parentId, node);
+    return node;
+  }
+
+  insertFieldAt(parentId: string, index: number, name: string, type: FieldType): SchemaNode {
+    const parent = this._currentTree.nodeById(parentId);
+    if (parent.isNull() || !parent.isObject()) {
+      return NULL_NODE;
+    }
+    const node = this._nodeFactory.createNode(name, type);
+    this._currentTree.insertChildAt(parentId, index, node);
     return node;
   }
 

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -81,6 +81,9 @@ export class SchemaModelImpl implements SchemaModel {
     if (parent.isNull() || !parent.isObject()) {
       return NULL_NODE;
     }
+    if (index < 0 || index > parent.properties().length) {
+      return NULL_NODE;
+    }
     const node = this._nodeFactory.createNode(name, type);
     this._currentTree.insertChildAt(parentId, index, node);
     return node;

--- a/src/model/schema-model/__tests__/SchemaModel.mutations.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.mutations.spec.ts
@@ -327,6 +327,26 @@ describe('SchemaModel mutations', () => {
       expect(model.root.properties()[3]?.name()).toBe('second');
     });
 
+    it('returns null node for negative index', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root.id();
+
+      const result = model.insertFieldAt(rootId, -1, 'field', 'string');
+
+      expect(result.isNull()).toBe(true);
+      expect(model.root.properties()).toHaveLength(2);
+    });
+
+    it('returns null node for index beyond length', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root.id();
+
+      const result = model.insertFieldAt(rootId, 10, 'field', 'string');
+
+      expect(result.isNull()).toBe(true);
+      expect(model.root.properties()).toHaveLength(2);
+    });
+
     it('supports all field types', () => {
       const model = createSchemaModel(emptySchema());
       const rootId = model.root.id();

--- a/src/model/schema-model/__tests__/SchemaModel.mutations.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.mutations.spec.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from '@jest/globals';
 import { serializeAst } from '@revisium/formula';
 import { createSchemaModel } from '../SchemaModelImpl.js';
 import {
+  emptySchema,
   simpleSchema,
+  nestedSchema,
+  arraySchema,
   schemaWithFormula,
   schemaWithForeignKey,
   schemaWithMetadata,
@@ -215,6 +218,126 @@ describe('SchemaModel mutations', () => {
       model.updateDefaultValue('unknown-id', 'test');
 
       expect(model.isDirty).toBe(false);
+    });
+  });
+
+  describe('insertFieldAt', () => {
+    it('inserts at beginning', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root.id();
+
+      const node = model.insertFieldAt(rootId, 0, 'email', 'string');
+
+      expect(node.isNull()).toBe(false);
+      expect(node.name()).toBe('email');
+      expect(node.nodeType()).toBe('string');
+      expect(model.root.properties()).toHaveLength(3);
+      expect(model.root.properties()[0]?.name()).toBe('email');
+      expect(model.root.properties()[1]?.name()).toBe('age');
+      expect(model.root.properties()[2]?.name()).toBe('name');
+    });
+
+    it('inserts in middle', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root.id();
+
+      model.insertFieldAt(rootId, 1, 'email', 'string');
+
+      expect(model.root.properties()).toHaveLength(3);
+      expect(model.root.properties()[0]?.name()).toBe('age');
+      expect(model.root.properties()[1]?.name()).toBe('email');
+      expect(model.root.properties()[2]?.name()).toBe('name');
+    });
+
+    it('inserts at end behaves like addField', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root.id();
+
+      model.insertFieldAt(rootId, 2, 'email', 'string');
+
+      expect(model.root.properties()).toHaveLength(3);
+      expect(model.root.properties()[0]?.name()).toBe('age');
+      expect(model.root.properties()[1]?.name()).toBe('name');
+      expect(model.root.properties()[2]?.name()).toBe('email');
+    });
+
+    it('inserts into nested object', () => {
+      const model = createSchemaModel(nestedSchema());
+      const userId = model.root.property('user').id();
+
+      model.insertFieldAt(userId, 0, 'email', 'string');
+
+      const user = model.root.property('user');
+      expect(user.properties()).toHaveLength(3);
+      expect(user.properties()[0]?.name()).toBe('email');
+      expect(user.properties()[1]?.name()).toBe('firstName');
+      expect(user.properties()[2]?.name()).toBe('lastName');
+    });
+
+    it('returns null node for non-object parent', () => {
+      const model = createSchemaModel(arraySchema());
+      const itemsId = model.root.property('items').id();
+
+      const result = model.insertFieldAt(itemsId, 0, 'field', 'string');
+
+      expect(result.isNull()).toBe(true);
+    });
+
+    it('returns null node for unknown parent', () => {
+      const model = createSchemaModel(simpleSchema());
+
+      const result = model.insertFieldAt('unknown-id', 0, 'field', 'string');
+
+      expect(result.isNull()).toBe(true);
+    });
+
+    it('sets isDirty to true', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root.id();
+
+      expect(model.isDirty).toBe(false);
+
+      model.insertFieldAt(rootId, 0, 'field', 'string');
+
+      expect(model.isDirty).toBe(true);
+    });
+
+    it('generates patches', () => {
+      const model = createSchemaModel(simpleSchema());
+      const rootId = model.root.id();
+
+      model.insertFieldAt(rootId, 0, 'email', 'string');
+
+      expect(model.patches).toMatchSnapshot();
+    });
+
+    it('maintains order with multiple inserts', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root.id();
+
+      model.insertFieldAt(rootId, 0, 'first', 'string');
+      model.insertFieldAt(rootId, 0, 'zeroth', 'number');
+      model.insertFieldAt(rootId, 2, 'second', 'boolean');
+      model.insertFieldAt(rootId, 1, 'between', 'string');
+
+      expect(model.root.properties()).toHaveLength(4);
+      expect(model.root.properties()[0]?.name()).toBe('zeroth');
+      expect(model.root.properties()[1]?.name()).toBe('between');
+      expect(model.root.properties()[2]?.name()).toBe('first');
+      expect(model.root.properties()[3]?.name()).toBe('second');
+    });
+
+    it('supports all field types', () => {
+      const model = createSchemaModel(emptySchema());
+      const rootId = model.root.id();
+
+      model.insertFieldAt(rootId, 0, 'obj', 'object');
+      model.insertFieldAt(rootId, 1, 'arr', 'array');
+      model.insertFieldAt(rootId, 2, 'bool', 'boolean');
+
+      expect(model.root.properties()[0]?.isObject()).toBe(true);
+      expect(model.root.properties()[1]?.isArray()).toBe(true);
+      expect(model.root.properties()[2]?.nodeType()).toBe('boolean');
     });
   });
 });

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.mutations.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.mutations.spec.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SchemaModel mutations insertFieldAt generates patches 1`] = `
+[
+  {
+    "defaultChange": {
+      "fromDefault": undefined,
+      "toDefault": "",
+    },
+    "fieldName": "email",
+    "metadataChanges": [
+      "default",
+    ],
+    "patch": {
+      "op": "add",
+      "path": "/properties/email",
+      "value": {
+        "default": "",
+        "type": "string",
+      },
+    },
+  },
+]
+`;

--- a/src/model/schema-model/types.ts
+++ b/src/model/schema-model/types.ts
@@ -33,6 +33,7 @@ export interface SchemaModel {
   pathOf(id: string): Path;
 
   addField(parentId: string, name: string, type: FieldType): SchemaNode;
+  insertFieldAt(parentId: string, index: number, name: string, type: FieldType): SchemaNode;
   removeField(nodeId: string): boolean;
   renameField(nodeId: string, newName: string): void;
   changeFieldType(nodeId: string, newType: FieldTypeSpec): SchemaNode;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds index-based insertion for object fields across nodes, tree, and model, so you can place new fields at exact positions. This improves control over field order without manual reordering.

- **New Features**
  - ObjectNode: insertChild(index, node) with bounds checks; supports begin/middle/end; raises “Index out of bounds” on invalid index.
  - BaseNode/NullNode: insertChild is a no-op.
  - SchemaTree: insertChildAt(parentId, index, node); no-op if parent not found; throws when parent is an array (use setItems); rebuilds index after insert.
  - SchemaModel: insertFieldAt(parentId, index, name, type); returns NULL_NODE for unknown or non-object parents or out-of-bounds index; marks model dirty and emits patches.
  - Docs/tests: READMEs updated with examples; comprehensive unit tests added.

<sup>Written for commit e23c707aaf901e43a7cf6a46949dd255d3f2891e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

