### PR TITLE
feat: patch changes

### DIFF
--- a/src/core/schema-diff/__tests__/SchemaDiff.spec.ts
+++ b/src/core/schema-diff/__tests__/SchemaDiff.spec.ts
@@ -6,6 +6,7 @@ import {
   createStringNode,
   createNumberNode,
 } from '../../schema-node/index.js';
+import type { SchemaPatch, PropertyName } from '../../schema-patch/index.js';
 import { PatchBuilder } from '../../schema-patch/index.js';
 import {
   resetIdCounter,
@@ -16,6 +17,11 @@ import {
 } from './test-helpers.js';
 
 const builder = new PatchBuilder();
+
+const findPropertyChange = (
+  patch: SchemaPatch | undefined,
+  property: PropertyName,
+) => patch?.propertyChanges.find((c) => c.property === property);
 
 describe('SchemaDiff', () => {
   describe('isDirty', () => {
@@ -154,9 +160,10 @@ describe('SchemaDiff', () => {
         fieldName: 'computed',
         patch: { op: 'replace', path: '/properties/computed' },
       });
-      expect(patch?.formulaChange).toMatchObject({
-        fromFormula: 'value * 2',
-        toFormula: undefined,
+      const formulaChange = findPropertyChange(patch, 'formula');
+      expect(formulaChange).toMatchObject({
+        from: 'value * 2',
+        to: undefined,
       });
     });
 
@@ -179,9 +186,10 @@ describe('SchemaDiff', () => {
         fieldName: 'computed',
         patch: { op: 'replace', path: '/properties/computed' },
       });
-      expect(patch?.formulaChange).toMatchObject({
-        fromFormula: undefined,
-        toFormula: 'value * 2',
+      const formulaChange = findPropertyChange(patch, 'formula');
+      expect(formulaChange).toMatchObject({
+        from: undefined,
+        to: 'value * 2',
       });
     });
 
@@ -204,9 +212,10 @@ describe('SchemaDiff', () => {
         fieldName: 'computed',
         patch: { op: 'replace', path: '/properties/computed' },
       });
-      expect(patch?.formulaChange).toMatchObject({
-        fromFormula: 'value * 2',
-        toFormula: 'value * 3',
+      const formulaChange = findPropertyChange(patch, 'formula');
+      expect(formulaChange).toMatchObject({
+        from: 'value * 2',
+        to: 'value * 3',
       });
     });
 
@@ -230,9 +239,10 @@ describe('SchemaDiff', () => {
         fieldName: 'computed',
         patch: { op: 'add', path: '/properties/computed' },
       });
-      expect(patch?.formulaChange).toMatchObject({
-        fromFormula: undefined,
-        toFormula: 'value * 2',
+      const formulaChange = findPropertyChange(patch, 'formula');
+      expect(formulaChange).toMatchObject({
+        from: undefined,
+        to: 'value * 2',
       });
     });
 
@@ -254,10 +264,12 @@ describe('SchemaDiff', () => {
         fieldName: 'computed',
         patch: { op: 'replace', path: '/properties/computed' },
       });
-      expect(patch?.formulaChange).toBeUndefined();
-      expect(patch?.defaultChange).toMatchObject({
-        fromDefault: 0,
-        toDefault: 100,
+      const formulaChange = findPropertyChange(patch, 'formula');
+      expect(formulaChange).toBeUndefined();
+      const defaultChange = findPropertyChange(patch, 'default');
+      expect(defaultChange).toMatchObject({
+        from: 0,
+        to: 100,
       });
     });
   });

--- a/src/core/schema-patch/PatchEnricher.ts
+++ b/src/core/schema-patch/PatchEnricher.ts
@@ -157,7 +157,7 @@ export class PatchEnricher {
     const result: PropertyChange[] = [];
 
     for (const extractor of this.extractors) {
-      if (skipSet && skipSet.includes(extractor.property)) {
+      if (skipSet?.includes(extractor.property)) {
         continue;
       }
 

--- a/src/core/schema-patch/PatchEnricher.ts
+++ b/src/core/schema-patch/PatchEnricher.ts
@@ -1,10 +1,16 @@
-import type { SchemaNode, Formula } from '../schema-node/index.js';
+import type { SchemaNode } from '../schema-node/index.js';
 import type { SchemaTree } from '../schema-tree/index.js';
 import type { Path } from '../path/index.js';
 import { jsonPointerToPath } from '../path/index.js';
 import { FormulaSerializer } from '../../model/schema-formula/serialization/FormulaSerializer.js';
 import type { JsonPatchMove } from '../../types/index.js';
-import type { DefaultValueType, JsonPatch, MetadataChangeType, SchemaPatch } from './types.js';
+import type { DefaultValueType, JsonPatch, PropertyChange, PropertyName, SchemaPatch } from './types.js';
+
+interface PropertyExtractor {
+  property: PropertyName;
+  extract: (node: SchemaNode | null, tree: SchemaTree) => unknown;
+  compare?: (from: unknown, to: unknown) => boolean;
+}
 
 function isPrimitiveDefault(value: unknown): value is string | number | boolean {
   const type = typeof value;
@@ -12,10 +18,14 @@ function isPrimitiveDefault(value: unknown): value is string | number | boolean 
 }
 
 export class PatchEnricher {
+  private readonly extractors: PropertyExtractor[];
+
   constructor(
     private readonly currentTree: SchemaTree,
     private readonly baseTree: SchemaTree,
-  ) {}
+  ) {
+    this.extractors = this.buildExtractors();
+  }
 
   enrich(patch: JsonPatch): SchemaPatch {
     const fieldName = this.getFieldNameFromPath(patch.path);
@@ -39,20 +49,15 @@ export class PatchEnricher {
     const currentNode = this.getNodeAtPath(this.currentTree, patch.path);
 
     if (!currentNode) {
-      return { patch, fieldName, metadataChanges: [] };
+      return { patch, fieldName, propertyChanges: [] };
     }
 
-    const metadata = this.computeAddMetadata(currentNode);
-    return {
-      patch,
-      fieldName,
-      metadataChanges: this.computeMetadataChanges(metadata),
-      ...metadata,
-    };
+    const propertyChanges = this.computeAddPropertyChanges(currentNode);
+    return { patch, fieldName, propertyChanges };
   }
 
   private enrichRemovePatch(patch: JsonPatch, fieldName: string): SchemaPatch {
-    return { patch, fieldName, metadataChanges: [] };
+    return { patch, fieldName, propertyChanges: [] };
   }
 
   private enrichMovePatch(patch: JsonPatchMove, fieldName: string): SchemaPatch {
@@ -63,19 +68,14 @@ export class PatchEnricher {
     const baseNode = this.getNodeAtPath(this.baseTree, fromPath);
     const currentNode = this.getNodeAtPath(this.currentTree, patch.path);
 
-    const formulaChange = this.computeFormulaChange(baseNode, currentNode);
-    const metadataChanges: MetadataChangeType[] = [];
-    if (formulaChange) {
-      metadataChanges.push('formula');
-    }
+    const propertyChanges = this.computePropertyChanges(baseNode, currentNode);
 
     return {
       patch,
       fieldName,
-      metadataChanges,
+      propertyChanges,
       isRename: isRename || undefined,
       movesIntoArray: movesIntoArray || undefined,
-      formulaChange,
     };
   }
 
@@ -85,93 +85,100 @@ export class PatchEnricher {
 
     const isArrayMetadataPatch = baseNode?.isArray() && currentNode?.isArray();
 
-    const formulaChange = this.computeFormulaChange(baseNode, currentNode);
-    const defaultChange = isArrayMetadataPatch
-      ? undefined
-      : this.computeDefaultChange(baseNode, currentNode);
-    const descriptionChange = this.computeDescriptionChange(baseNode, currentNode);
-    const deprecatedChange = this.computeDeprecatedChange(baseNode, currentNode);
-    const foreignKeyChange = this.computeForeignKeyChange(baseNode, currentNode);
-    const contentMediaTypeChange = this.computeContentMediaTypeChange(baseNode, currentNode);
+    const skipProperties: PropertyName[] = isArrayMetadataPatch ? ['default'] : [];
 
-    const metadataChanges = this.computeMetadataChanges({
-      formulaChange,
-      defaultChange,
-      descriptionChange,
-      deprecatedChange,
-      foreignKeyChange,
-      contentMediaTypeChange,
-    });
+    const propertyChanges = this.computePropertyChanges(
+      baseNode,
+      currentNode,
+      { skipProperties },
+    );
 
     return {
       patch,
       fieldName,
-      metadataChanges,
+      propertyChanges,
       typeChange: this.computeTypeChange(baseNode, currentNode, isArrayMetadataPatch),
-      formulaChange,
-      defaultChange,
-      descriptionChange,
-      deprecatedChange,
-      foreignKeyChange,
-      contentMediaTypeChange,
     };
   }
 
-  private computeAddMetadata(
-    node: SchemaNode,
-  ): Partial<SchemaPatch> {
-    const result: Partial<SchemaPatch> = {};
+  private buildExtractors(): PropertyExtractor[] {
+    return [
+      {
+        property: 'formula',
+        extract: (node, tree) => {
+          const formula = node?.formula();
+          if (!formula || !node) {
+            return undefined;
+          }
+          return FormulaSerializer.serializeExpression(tree, node.id(), formula, { strict: false });
+        },
+        compare: (from, to) => from === to,
+      },
+      {
+        property: 'default',
+        extract: (node) => {
+          const value = node?.defaultValue();
+          return isPrimitiveDefault(value) ? value as DefaultValueType : undefined;
+        },
+      },
+      {
+        property: 'description',
+        extract: (node) => node?.metadata().description,
+      },
+      {
+        property: 'deprecated',
+        extract: (node) => node?.metadata().deprecated,
+      },
+      {
+        property: 'foreignKey',
+        extract: (node) => node?.foreignKey(),
+      },
+      {
+        property: 'contentMediaType',
+        extract: (node) => node?.contentMediaType(),
+      },
+      {
+        property: 'ref',
+        extract: (node) => node?.ref(),
+      },
+      {
+        property: 'title',
+        extract: (node) => node?.metadata().title,
+      },
+    ];
+  }
 
-    const formula = node.formula();
-    if (formula) {
-      result.formulaChange = {
-        fromFormula: undefined,
-        toFormula: this.getFormulaExpression(formula, this.currentTree, node.id()),
-        fromVersion: undefined,
-        toVersion: formula.version(),
-      };
-    }
+  private computePropertyChanges(
+    baseNode: SchemaNode | null,
+    currentNode: SchemaNode | null,
+    options?: { skipProperties?: PropertyName[] },
+  ): PropertyChange[] {
+    const skipSet = options?.skipProperties;
+    const result: PropertyChange[] = [];
 
-    const defaultValue = node.defaultValue();
-    if (defaultValue !== undefined && isPrimitiveDefault(defaultValue)) {
-      result.defaultChange = {
-        fromDefault: undefined,
-        toDefault: defaultValue,
-      };
-    }
+    for (const extractor of this.extractors) {
+      if (skipSet && skipSet.includes(extractor.property)) {
+        continue;
+      }
 
-    const meta = node.metadata();
-    if (meta.description) {
-      result.descriptionChange = {
-        fromDescription: undefined,
-        toDescription: meta.description,
-      };
-    }
+      const from = extractor.extract(baseNode, this.baseTree);
+      const to = extractor.extract(currentNode, this.currentTree);
 
-    if (meta.deprecated) {
-      result.deprecatedChange = {
-        fromDeprecated: undefined,
-        toDeprecated: meta.deprecated,
-      };
-    }
+      const areEqual = extractor.compare
+        ? extractor.compare(from, to)
+        : from === to;
 
-    const foreignKey = node.foreignKey();
-    if (foreignKey) {
-      result.foreignKeyChange = {
-        fromForeignKey: undefined,
-        toForeignKey: foreignKey,
-      };
-    }
-
-    const contentMediaType = node.contentMediaType();
-    if (contentMediaType) {
-      result.contentMediaTypeChange = {
-        fromContentMediaType: undefined,
-        toContentMediaType: contentMediaType,
-      };
+      if (!areEqual) {
+        result.push({ property: extractor.property, from, to });
+      }
     }
 
     return result;
+  }
+
+  private computeAddPropertyChanges(node: SchemaNode): PropertyChange[] {
+    const allChanges = this.computePropertyChanges(null, node);
+    return allChanges.filter((change) => change.to !== undefined);
   }
 
   private computeTypeChange(
@@ -199,152 +206,6 @@ export class PatchEnricher {
     }
 
     return undefined;
-  }
-
-  private computeFormulaChange(
-    baseNode: SchemaNode | null,
-    currentNode: SchemaNode | null,
-  ): SchemaPatch['formulaChange'] {
-    const baseFormula = baseNode?.formula();
-    const currentFormula = currentNode?.formula();
-
-    const baseExpr = baseFormula && baseNode
-      ? this.getFormulaExpression(baseFormula, this.baseTree, baseNode.id())
-      : undefined;
-    const currentExpr = currentFormula && currentNode
-      ? this.getFormulaExpression(currentFormula, this.currentTree, currentNode.id())
-      : undefined;
-    const baseVersion = baseFormula?.version();
-    const currentVersion = currentFormula?.version();
-
-    if (baseExpr !== currentExpr || baseVersion !== currentVersion) {
-      return {
-        fromFormula: baseExpr,
-        toFormula: currentExpr,
-        fromVersion: baseVersion,
-        toVersion: currentVersion,
-      };
-    }
-
-    return undefined;
-  }
-
-  private getFormulaExpression(
-    formula: Formula,
-    tree: SchemaTree,
-    nodeId: string,
-  ): string {
-    return FormulaSerializer.serializeExpression(tree, nodeId, formula, { strict: false });
-  }
-
-  private computeDefaultChange(
-    baseNode: SchemaNode | null,
-    currentNode: SchemaNode | null,
-  ): SchemaPatch['defaultChange'] {
-    const baseDefault = baseNode?.defaultValue();
-    const currentDefault = currentNode?.defaultValue();
-
-    const safeBaseDefault: DefaultValueType = isPrimitiveDefault(baseDefault)
-      ? baseDefault
-      : undefined;
-    const safeCurrentDefault: DefaultValueType = isPrimitiveDefault(
-      currentDefault,
-    )
-      ? currentDefault
-      : undefined;
-
-    if (safeBaseDefault !== safeCurrentDefault) {
-      return {
-        fromDefault: safeBaseDefault,
-        toDefault: safeCurrentDefault,
-      };
-    }
-
-    return undefined;
-  }
-
-  private computeDescriptionChange(
-    baseNode: SchemaNode | null,
-    currentNode: SchemaNode | null,
-  ): SchemaPatch['descriptionChange'] {
-    const baseDesc = baseNode?.metadata().description;
-    const currentDesc = currentNode?.metadata().description;
-
-    if (baseDesc !== currentDesc) {
-      return { fromDescription: baseDesc, toDescription: currentDesc };
-    }
-
-    return undefined;
-  }
-
-  private computeDeprecatedChange(
-    baseNode: SchemaNode | null,
-    currentNode: SchemaNode | null,
-  ): SchemaPatch['deprecatedChange'] {
-    const baseDeprecated = baseNode?.metadata().deprecated;
-    const currentDeprecated = currentNode?.metadata().deprecated;
-
-    if (baseDeprecated !== currentDeprecated) {
-      return { fromDeprecated: baseDeprecated, toDeprecated: currentDeprecated };
-    }
-
-    return undefined;
-  }
-
-  private computeForeignKeyChange(
-    baseNode: SchemaNode | null,
-    currentNode: SchemaNode | null,
-  ): SchemaPatch['foreignKeyChange'] {
-    const baseFk = baseNode?.foreignKey();
-    const currentFk = currentNode?.foreignKey();
-
-    if (baseFk !== currentFk) {
-      return { fromForeignKey: baseFk, toForeignKey: currentFk };
-    }
-
-    return undefined;
-  }
-
-  private computeContentMediaTypeChange(
-    baseNode: SchemaNode | null,
-    currentNode: SchemaNode | null,
-  ): SchemaPatch['contentMediaTypeChange'] {
-    const baseMediaType = baseNode?.contentMediaType();
-    const currentMediaType = currentNode?.contentMediaType();
-
-    if (baseMediaType !== currentMediaType) {
-      return {
-        fromContentMediaType: baseMediaType,
-        toContentMediaType: currentMediaType,
-      };
-    }
-
-    return undefined;
-  }
-
-  private computeMetadataChanges(changes: Partial<SchemaPatch>): MetadataChangeType[] {
-    const result: MetadataChangeType[] = [];
-
-    if (changes.formulaChange) {
-      result.push('formula');
-    }
-    if (changes.defaultChange) {
-      result.push('default');
-    }
-    if (changes.descriptionChange) {
-      result.push('description');
-    }
-    if (changes.deprecatedChange) {
-      result.push('deprecated');
-    }
-    if (changes.foreignKeyChange) {
-      result.push('foreignKey');
-    }
-    if (changes.contentMediaTypeChange) {
-      result.push('contentMediaType');
-    }
-
-    return result;
   }
 
   private getNodeType(node: SchemaNode): string {

--- a/src/core/schema-patch/README.md
+++ b/src/core/schema-patch/README.md
@@ -119,7 +119,7 @@ For add patches, `from` is always `undefined`. For replace patches, both `from` 
 
 ## Pipeline
 
-```
+```text
 SchemaTree (current) + SchemaTree (base)
     |
 ChangeCollector -> RawChange[]

--- a/src/core/schema-patch/__tests__/PatchEnricher.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchEnricher.spec.ts
@@ -8,6 +8,7 @@ import {
   arr,
   str,
   num,
+  ref,
   createMockFormula,
 } from './test-helpers.js';
 import type { JsonPatch } from '../types.js';
@@ -128,6 +129,18 @@ describe('PatchEnricher', () => {
       const { base, current } = treePair(
         objRoot([]),
         objRoot([str('avatar', { contentMediaType: 'text/plain' })]),
+      );
+
+      const enricher = new PatchEnricher(current, base);
+      const patch = { op: 'add', path: '/properties/avatar' } as JsonPatch;
+
+      expect(enricher.enrich(patch)).toMatchSnapshot();
+    });
+
+    it('includes ref in add patch metadata', () => {
+      const { base, current } = treePair(
+        objRoot([]),
+        objRoot([ref('avatar', 'File')]),
       );
 
       const enricher = new PatchEnricher(current, base);

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.arrays.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.arrays.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`PatchBuilder array operations generates add patch for field inside arra
 [
   {
     "fieldName": "items[*].newField",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/items/items/properties/newField",
@@ -13,6 +12,7 @@ exports[`PatchBuilder array operations generates add patch for field inside arra
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -21,15 +21,14 @@ exports[`PatchBuilder array operations generates move patch for renamed field in
 [
   {
     "fieldName": "items[*].newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/items/items/properties/oldName",
       "op": "move",
       "path": "/properties/items/items/properties/newName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -38,11 +37,11 @@ exports[`PatchBuilder array operations generates remove patch for field inside a
 [
   {
     "fieldName": "items[*].fieldA",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/items/items/properties/fieldA",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -50,19 +49,7 @@ exports[`PatchBuilder array operations generates remove patch for field inside a
 exports[`PatchBuilder array operations generates replace patch for array when only array metadata changes 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": {
-      "fromDescription": undefined,
-      "toDescription": "New description",
-    },
     "fieldName": "items",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items",
@@ -75,6 +62,13 @@ exports[`PatchBuilder array operations generates replace patch for array when on
         "type": "array",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "New description",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -83,19 +77,7 @@ exports[`PatchBuilder array operations generates replace patch for array when on
 exports[`PatchBuilder array operations generates replace patch for field inside array items 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "initial",
-      "toDefault": "modified",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "items[*].name",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items/properties/name",
@@ -104,6 +86,13 @@ exports[`PatchBuilder array operations generates replace patch for field inside 
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "initial",
+        "property": "default",
+        "to": "modified",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -112,14 +101,7 @@ exports[`PatchBuilder array operations generates replace patch for field inside 
 exports[`PatchBuilder array operations generates replace patch for items when array items type changes 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "items[*]",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items",
@@ -128,6 +110,7 @@ exports[`PatchBuilder array operations generates replace patch for items when ar
         "type": "number",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "string",
       "toType": "number",
@@ -139,19 +122,7 @@ exports[`PatchBuilder array operations generates replace patch for items when ar
 exports[`PatchBuilder array operations generates two patches when both array metadata and items type change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": {
-      "fromDescription": undefined,
-      "toDescription": "New description",
-    },
     "fieldName": "items",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items",
@@ -164,17 +135,17 @@ exports[`PatchBuilder array operations generates two patches when both array met
         "type": "array",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "New description",
+      },
+    ],
     "typeChange": undefined,
   },
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "items[*]",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items",
@@ -183,6 +154,7 @@ exports[`PatchBuilder array operations generates two patches when both array met
         "type": "number",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "string",
       "toType": "number",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.basic.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.basic.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`PatchBuilder basic operations adding nested field generates add patch f
 [
   {
     "fieldName": "nested.new",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/nested/properties/new",
@@ -13,6 +12,7 @@ exports[`PatchBuilder basic operations adding nested field generates add patch f
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -21,7 +21,6 @@ exports[`PatchBuilder basic operations adding top-level field generates add patc
 [
   {
     "fieldName": "newField",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -30,6 +29,7 @@ exports[`PatchBuilder basic operations adding top-level field generates add patc
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -37,19 +37,7 @@ exports[`PatchBuilder basic operations adding top-level field generates add patc
 exports[`PatchBuilder basic operations modifying field generates replace patch when default value changes 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "initial",
-      "toDefault": "modified",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "name",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -58,6 +46,13 @@ exports[`PatchBuilder basic operations modifying field generates replace patch w
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "initial",
+        "property": "default",
+        "to": "modified",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -69,11 +64,11 @@ exports[`PatchBuilder basic operations removing field generates remove patch whe
 [
   {
     "fieldName": "nested.fieldA",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/nested/properties/fieldA",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -82,11 +77,11 @@ exports[`PatchBuilder basic operations removing field generates remove patch whe
 [
   {
     "fieldName": "name",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/name",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -95,15 +90,14 @@ exports[`PatchBuilder basic operations renaming field generates move patch when 
 [
   {
     "fieldName": "newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldName",
       "op": "move",
       "path": "/properties/newName",
     },
+    "propertyChanges": [],
   },
 ]
 `;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.edgeCases.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.edgeCases.spec.ts.snap
@@ -4,11 +4,11 @@ exports[`PatchBuilder edge cases removes parent with children - single remove pa
 [
   {
     "fieldName": "parent",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/parent",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -17,30 +17,23 @@ exports[`PatchBuilder edge cases rename + modify generates move then replace 1`]
 [
   {
     "fieldName": "newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldName",
       "op": "move",
       "path": "/properties/newName",
     },
+    "propertyChanges": [
+      {
+        "from": "initial",
+        "property": "default",
+        "to": "modified",
+      },
+    ],
   },
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "modified",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "newName",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/newName",
@@ -49,6 +42,13 @@ exports[`PatchBuilder edge cases rename + modify generates move then replace 1`]
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "modified",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -58,15 +58,14 @@ exports[`PatchBuilder edge cases renames parent - children move together, single
 [
   {
     "fieldName": "newParent",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldParent",
       "op": "move",
       "path": "/properties/newParent",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -77,30 +76,23 @@ exports[`PatchBuilder patch ordering array items rename with nested modification
 [
   {
     "fieldName": "items[*].newField",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/items/items/properties/oldField",
       "op": "move",
       "path": "/properties/items/items/properties/newField",
     },
+    "propertyChanges": [
+      {
+        "from": "original",
+        "property": "default",
+        "to": "modified",
+      },
+    ],
   },
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "modified",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "items[*].newField",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items/properties/newField",
@@ -109,6 +101,13 @@ exports[`PatchBuilder patch ordering array items rename with nested modification
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "modified",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -118,19 +117,17 @@ exports[`PatchBuilder patch ordering move patches come before add/remove 1`] = `
 [
   {
     "fieldName": "renamedA",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/fieldA",
       "op": "move",
       "path": "/properties/renamedA",
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "newField",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -139,14 +136,15 @@ exports[`PatchBuilder patch ordering move patches come before add/remove 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "fieldB",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/fieldB",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -155,39 +153,36 @@ exports[`PatchBuilder patch ordering multiple renames in sequence 1`] = `
 [
   {
     "fieldName": "x",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/a",
       "op": "move",
       "path": "/properties/x",
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "y",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/b",
       "op": "move",
       "path": "/properties/y",
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "z",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/c",
       "op": "move",
       "path": "/properties/z",
     },
+    "propertyChanges": [],
   },
 ]
 `;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.metadata.spec.ts.snap
@@ -3,19 +3,7 @@
 exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "initial",
-      "toDefault": "modified",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -24,6 +12,13 @@ exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "initial",
+        "property": "default",
+        "to": "modified",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -32,19 +27,7 @@ exports[`PatchBuilder SchemaPatch metadata detects default value change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": {
-      "fromDeprecated": undefined,
-      "toDeprecated": true,
-    },
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "deprecated",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -54,6 +37,13 @@ exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "deprecated",
+        "to": true,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -62,19 +52,7 @@ exports[`PatchBuilder SchemaPatch metadata detects deprecated change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": {
-      "fromDescription": "old description",
-      "toDescription": "new description",
-    },
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -84,6 +62,13 @@ exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "old description",
+        "property": "description",
+        "to": "new description",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -92,19 +77,7 @@ exports[`PatchBuilder SchemaPatch metadata detects description change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": {
-      "fromForeignKey": undefined,
-      "toForeignKey": "users",
-    },
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "foreignKey",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -114,6 +87,13 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "foreignKey",
+        "to": "users",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -122,19 +102,7 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey addition 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": {
-      "fromForeignKey": "users",
-      "toForeignKey": "categories",
-    },
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "foreignKey",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -144,6 +112,13 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "users",
+        "property": "foreignKey",
+        "to": "categories",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -152,19 +127,7 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey change 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": {
-      "fromForeignKey": "users",
-      "toForeignKey": undefined,
-    },
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "foreignKey",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -173,6 +136,13 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "users",
+        "property": "foreignKey",
+        "to": undefined,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -181,21 +151,7 @@ exports[`PatchBuilder SchemaPatch metadata detects foreignKey removal 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": {
-      "fromFormula": undefined,
-      "fromVersion": undefined,
-      "toFormula": "value * 2",
-      "toVersion": 1,
-    },
-    "metadataChanges": [
-      "formula",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -209,6 +165,13 @@ exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
         },
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "formula",
+        "to": "value * 2",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -217,21 +180,7 @@ exports[`PatchBuilder SchemaPatch metadata detects formula addition 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "computed",
-    "foreignKeyChange": undefined,
-    "formulaChange": {
-      "fromFormula": "value * 2",
-      "fromVersion": 1,
-      "toFormula": undefined,
-      "toVersion": undefined,
-    },
-    "metadataChanges": [
-      "formula",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/computed",
@@ -240,6 +189,13 @@ exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "value * 2",
+        "property": "formula",
+        "to": undefined,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -248,14 +204,7 @@ exports[`PatchBuilder SchemaPatch metadata detects formula removal 1`] = `
 exports[`PatchBuilder SchemaPatch metadata detects type change from string to number 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -264,6 +213,7 @@ exports[`PatchBuilder SchemaPatch metadata detects type change from string to nu
         "type": "number",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "string",
       "toType": "number",
@@ -276,15 +226,14 @@ exports[`PatchBuilder SchemaPatch metadata marks move as rename when parent is s
 [
   {
     "fieldName": "newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/oldName",
       "op": "move",
       "path": "/properties/newName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -292,14 +241,7 @@ exports[`PatchBuilder SchemaPatch metadata marks move as rename when parent is s
 exports[`PatchBuilder add patch metadata includes default value in add patch when not standard 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "my default",
-    },
     "fieldName": "field",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field",
@@ -308,6 +250,13 @@ exports[`PatchBuilder add patch metadata includes default value in add patch whe
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "my default",
+      },
+    ],
   },
 ]
 `;
@@ -315,14 +264,7 @@ exports[`PatchBuilder add patch metadata includes default value in add patch whe
 exports[`PatchBuilder add patch metadata includes deprecated in add patch when field is deprecated 1`] = `
 [
   {
-    "deprecatedChange": {
-      "fromDeprecated": undefined,
-      "toDeprecated": true,
-    },
     "fieldName": "field",
-    "metadataChanges": [
-      "deprecated",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field",
@@ -332,6 +274,13 @@ exports[`PatchBuilder add patch metadata includes deprecated in add patch when f
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "deprecated",
+        "to": true,
+      },
+    ],
   },
 ]
 `;
@@ -339,14 +288,7 @@ exports[`PatchBuilder add patch metadata includes deprecated in add patch when f
 exports[`PatchBuilder add patch metadata includes description in add patch when field has description 1`] = `
 [
   {
-    "descriptionChange": {
-      "fromDescription": undefined,
-      "toDescription": "My description",
-    },
     "fieldName": "field",
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field",
@@ -356,6 +298,13 @@ exports[`PatchBuilder add patch metadata includes description in add patch when 
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "My description",
+      },
+    ],
   },
 ]
 `;
@@ -364,13 +313,6 @@ exports[`PatchBuilder add patch metadata includes foreignKey in add patch when f
 [
   {
     "fieldName": "categoryId",
-    "foreignKeyChange": {
-      "fromForeignKey": undefined,
-      "toForeignKey": "categories",
-    },
-    "metadataChanges": [
-      "foreignKey",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/categoryId",
@@ -380,6 +322,13 @@ exports[`PatchBuilder add patch metadata includes foreignKey in add patch when f
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "foreignKey",
+        "to": "categories",
+      },
+    ],
   },
 ]
 `;
@@ -388,15 +337,6 @@ exports[`PatchBuilder add patch metadata includes formula in add patch when fiel
 [
   {
     "fieldName": "computed",
-    "formulaChange": {
-      "fromFormula": undefined,
-      "fromVersion": undefined,
-      "toFormula": "value * 2",
-      "toVersion": 1,
-    },
-    "metadataChanges": [
-      "formula",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/computed",
@@ -410,6 +350,13 @@ exports[`PatchBuilder add patch metadata includes formula in add patch when fiel
         },
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "formula",
+        "to": "value * 2",
+      },
+    ],
   },
 ]
 `;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
@@ -4,15 +4,14 @@ exports[`PatchBuilder nested operations generates move patch for renamed nested 
 [
   {
     "fieldName": "nested.newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/nested/properties/oldName",
       "op": "move",
       "path": "/properties/nested/properties/newName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -20,19 +19,7 @@ exports[`PatchBuilder nested operations generates move patch for renamed nested 
 exports[`PatchBuilder nested operations generates multiple patches for multiple changes in one object 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "a",
-      "toDefault": "modified",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "nested.fieldA",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/nested/properties/fieldA",
@@ -41,11 +28,17 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "a",
+        "property": "default",
+        "to": "modified",
+      },
+    ],
     "typeChange": undefined,
   },
   {
     "fieldName": "nested.fieldD",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/nested/properties/fieldD",
@@ -54,14 +47,15 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "nested.fieldB",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/nested/properties/fieldB",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -69,19 +63,7 @@ exports[`PatchBuilder nested operations generates multiple patches for multiple 
 exports[`PatchBuilder nested operations generates replace patch for nested field modification 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": 10,
-      "toDefault": 20,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "nested.value",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/nested/properties/value",
@@ -90,6 +72,13 @@ exports[`PatchBuilder nested operations generates replace patch for nested field
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": 10,
+        "property": "default",
+        "to": 20,
+      },
+    ],
     "typeChange": undefined,
   },
 ]

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.rootChanges.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.rootChanges.spec.ts.snap
@@ -3,19 +3,7 @@
 exports[`PatchBuilder root changes array root array root - description change on root 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": {
-      "fromDescription": undefined,
-      "toDescription": "Array of strings",
-    },
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -28,6 +16,13 @@ exports[`PatchBuilder root changes array root array root - description change on
         "type": "array",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "Array of strings",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -36,19 +31,7 @@ exports[`PatchBuilder root changes array root array root - description change on
 exports[`PatchBuilder root changes array root array root - items default value change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "old",
-      "toDefault": "new",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "[*]",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/items",
@@ -57,6 +40,13 @@ exports[`PatchBuilder root changes array root array root - items default value c
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "old",
+        "property": "default",
+        "to": "new",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -66,7 +56,6 @@ exports[`PatchBuilder root changes array root array root with object items - add
 [
   {
     "fieldName": "[*].new",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/items/properties/new",
@@ -75,6 +64,7 @@ exports[`PatchBuilder root changes array root array root with object items - add
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -83,11 +73,11 @@ exports[`PatchBuilder root changes array root array root with object items - rem
 [
   {
     "fieldName": "[*].fieldA",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/items/properties/fieldA",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -96,15 +86,14 @@ exports[`PatchBuilder root changes array root array root with object items - ren
 [
   {
     "fieldName": "[*].newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/items/properties/oldName",
       "op": "move",
       "path": "/items/properties/newName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -114,19 +103,7 @@ exports[`PatchBuilder root changes array root array root with primitive items - 
 exports[`PatchBuilder root changes nested arrays array of arrays - inner items change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "old",
-      "toDefault": "new",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "[*][*]",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/items/items",
@@ -135,6 +112,13 @@ exports[`PatchBuilder root changes nested arrays array of arrays - inner items c
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "old",
+        "property": "default",
+        "to": "new",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -146,7 +130,6 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - ad
 [
   {
     "fieldName": "[*][*].new",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/items/items/properties/new",
@@ -155,6 +138,7 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - ad
         "type": "string",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -163,11 +147,11 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - re
 [
   {
     "fieldName": "[*][*].fieldA",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/items/items/properties/fieldA",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -176,15 +160,14 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - re
 [
   {
     "fieldName": "[*][*].newName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/items/items/properties/oldName",
       "op": "move",
       "path": "/items/items/properties/newName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -192,19 +175,7 @@ exports[`PatchBuilder root changes nested arrays array of arrays of objects - re
 exports[`PatchBuilder root changes object root generates replace patch when root deprecated changes 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": {
-      "fromDeprecated": undefined,
-      "toDeprecated": true,
-    },
-    "descriptionChange": undefined,
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "deprecated",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -223,6 +194,13 @@ exports[`PatchBuilder root changes object root generates replace patch when root
         "type": "object",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "deprecated",
+        "to": true,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -231,19 +209,7 @@ exports[`PatchBuilder root changes object root generates replace patch when root
 exports[`PatchBuilder root changes object root generates replace patch when root description changes 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": {
-      "fromDescription": undefined,
-      "toDescription": "New root description",
-    },
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -262,6 +228,13 @@ exports[`PatchBuilder root changes object root generates replace patch when root
         "type": "object",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "New root description",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -270,19 +243,7 @@ exports[`PatchBuilder root changes object root generates replace patch when root
 exports[`PatchBuilder root changes primitive root boolean root - deprecated change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": {
-      "fromDeprecated": undefined,
-      "toDeprecated": true,
-    },
-    "descriptionChange": undefined,
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "deprecated",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -292,6 +253,13 @@ exports[`PatchBuilder root changes primitive root boolean root - deprecated chan
         "type": "boolean",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "deprecated",
+        "to": true,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -300,19 +268,7 @@ exports[`PatchBuilder root changes primitive root boolean root - deprecated chan
 exports[`PatchBuilder root changes primitive root number root - default value change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": 0,
-      "toDefault": 42,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -321,6 +277,13 @@ exports[`PatchBuilder root changes primitive root number root - default value ch
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": 0,
+        "property": "default",
+        "to": 42,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -329,19 +292,7 @@ exports[`PatchBuilder root changes primitive root number root - default value ch
 exports[`PatchBuilder root changes primitive root string root - default value change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "old",
-      "toDefault": "new",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -350,6 +301,13 @@ exports[`PatchBuilder root changes primitive root string root - default value ch
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "old",
+        "property": "default",
+        "to": "new",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -358,19 +316,7 @@ exports[`PatchBuilder root changes primitive root string root - default value ch
 exports[`PatchBuilder root changes primitive root string root - description change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": {
-      "fromDescription": undefined,
-      "toDescription": "A string value",
-    },
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "description",
-    ],
     "patch": {
       "op": "replace",
       "path": "",
@@ -380,6 +326,13 @@ exports[`PatchBuilder root changes primitive root string root - description chan
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "A string value",
+      },
+    ],
     "typeChange": undefined,
   },
 ]

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.typeChanges.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.typeChanges.spec.ts.snap
@@ -3,14 +3,7 @@
 exports[`PatchBuilder type changes object to array 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -22,6 +15,7 @@ exports[`PatchBuilder type changes object to array 1`] = `
         "type": "array",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "object",
       "toType": "array<string>",
@@ -33,14 +27,7 @@ exports[`PatchBuilder type changes object to array 1`] = `
 exports[`PatchBuilder type changes object to primitive 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -49,6 +36,7 @@ exports[`PatchBuilder type changes object to primitive 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "object",
       "toType": "string",
@@ -60,14 +48,7 @@ exports[`PatchBuilder type changes object to primitive 1`] = `
 exports[`PatchBuilder type changes primitive to array 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -79,6 +60,7 @@ exports[`PatchBuilder type changes primitive to array 1`] = `
         "type": "array",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "string",
       "toType": "array<string>",
@@ -90,14 +72,7 @@ exports[`PatchBuilder type changes primitive to array 1`] = `
 exports[`PatchBuilder type changes primitive to object 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -115,6 +90,7 @@ exports[`PatchBuilder type changes primitive to object 1`] = `
         "type": "object",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "string",
       "toType": "object",

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.edgeCases.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.edgeCases.spec.ts.snap
@@ -3,36 +3,35 @@
 exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in move from path 1`] = `
 {
   "fieldName": "field",
-  "formulaChange": undefined,
   "isRename": undefined,
-  "metadataChanges": [],
   "movesIntoArray": undefined,
   "patch": {
     "from": "invalid-no-slash",
     "op": "move",
     "path": "/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher edge cases invalid paths handles invalid json pointer in path 1`] = `
 {
   "fieldName": "",
-  "metadataChanges": [],
   "patch": {
     "op": "add",
     "path": "invalid-no-slash",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher edge cases invalid paths handles path to non-existent node 1`] = `
 {
   "fieldName": "nonexistent.deep",
-  "metadataChanges": [],
   "patch": {
     "op": "add",
     "path": "/properties/nonexistent/properties/deep",
   },
+  "propertyChanges": [],
 }
 `;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.replace.spec.ts.snap
@@ -3,69 +3,59 @@
 exports[`PatchEnricher move patch enrichment detects formula change on move 1`] = `
 {
   "fieldName": "newName",
-  "formulaChange": {
-    "fromFormula": "value * 2",
-    "fromVersion": 1,
-    "toFormula": "value * 3",
-    "toVersion": 1,
-  },
   "isRename": true,
-  "metadataChanges": [
-    "formula",
-  ],
   "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/oldName",
     "op": "move",
     "path": "/properties/newName",
   },
+  "propertyChanges": [
+    {
+      "from": "value * 2",
+      "property": "formula",
+      "to": "value * 3",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher move patch enrichment does not mark as rename when parent differs 1`] = `
 {
   "fieldName": "target.field",
-  "formulaChange": undefined,
   "isRename": undefined,
-  "metadataChanges": [],
   "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/source/properties/field",
     "op": "move",
     "path": "/properties/target/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher move patch enrichment marks as rename when parent is same 1`] = `
 {
   "fieldName": "newName",
-  "formulaChange": undefined,
   "isRename": true,
-  "metadataChanges": [],
   "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/oldName",
     "op": "move",
     "path": "/properties/newName",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects array type with items 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [],
   "typeChange": {
     "fromType": "string",
     "toType": "array<number>",
@@ -75,185 +65,174 @@ exports[`PatchEnricher replace patch enrichment detects array type with items 1`
 
 exports[`PatchEnricher replace patch enrichment detects default value change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": {
-    "fromDefault": "old",
-    "toDefault": "new",
-  },
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "default",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": "old",
+      "property": "default",
+      "to": "new",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects deprecated change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": {
-    "fromDeprecated": undefined,
-    "toDeprecated": true,
-  },
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "deprecated",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "deprecated",
+      "to": true,
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects description change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": {
-    "fromDescription": "old",
-    "toDescription": "new",
-  },
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "description",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": "old",
+      "property": "description",
+      "to": "new",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects foreignKey change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": {
-    "fromForeignKey": "users",
-    "toForeignKey": "categories",
-  },
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "foreignKey",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": "users",
+      "property": "foreignKey",
+      "to": "categories",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects formula addition 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": {
-    "fromFormula": undefined,
-    "fromVersion": undefined,
-    "toFormula": "value * 2",
-    "toVersion": 1,
-  },
-  "metadataChanges": [
-    "formula",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "formula",
+      "to": "value * 2",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects formula change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": {
-    "fromFormula": "value * 2",
-    "fromVersion": 1,
-    "toFormula": "value * 3",
-    "toVersion": 1,
-  },
-  "metadataChanges": [
-    "formula",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": "value * 2",
+      "property": "formula",
+      "to": "value * 3",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects formula removal 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": {
-    "fromFormula": "value * 2",
-    "fromVersion": 1,
-    "toFormula": undefined,
-    "toVersion": undefined,
-  },
-  "metadataChanges": [
-    "formula",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": "value * 2",
+      "property": "formula",
+      "to": undefined,
+    },
+  ],
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects ref change 1`] = `
+{
+  "fieldName": "avatar",
+  "patch": {
+    "op": "replace",
+    "path": "/properties/avatar",
+  },
+  "propertyChanges": [
+    {
+      "from": "File",
+      "property": "ref",
+      "to": "Markdown",
+    },
+  ],
+  "typeChange": undefined,
+}
+`;
+
+exports[`PatchEnricher replace patch enrichment detects title change 1`] = `
+{
+  "fieldName": "field",
+  "patch": {
+    "op": "replace",
+    "path": "/properties/field",
+  },
+  "propertyChanges": [
+    {
+      "from": "Old Title",
+      "property": "title",
+      "to": "New Title",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects type change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "field",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/field",
   },
+  "propertyChanges": [],
   "typeChange": {
     "fromType": "string",
     "toType": "number",
@@ -263,23 +242,18 @@ exports[`PatchEnricher replace patch enrichment detects type change 1`] = `
 
 exports[`PatchEnricher replace patch enrichment skips defaultChange for array replace when only metadata changes 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": {
-    "fromDescription": undefined,
-    "toDescription": "Updated",
-  },
   "fieldName": "items",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "description",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/items",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "description",
+      "to": "Updated",
+    },
+  ],
   "typeChange": undefined,
 }
 `;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchEnricher.spec.ts.snap
@@ -2,175 +2,172 @@
 
 exports[`PatchEnricher add patch enrichment includes contentMediaType in add patch metadata 1`] = `
 {
-  "contentMediaTypeChange": {
-    "fromContentMediaType": undefined,
-    "toContentMediaType": "text/plain",
-  },
   "fieldName": "avatar",
-  "metadataChanges": [
-    "contentMediaType",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/avatar",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "contentMediaType",
+      "to": "text/plain",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher add patch enrichment includes deprecated in add patch metadata 1`] = `
 {
-  "deprecatedChange": {
-    "fromDeprecated": undefined,
-    "toDeprecated": true,
-  },
   "fieldName": "field",
-  "metadataChanges": [
-    "deprecated",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "deprecated",
+      "to": true,
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher add patch enrichment includes description in add patch metadata 1`] = `
 {
-  "descriptionChange": {
-    "fromDescription": undefined,
-    "toDescription": "My description",
-  },
   "fieldName": "field",
-  "metadataChanges": [
-    "description",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "description",
+      "to": "My description",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher add patch enrichment includes foreignKey in add patch metadata 1`] = `
 {
   "fieldName": "categoryId",
-  "foreignKeyChange": {
-    "fromForeignKey": undefined,
-    "toForeignKey": "categories",
-  },
-  "metadataChanges": [
-    "foreignKey",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/categoryId",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "foreignKey",
+      "to": "categories",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher add patch enrichment includes formula in add patch metadata 1`] = `
 {
   "fieldName": "computed",
-  "formulaChange": {
-    "fromFormula": undefined,
-    "fromVersion": undefined,
-    "toFormula": "value * 2",
-    "toVersion": 1,
-  },
-  "metadataChanges": [
-    "formula",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/computed",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "formula",
+      "to": "value * 2",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher add patch enrichment includes non-standard default value in add patch metadata 1`] = `
 {
-  "defaultChange": {
-    "fromDefault": undefined,
-    "toDefault": "my default",
-  },
   "fieldName": "field",
-  "metadataChanges": [
-    "default",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "default",
+      "to": "my default",
+    },
+  ],
+}
+`;
+
+exports[`PatchEnricher add patch enrichment includes ref in add patch metadata 1`] = `
+{
+  "fieldName": "avatar",
+  "patch": {
+    "op": "add",
+    "path": "/properties/avatar",
+  },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "ref",
+      "to": "File",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher add patch enrichment skips standard default values in add patch metadata 1`] = `
 {
-  "defaultChange": {
-    "fromDefault": undefined,
-    "toDefault": "",
-  },
   "fieldName": "field",
-  "metadataChanges": [
-    "default",
-  ],
   "patch": {
     "op": "add",
     "path": "/properties/field",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "default",
+      "to": "",
+    },
+  ],
 }
 `;
 
 exports[`PatchEnricher fieldName extraction extracts array items field name 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "items[*].name",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/items/items/properties/name",
   },
+  "propertyChanges": [],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher fieldName extraction extracts nested field name 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "nested.field",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/nested/properties/field",
   },
+  "propertyChanges": [],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher fieldName extraction extracts simple field name 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "name",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [],
   "patch": {
     "op": "replace",
     "path": "/properties/name",
   },
+  "propertyChanges": [],
   "typeChange": undefined,
 }
 `;
@@ -178,200 +175,170 @@ exports[`PatchEnricher fieldName extraction extracts simple field name 1`] = `
 exports[`PatchEnricher move patch enrichment detects movesIntoArray when moving from root to array items 1`] = `
 {
   "fieldName": "items[*].field",
-  "formulaChange": undefined,
   "isRename": undefined,
-  "metadataChanges": [],
   "movesIntoArray": true,
   "patch": {
     "from": "/properties/field",
     "op": "move",
     "path": "/properties/items/items/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher move patch enrichment detects movesIntoArray when moving into deeper array nesting 1`] = `
 {
   "fieldName": "items[*].nested[*].field",
-  "formulaChange": undefined,
   "isRename": undefined,
-  "metadataChanges": [],
   "movesIntoArray": true,
   "patch": {
     "from": "/properties/outer/items/properties/field",
     "op": "move",
     "path": "/properties/items/items/properties/nested/items/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher move patch enrichment detects rename (same parent) 1`] = `
 {
   "fieldName": "newName",
-  "formulaChange": undefined,
   "isRename": true,
-  "metadataChanges": [],
   "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/oldName",
     "op": "move",
     "path": "/properties/newName",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher move patch enrichment does not set movesIntoArray when moving out of array 1`] = `
 {
   "fieldName": "field",
-  "formulaChange": undefined,
   "isRename": undefined,
-  "metadataChanges": [],
   "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/items/items/properties/field",
     "op": "move",
     "path": "/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher move patch enrichment does not set movesIntoArray when moving within same level 1`] = `
 {
   "fieldName": "other.field",
-  "formulaChange": undefined,
   "isRename": undefined,
-  "metadataChanges": [],
   "movesIntoArray": undefined,
   "patch": {
     "from": "/properties/nested/properties/field",
     "op": "move",
     "path": "/properties/other/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher remove patch enrichment returns patch with fieldName only 1`] = `
 {
   "fieldName": "field",
-  "metadataChanges": [],
   "patch": {
     "op": "remove",
     "path": "/properties/field",
   },
+  "propertyChanges": [],
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects contentMediaType addition 1`] = `
 {
-  "contentMediaTypeChange": {
-    "fromContentMediaType": undefined,
-    "toContentMediaType": "text/plain",
-  },
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "image",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "contentMediaType",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/image",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "contentMediaType",
+      "to": "text/plain",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects contentMediaType change 1`] = `
 {
-  "contentMediaTypeChange": {
-    "fromContentMediaType": "text/plain",
-    "toContentMediaType": "text/markdown",
-  },
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "image",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "contentMediaType",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/image",
   },
+  "propertyChanges": [
+    {
+      "from": "text/plain",
+      "property": "contentMediaType",
+      "to": "text/markdown",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher replace patch enrichment detects contentMediaType removal 1`] = `
 {
-  "contentMediaTypeChange": {
-    "fromContentMediaType": "text/plain",
-    "toContentMediaType": undefined,
-  },
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "image",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "contentMediaType",
-  ],
   "patch": {
     "op": "replace",
     "path": "/properties/image",
   },
+  "propertyChanges": [
+    {
+      "from": "text/plain",
+      "property": "contentMediaType",
+      "to": undefined,
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher root node patches enriches primitive root default change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": {
-    "fromDefault": "old",
-    "toDefault": "new",
-  },
-  "deprecatedChange": undefined,
-  "descriptionChange": undefined,
   "fieldName": "",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "default",
-  ],
   "patch": {
     "op": "replace",
     "path": "",
   },
+  "propertyChanges": [
+    {
+      "from": "old",
+      "property": "default",
+      "to": "new",
+    },
+  ],
   "typeChange": undefined,
 }
 `;
 
 exports[`PatchEnricher root node patches enriches root description change 1`] = `
 {
-  "contentMediaTypeChange": undefined,
-  "defaultChange": undefined,
-  "deprecatedChange": undefined,
-  "descriptionChange": {
-    "fromDescription": undefined,
-    "toDescription": "Root description",
-  },
   "fieldName": "",
-  "foreignKeyChange": undefined,
-  "formulaChange": undefined,
-  "metadataChanges": [
-    "description",
-  ],
   "patch": {
     "op": "replace",
     "path": "",
   },
+  "propertyChanges": [
+    {
+      "from": undefined,
+      "property": "description",
+      "to": "Root description",
+    },
+  ],
   "typeChange": undefined,
 }
 `;

--- a/src/core/schema-patch/__tests__/test-helpers.ts
+++ b/src/core/schema-patch/__tests__/test-helpers.ts
@@ -8,6 +8,7 @@ import {
   createNumberNode,
   createArrayNode,
   createBooleanNode,
+  createRefNode,
 } from '../../schema-node/index.js';
 import type {
   CoalescedChanges,
@@ -30,6 +31,7 @@ export {
   createNumberNode,
   createArrayNode,
   createBooleanNode,
+  createRefNode,
 };
 
 export type { SchemaTree, SchemaNode };
@@ -51,6 +53,12 @@ interface ObjectNodeOptions {
 }
 
 interface ArrayNodeOptions {
+  id?: string;
+  description?: string;
+  deprecated?: boolean;
+}
+
+interface RefNodeOptions {
   id?: string;
   description?: string;
   deprecated?: boolean;
@@ -122,6 +130,19 @@ export const arr = (
     opts?.id ?? name,
     name,
     items,
+    buildMetadata(opts),
+  );
+};
+
+export const ref = (
+  name: string,
+  refValue: string,
+  opts?: RefNodeOptions,
+): SchemaNode => {
+  return createRefNode(
+    opts?.id ?? name,
+    name,
+    refValue,
     buildMetadata(opts),
   );
 };

--- a/src/core/schema-patch/index.ts
+++ b/src/core/schema-patch/index.ts
@@ -1,4 +1,4 @@
 export { PatchBuilder } from './PatchBuilder.js';
 export { PatchGenerator } from './PatchGenerator.js';
 export { PatchEnricher } from './PatchEnricher.js';
-export type { JsonPatch, SchemaPatch, DefaultValueType, MetadataChangeType } from './types.js';
+export type { JsonPatch, SchemaPatch, DefaultValueType, PropertyChange, PropertyName } from './types.js';

--- a/src/core/schema-patch/types.ts
+++ b/src/core/schema-patch/types.ts
@@ -4,50 +4,27 @@ export type { JsonPatch };
 
 export type DefaultValueType = string | number | boolean | undefined;
 
-export type MetadataChangeType =
+export type PropertyName =
   | 'formula'
+  | 'default'
   | 'description'
   | 'deprecated'
   | 'foreignKey'
-  | 'default'
-  | 'enum'
-  | 'format'
-  | 'contentMediaType';
+  | 'contentMediaType'
+  | 'ref'
+  | 'title';
+
+export interface PropertyChange {
+  property: PropertyName;
+  from: unknown;
+  to: unknown;
+}
 
 export interface SchemaPatch {
   patch: JsonPatch;
   fieldName: string;
-  metadataChanges: MetadataChangeType[];
-  typeChange?: {
-    fromType: string;
-    toType: string;
-  };
-  formulaChange?: {
-    fromFormula: string | undefined;
-    toFormula: string | undefined;
-    fromVersion: number | undefined;
-    toVersion: number | undefined;
-  };
-  defaultChange?: {
-    fromDefault: DefaultValueType;
-    toDefault: DefaultValueType;
-  };
-  descriptionChange?: {
-    fromDescription: string | undefined;
-    toDescription: string | undefined;
-  };
-  deprecatedChange?: {
-    fromDeprecated: boolean | undefined;
-    toDeprecated: boolean | undefined;
-  };
-  foreignKeyChange?: {
-    fromForeignKey: string | undefined;
-    toForeignKey: string | undefined;
-  };
-  contentMediaTypeChange?: {
-    fromContentMediaType: string | undefined;
-    toContentMediaType: string | undefined;
-  };
+  typeChange?: { fromType: string; toType: string };
   isRename?: boolean;
   movesIntoArray?: boolean;
+  propertyChanges: PropertyChange[];
 }

--- a/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
@@ -153,9 +153,10 @@ describe('SchemaModel patches', () => {
       expect(replacePatches).toHaveLength(1);
       const formulaPatch = replacePatches[0];
       expect(formulaPatch?.fieldName).toBe('total');
-      expect(formulaPatch?.formulaChange).toMatchObject({
-        fromFormula: 'price * quantity',
-        toFormula: 'cost * quantity',
+      const formulaChange = formulaPatch?.propertyChanges.find((c) => c.property === 'formula');
+      expect(formulaChange).toMatchObject({
+        from: 'price * quantity',
+        to: 'cost * quantity',
       });
 
       const totalNode = model.nodeById(totalId!);

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.addMovePatch.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.addMovePatch.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`SchemaModel add + move patch generation add + move + remove moved field
 [
   {
     "fieldName": "nested",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/nested",
@@ -15,14 +14,15 @@ exports[`SchemaModel add + move patch generation add + move + remove moved field
         "type": "object",
       },
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "sum",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/sum",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -31,11 +31,11 @@ exports[`SchemaModel add + move patch generation add + move + remove new parent 
 [
   {
     "fieldName": "sum",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/sum",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -44,7 +44,6 @@ exports[`SchemaModel add + move patch generation move field into newly created p
 [
   {
     "fieldName": "group",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/group",
@@ -55,30 +54,29 @@ exports[`SchemaModel add + move patch generation move field into newly created p
         "type": "object",
       },
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "group.a",
-    "formulaChange": undefined,
     "isRename": undefined,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/a",
       "op": "move",
       "path": "/properties/group/properties/a",
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "group.b",
-    "formulaChange": undefined,
     "isRename": undefined,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/b",
       "op": "move",
       "path": "/properties/group/properties/b",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -87,7 +85,6 @@ exports[`SchemaModel add + move patch generation move field into newly created p
 [
   {
     "fieldName": "nested",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/nested",
@@ -98,18 +95,18 @@ exports[`SchemaModel add + move patch generation move field into newly created p
         "type": "object",
       },
     },
+    "propertyChanges": [],
   },
   {
     "fieldName": "nested.sum",
-    "formulaChange": undefined,
     "isRename": undefined,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/sum",
       "op": "move",
       "path": "/properties/nested/properties/sum",
     },
+    "propertyChanges": [],
   },
 ]
 `;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.edgeCases.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.edgeCases.spec.ts.snap
@@ -3,14 +3,7 @@
 exports[`SchemaModel edge cases array operations changes array to object 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "items",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "/properties/items",
@@ -21,6 +14,7 @@ exports[`SchemaModel edge cases array operations changes array to object 1`] = `
         "type": "object",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "array<string>",
       "toType": "object",
@@ -32,19 +26,7 @@ exports[`SchemaModel edge cases array operations changes array to object 1`] = `
 exports[`SchemaModel edge cases array operations modifies array items type 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "",
-      "toDefault": 0,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "items[*]",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/items/items",
@@ -53,6 +35,13 @@ exports[`SchemaModel edge cases array operations modifies array items type 1`] =
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "",
+        "property": "default",
+        "to": 0,
+      },
+    ],
     "typeChange": {
       "fromType": "string",
       "toType": "number",
@@ -65,15 +54,14 @@ exports[`SchemaModel edge cases complex operations handles multiple renames 1`] 
 [
   {
     "fieldName": "givenName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/name",
       "op": "move",
       "path": "/properties/givenName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -81,14 +69,7 @@ exports[`SchemaModel edge cases complex operations handles multiple renames 1`] 
 exports[`SchemaModel edge cases complex operations handles remove then add same name 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "name",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/name",
@@ -97,14 +78,21 @@ exports[`SchemaModel edge cases complex operations handles remove then add same 
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
   {
     "fieldName": "name",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/name",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -112,19 +100,7 @@ exports[`SchemaModel edge cases complex operations handles remove then add same 
 exports[`SchemaModel edge cases complex operations handles type change then modification 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "",
-      "toDefault": 42,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "name",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -133,6 +109,13 @@ exports[`SchemaModel edge cases complex operations handles type change then modi
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "",
+        "property": "default",
+        "to": 42,
+      },
+    ],
     "typeChange": {
       "fromType": "string",
       "toType": "number",
@@ -144,14 +127,7 @@ exports[`SchemaModel edge cases complex operations handles type change then modi
 exports[`SchemaModel edge cases multiple changes before save accumulates all changes 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "",
-    },
     "fieldName": "field1",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field1",
@@ -160,16 +136,16 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "",
+      },
+    ],
   },
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "field2",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -178,16 +154,16 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": false,
-    },
     "fieldName": "field3",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field3",
@@ -196,6 +172,13 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
         "type": "boolean",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": false,
+      },
+    ],
   },
 ]
 `;
@@ -203,14 +186,7 @@ exports[`SchemaModel edge cases multiple changes before save accumulates all cha
 exports[`SchemaModel edge cases multiple changes before save correctly handles remove after multiple adds 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "field2",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -219,6 +195,13 @@ exports[`SchemaModel edge cases multiple changes before save correctly handles r
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
 ]
 `;
@@ -226,14 +209,7 @@ exports[`SchemaModel edge cases multiple changes before save correctly handles r
 exports[`SchemaModel edge cases nested operations adds field to nested object 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "user.age",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/user/properties/age",
@@ -242,6 +218,13 @@ exports[`SchemaModel edge cases nested operations adds field to nested object 1`
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
 ]
 `;
@@ -250,11 +233,11 @@ exports[`SchemaModel edge cases nested operations removes nested object with chi
 [
   {
     "fieldName": "user",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/user",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -263,15 +246,14 @@ exports[`SchemaModel edge cases nested operations renames nested field 1`] = `
 [
   {
     "fieldName": "user.givenName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/user/properties/firstName",
       "op": "move",
       "path": "/properties/user/properties/givenName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -279,19 +261,7 @@ exports[`SchemaModel edge cases nested operations renames nested field 1`] = `
 exports[`SchemaModel edge cases save and continue editing can modify saved fields 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "",
-      "toDefault": "changed",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "field",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/field",
@@ -300,6 +270,13 @@ exports[`SchemaModel edge cases save and continue editing can modify saved field
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "",
+        "property": "default",
+        "to": "changed",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -308,14 +285,7 @@ exports[`SchemaModel edge cases save and continue editing can modify saved field
 exports[`SchemaModel edge cases save and continue editing tracks new changes after save 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "new",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/new",
@@ -324,6 +294,13 @@ exports[`SchemaModel edge cases save and continue editing tracks new changes aft
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
 ]
 `;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.formulaMovePatches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.formulaMovePatches.spec.ts.snap
@@ -4,32 +4,17 @@ exports[`SchemaModel formula move patches move formula dependency generates repl
 [
   {
     "fieldName": "nested.value",
-    "formulaChange": undefined,
     "isRename": undefined,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/value",
       "op": "move",
       "path": "/properties/nested/properties/value",
     },
+    "propertyChanges": [],
   },
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "sum",
-    "foreignKeyChange": undefined,
-    "formulaChange": {
-      "fromFormula": "value + 2",
-      "fromVersion": 1,
-      "toFormula": "nested.value + 2",
-      "toVersion": 1,
-    },
-    "metadataChanges": [
-      "formula",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/sum",
@@ -43,6 +28,13 @@ exports[`SchemaModel formula move patches move formula dependency generates repl
         },
       },
     },
+    "propertyChanges": [
+      {
+        "from": "value + 2",
+        "property": "formula",
+        "to": "nested.value + 2",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -52,43 +44,23 @@ exports[`SchemaModel formula move patches move formula field into nested object 
 [
   {
     "fieldName": "nested.sum",
-    "formulaChange": {
-      "fromFormula": "value + 2",
-      "fromVersion": 1,
-      "toFormula": "../value + 2",
-      "toVersion": 1,
-    },
     "isRename": undefined,
-    "metadataChanges": [
-      "formula",
-    ],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/sum",
       "op": "move",
       "path": "/properties/nested/properties/sum",
     },
+    "propertyChanges": [
+      {
+        "from": "value + 2",
+        "property": "formula",
+        "to": "../value + 2",
+      },
+    ],
   },
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "nested.sum",
-    "foreignKeyChange": undefined,
-    "formulaChange": {
-      "fromFormula": undefined,
-      "fromVersion": undefined,
-      "toFormula": "../value + 2",
-      "toVersion": 1,
-    },
-    "metadataChanges": [
-      "formula",
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/nested/properties/sum",
@@ -102,6 +74,18 @@ exports[`SchemaModel formula move patches move formula field into nested object 
         },
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "formula",
+        "to": "../value + 2",
+      },
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -111,32 +95,17 @@ exports[`SchemaModel formula move patches rename formula dependency generates re
 [
   {
     "fieldName": "cost",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/price",
       "op": "move",
       "path": "/properties/cost",
     },
+    "propertyChanges": [],
   },
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "total",
-    "foreignKeyChange": undefined,
-    "formulaChange": {
-      "fromFormula": "price * quantity",
-      "fromVersion": 1,
-      "toFormula": "cost * quantity",
-      "toVersion": 1,
-    },
-    "metadataChanges": [
-      "formula",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/total",
@@ -150,6 +119,13 @@ exports[`SchemaModel formula move patches rename formula dependency generates re
         },
       },
     },
+    "propertyChanges": [
+      {
+        "from": "price * quantity",
+        "property": "formula",
+        "to": "cost * quantity",
+      },
+    ],
     "typeChange": undefined,
   },
 ]

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.mutations.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.mutations.spec.ts.snap
@@ -3,14 +3,7 @@
 exports[`SchemaModel mutations insertFieldAt generates patches 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "",
-    },
     "fieldName": "email",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/email",
@@ -19,6 +12,13 @@ exports[`SchemaModel mutations insertFieldAt generates patches 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "",
+      },
+    ],
   },
 ]
 `;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.patches.spec.ts.snap
@@ -17,7 +17,6 @@ exports[`SchemaModel patches getPatches handles type change on newly created fie
 [
   {
     "fieldName": "newField",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -28,6 +27,7 @@ exports[`SchemaModel patches getPatches handles type change on newly created fie
         "type": "object",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -36,7 +36,6 @@ exports[`SchemaModel patches getPatches handles type change on newly created fie
 [
   {
     "fieldName": "newField",
-    "metadataChanges": [],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -48,6 +47,7 @@ exports[`SchemaModel patches getPatches handles type change on newly created fie
         "type": "array",
       },
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -55,21 +55,7 @@ exports[`SchemaModel patches getPatches handles type change on newly created fie
 exports[`SchemaModel patches getPatches includes formula change info 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "age",
-    "foreignKeyChange": undefined,
-    "formulaChange": {
-      "fromFormula": undefined,
-      "fromVersion": undefined,
-      "toFormula": "name",
-      "toVersion": 1,
-    },
-    "metadataChanges": [
-      "formula",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/age",
@@ -83,6 +69,13 @@ exports[`SchemaModel patches getPatches includes formula change info 1`] = `
         },
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "formula",
+        "to": "name",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -91,14 +84,7 @@ exports[`SchemaModel patches getPatches includes formula change info 1`] = `
 exports[`SchemaModel patches getPatches multiple field additions 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "",
-    },
     "fieldName": "field1",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field1",
@@ -107,16 +93,16 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "",
+      },
+    ],
   },
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "field2",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -125,16 +111,16 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": false,
-    },
     "fieldName": "field3",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field3",
@@ -143,6 +129,13 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
         "type": "boolean",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": false,
+      },
+    ],
   },
 ]
 `;
@@ -150,14 +143,7 @@ exports[`SchemaModel patches getPatches multiple field additions 1`] = `
 exports[`SchemaModel patches getPatches returns add patch for new field 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": "",
-    },
     "fieldName": "newField",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/newField",
@@ -166,6 +152,13 @@ exports[`SchemaModel patches getPatches returns add patch for new field 1`] = `
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": "",
+      },
+    ],
   },
 ]
 `;
@@ -176,15 +169,14 @@ exports[`SchemaModel patches getPatches returns move patch for renamed field 1`]
 [
   {
     "fieldName": "fullName",
-    "formulaChange": undefined,
     "isRename": true,
-    "metadataChanges": [],
     "movesIntoArray": undefined,
     "patch": {
       "from": "/properties/name",
       "op": "move",
       "path": "/properties/fullName",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -193,11 +185,11 @@ exports[`SchemaModel patches getPatches returns remove patch for deleted field 1
 [
   {
     "fieldName": "name",
-    "metadataChanges": [],
     "patch": {
       "op": "remove",
       "path": "/properties/name",
     },
+    "propertyChanges": [],
   },
 ]
 `;
@@ -205,19 +197,7 @@ exports[`SchemaModel patches getPatches returns remove patch for deleted field 1
 exports[`SchemaModel patches getPatches returns replace patch for default value change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "",
-      "toDefault": "changed",
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "name",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -226,6 +206,13 @@ exports[`SchemaModel patches getPatches returns replace patch for default value 
         "type": "string",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "",
+        "property": "default",
+        "to": "changed",
+      },
+    ],
     "typeChange": undefined,
   },
 ]
@@ -234,19 +221,7 @@ exports[`SchemaModel patches getPatches returns replace patch for default value 
 exports[`SchemaModel patches getPatches returns replace patch for type change 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "",
-      "toDefault": 0,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "name",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -255,6 +230,13 @@ exports[`SchemaModel patches getPatches returns replace patch for type change 1`
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "",
+        "property": "default",
+        "to": 0,
+      },
+    ],
     "typeChange": {
       "fromType": "string",
       "toType": "number",

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.state.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.state.spec.ts.snap
@@ -146,14 +146,7 @@ exports[`SchemaModel state management getPlainSchema serializes simple schema 1`
 exports[`SchemaModel state management markAsSaved resets base tree - new changes tracked from saved state 1`] = `
 [
   {
-    "defaultChange": {
-      "fromDefault": undefined,
-      "toDefault": 0,
-    },
     "fieldName": "field2",
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "add",
       "path": "/properties/field2",
@@ -162,6 +155,13 @@ exports[`SchemaModel state management markAsSaved resets base tree - new changes
         "type": "number",
       },
     },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "default",
+        "to": 0,
+      },
+    ],
   },
 ]
 `;

--- a/src/model/schema-model/__tests__/__snapshots__/SchemaModel.wrap.spec.ts.snap
+++ b/src/model/schema-model/__tests__/__snapshots__/SchemaModel.wrap.spec.ts.snap
@@ -3,14 +3,7 @@
 exports[`SchemaModel wrap operations replaceRoot generates correct patch 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "",
@@ -22,6 +15,7 @@ exports[`SchemaModel wrap operations replaceRoot generates correct patch 1`] = `
         "type": "array",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "object",
       "toType": "array<string>",
@@ -33,19 +27,7 @@ exports[`SchemaModel wrap operations replaceRoot generates correct patch 1`] = `
 exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": {
-      "fromDefault": "",
-      "toDefault": undefined,
-    },
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "name",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [
-      "default",
-    ],
     "patch": {
       "op": "replace",
       "path": "/properties/name",
@@ -57,6 +39,13 @@ exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
         "type": "array",
       },
     },
+    "propertyChanges": [
+      {
+        "from": "",
+        "property": "default",
+        "to": undefined,
+      },
+    ],
     "typeChange": {
       "fromType": "string",
       "toType": "array<string>",
@@ -68,14 +57,7 @@ exports[`SchemaModel wrap operations wrapInArray generates correct patch 1`] = `
 exports[`SchemaModel wrap operations wrapRootInArray generates correct patch 1`] = `
 [
   {
-    "contentMediaTypeChange": undefined,
-    "defaultChange": undefined,
-    "deprecatedChange": undefined,
-    "descriptionChange": undefined,
     "fieldName": "",
-    "foreignKeyChange": undefined,
-    "formulaChange": undefined,
-    "metadataChanges": [],
     "patch": {
       "op": "replace",
       "path": "",
@@ -101,6 +83,7 @@ exports[`SchemaModel wrap operations wrapRootInArray generates correct patch 1`]
         "type": "array",
       },
     },
+    "propertyChanges": [],
     "typeChange": {
       "fromType": "object",
       "toType": "array<object>",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Consolidated schema patch metadata into a new propertyChanges model and added detection for ref and title changes. This simplifies PatchEnricher and types while keeping typeChange and rename behavior.

- **Refactors**
  - Replaced metadataChanges and per-property fields with propertyChanges: PropertyChange[].
  - Added PropertyName union (formula, default, description, deprecated, foreignKey, contentMediaType, ref, title).
  - Rewrote PatchEnricher with property extractors; preserves typeChange and rename detection.
  - Updated README, public exports, tests/snapshots; added ref node helpers and tests for ref/title.

- **Migration**
  - Read changes from propertyChanges instead of formulaChange/defaultChange/descriptionChange/... and metadataChanges.
  - Use PropertyName instead of MetadataChangeType; import PropertyChange/PropertyName from schema-patch.
  - For formulas/defaults, find the entry where property is 'formula' or 'default' and use from/to.
  - Expect propertyChanges on all patches (may be empty); typeChange remains unchanged.

<sup>Written for commit 01bc648ff997f3f1ac3f820c153f5575813eb2a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

