### PR TITLE
feat: id preservation

### DIFF
--- a/src/core/schema-diff/README.md
+++ b/src/core/schema-diff/README.md
@@ -63,17 +63,18 @@ diff.markAsSaved();
 
 ## Type Changes
 
-Track node type changes via replacement:
+When a node's type changes but its ID is preserved (e.g., via `SchemaModel.changeFieldType`), the diff detects the modification naturally — `areNodesEqual()` compares the base and current nodes and reports a `'modified'` change.
+
+For operations where the node ID changes (e.g., `wrapInArray`, `replaceRoot`), use `trackReplacement` to link old and new IDs:
 
 ```typescript
 const oldNodeId = stringNode.id();
-// Replace string node with number node
-const newNodeId = numberNode.id();
+const newNodeId = arrayNode.id();
 
 diff.trackReplacement(oldNodeId, newNodeId);
 
 const changes = diff.collectChanges();
-// Will have 'modified' change with baseNode (string) and currentNode (number)
+// Will have 'modified' change with baseNode (string) and currentNode (array)
 ```
 
 ## Move Into New Parent

--- a/src/core/schema-patch/README.md
+++ b/src/core/schema-patch/README.md
@@ -170,23 +170,29 @@ const patches = builder.build(currentTree, baseTree);
 
 ### Detect type change
 
+When using `SchemaModel.changeFieldType`, node ID is preserved and `trackReplacement` is not needed — the diff detects the change naturally:
+
 ```typescript
 const baseRoot = createObjectNode('root', 'root', [
-  createStringNode('old-id', 'field'),
+  createStringNode('field-id', 'field'),
 ]);
 const currentRoot = createObjectNode('root', 'root', [
-  createNumberNode('new-id', 'field'),
+  createNumberNode('field-id', 'field'),
 ]);
 
 const baseTree = createSchemaTree(baseRoot);
 const currentTree = createSchemaTree(currentRoot);
 
-currentTree.trackReplacement('old-id', 'new-id');
-
 const patches = builder.build(currentTree, baseTree);
 
 // patches[0].typeChange:
 // { fromType: 'string', toType: 'number' }
+```
+
+For operations where the node ID changes (e.g., `wrapInArray`, `replaceRoot`), use `trackReplacement`:
+
+```typescript
+currentTree.trackReplacement('old-id', 'new-id');
 ```
 
 ### Detect property changes

--- a/src/model/schema-model/README.md
+++ b/src/model/schema-model/README.md
@@ -264,6 +264,10 @@ interface FieldSchemaSpec {
 }
 ```
 
+### ID Preservation
+
+`changeFieldType` preserves the node ID — the returned node has the same `id()` as the original. This means `trackReplacement` is not needed for type changes, and the diff system detects the change naturally via `areNodesEqual()`.
+
 ### Smart Transformations
 
 Built-in transformers handle common type conversions intelligently:

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -118,7 +118,6 @@ export class SchemaModelImpl implements SchemaModel {
 
     const result = this._transformChain.transform(node, newType);
     this._currentTree.setNodeAt(path, result.node);
-    this._currentTree.trackReplacement(nodeId, result.node.id());
 
     return result.node;
   }

--- a/src/model/type-transformer/README.md
+++ b/src/model/type-transformer/README.md
@@ -8,7 +8,7 @@ Pluggable type transformation system for schema field type changes.
 core/schema-node  ← SchemaNode, createArrayNode, createRefNode, etc.
 model/schema-model ← RefSchemas, SchemaParser
 mocks/schema.mocks ← obj, ref (for schema construction)
-nanoid            ← ID generation
+nanoid            ← ID generation (for internal child nodes only)
 ```
 
 ## API
@@ -101,7 +101,8 @@ class MyCustomTransformer implements TypeTransformer {
 
   transform(ctx: TransformContext): TransformResult {
     // Create and return transformed node
-    return { node: createNumberNode(nanoid(), ctx.sourceNode.name(), { defaultValue: 0 }) };
+    // Use sourceNode.id() to preserve the node identity
+    return { node: createNumberNode(ctx.sourceNode.id(), ctx.sourceNode.name(), { defaultValue: 0 }) };
   }
 }
 
@@ -109,6 +110,14 @@ const chain = createTypeTransformChain({
   customTransformers: [new MyCustomTransformer()],
 });
 ```
+
+## Node ID Preservation
+
+All built-in transformers preserve the source node's ID on the outermost returned node. This means `result.node.id() === sourceNode.id()`. Internal child nodes (e.g., items inside a new array) receive new IDs via `nanoid()`.
+
+This behavior enables UI frameworks to maintain DOM element identity across type changes, preventing unnecessary destruction and recreation of UI components.
+
+Custom transformers should follow the same convention: use `sourceNode.id()` for the top-level returned node.
 
 ## Built-in Transformers
 

--- a/src/model/type-transformer/__tests__/TypeTransformChain.spec.ts
+++ b/src/model/type-transformer/__tests__/TypeTransformChain.spec.ts
@@ -233,8 +233,8 @@ describe('TypeTransformChain', () => {
     });
   });
 
-  describe('new node id', () => {
-    it('creates node with new id', () => {
+  describe('node id preservation', () => {
+    it('preserves source node id', () => {
       const model = createModel(obj({ field: str() }));
       const source = getFieldNode(model, 'field');
       const originalId = source.id();
@@ -242,7 +242,7 @@ describe('TypeTransformChain', () => {
 
       const result = chain.transform(source, 'number');
 
-      expect(result.node.id()).not.toBe(originalId);
+      expect(result.node.id()).toBe(originalId);
     });
   });
 

--- a/src/model/type-transformer/transformers/ArrayToItemsTypeTransformer.ts
+++ b/src/model/type-transformer/transformers/ArrayToItemsTypeTransformer.ts
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid';
 import type { TypeTransformer, TransformContext, TransformResult, PrimitiveTypeName } from '../types.js';
 
 export class ArrayToItemsTypeTransformer implements TypeTransformer {
@@ -18,7 +17,7 @@ export class ArrayToItemsTypeTransformer implements TypeTransformer {
   transform(ctx: TransformContext): TransformResult {
     const { sourceNode } = ctx;
     const items = sourceNode.items();
-    const newNode = items.cloneWithId(nanoid());
+    const newNode = items.cloneWithId(sourceNode.id());
     newNode.setName(sourceNode.name());
     return { node: newNode };
   }

--- a/src/model/type-transformer/transformers/DefaultTransformer.ts
+++ b/src/model/type-transformer/transformers/DefaultTransformer.ts
@@ -18,11 +18,12 @@ export class DefaultTransformer implements TypeTransformer {
     const { sourceNode, targetSpec } = ctx;
     const type = targetSpec.type!;
     const metadata = this.extractMetadata(targetSpec);
-    const node = this.createNode(sourceNode.name(), type, targetSpec, metadata);
+    const node = this.createNode(sourceNode.id(), sourceNode.name(), type, targetSpec, metadata);
     return { node };
   }
 
   private createNode(
+    id: string,
     name: string,
     type: SimpleFieldType,
     spec: TransformContext['targetSpec'],
@@ -30,33 +31,33 @@ export class DefaultTransformer implements TypeTransformer {
   ): SchemaNode {
     switch (type) {
       case 'string':
-        return createStringNode(nanoid(), name, {
+        return createStringNode(id, name, {
           defaultValue: spec.default as string ?? '',
           foreignKey: spec.foreignKey,
           metadata,
         });
       case 'number':
-        return createNumberNode(nanoid(), name, {
+        return createNumberNode(id, name, {
           defaultValue: spec.default as number ?? 0,
           metadata,
         });
       case 'boolean':
-        return createBooleanNode(nanoid(), name, {
+        return createBooleanNode(id, name, {
           defaultValue: spec.default as boolean ?? false,
           metadata,
         });
       case 'object':
-        return createObjectNode(nanoid(), name, [], { metadata });
+        return createObjectNode(id, name, [], { metadata });
       case 'array':
-        return this.createArrayNode(name, metadata);
+        return this.createArrayNode(id, name, metadata);
       default:
         throw new Error(`Unknown field type: ${type}`);
     }
   }
 
-  private createArrayNode(name: string, metadata?: NodeMetadata): SchemaNode {
+  private createArrayNode(id: string, name: string, metadata?: NodeMetadata): SchemaNode {
     const items = createStringNode(nanoid(), 'items', { defaultValue: '' });
-    return createArrayNode(nanoid(), name, items, { metadata });
+    return createArrayNode(id, name, items, { metadata });
   }
 
   private extractMetadata(spec: TransformContext['targetSpec']): NodeMetadata | undefined {

--- a/src/model/type-transformer/transformers/ObjectToArrayTransformer.ts
+++ b/src/model/type-transformer/transformers/ObjectToArrayTransformer.ts
@@ -12,7 +12,7 @@ export class ObjectToArrayTransformer implements TypeTransformer {
     const { sourceNode } = ctx;
     const itemsNode = sourceNode.cloneWithId(nanoid());
     itemsNode.setName('items');
-    const arrayNode = createArrayNode(nanoid(), sourceNode.name(), itemsNode);
+    const arrayNode = createArrayNode(sourceNode.id(), sourceNode.name(), itemsNode);
     return { node: arrayNode };
   }
 }

--- a/src/model/type-transformer/transformers/PrimitiveToArrayTransformer.ts
+++ b/src/model/type-transformer/transformers/PrimitiveToArrayTransformer.ts
@@ -12,7 +12,7 @@ export class PrimitiveToArrayTransformer implements TypeTransformer {
     const { sourceNode } = ctx;
     const itemsNode = sourceNode.cloneWithId(nanoid());
     itemsNode.setName('items');
-    const arrayNode = createArrayNode(nanoid(), sourceNode.name(), itemsNode);
+    const arrayNode = createArrayNode(sourceNode.id(), sourceNode.name(), itemsNode);
     return { node: arrayNode };
   }
 }

--- a/src/model/type-transformer/transformers/RefTransformer.ts
+++ b/src/model/type-transformer/transformers/RefTransformer.ts
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid';
 import { createRefNode } from '../../../core/schema-node/index.js';
 import { obj, ref } from '../../../mocks/schema.mocks.js';
 import type { TypeTransformer, TransformContext, TransformResult } from '../types.js';
@@ -19,13 +18,13 @@ export class RefTransformer implements TypeTransformer {
       const wrapperSchema = obj({ temp: ref(refUri) });
       const resolvedNode = parser.parse(wrapperSchema, refSchemas);
       const tempNode = resolvedNode.property('temp');
-      const newNode = tempNode.cloneWithId(nanoid());
+      const newNode = tempNode.cloneWithId(sourceNode.id());
       newNode.setName(sourceNode.name());
       return { node: newNode };
     }
 
     const metadata = this.extractMetadata(targetSpec);
-    const node = createRefNode(nanoid(), sourceNode.name(), refUri, metadata);
+    const node = createRefNode(sourceNode.id(), sourceNode.name(), refUri, metadata);
     return { node };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves node IDs during field type changes to keep UI element identity stable. Removes the need to track replacements when changing field types.

- **New Features**
  - SchemaModel.changeFieldType keeps the original node ID; removed the internal trackReplacement call.
  - All built-in transformers return a node with sourceNode.id(); only new child nodes use nanoid.
  - Diff/Patch: type changes are detected naturally without trackReplacement; still use it for operations that replace IDs (e.g., wrapInArray, replaceRoot).

<sup>Written for commit 3ca6dfd7fe0413539071c815c63de3850b690992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

