### PR TITLE
fix: parent and child renaming

### DIFF
--- a/src/core/schema-diff/ChangeCoalescer.ts
+++ b/src/core/schema-diff/ChangeCoalescer.ts
@@ -102,20 +102,8 @@ export class ChangeCoalescer {
     for (const other of allChanges) {
       if (other === change) continue;
 
-      if (other.type === 'modified') {
-        if (!this.isTypeChangeReplacement(other)) {
-          continue;
-        }
-      }
-
-      if (change.type === 'moved' && other.type === 'added') {
+      if (this.shouldSkipParentCandidate(change, other)) {
         continue;
-      }
-
-      if (change.type === 'moved' && other.type === 'moved') {
-        if (this.hasIndependentRename(change)) {
-          continue;
-        }
       }
 
       const otherPath = this.getChangePath(other);
@@ -123,6 +111,25 @@ export class ChangeCoalescer {
       if (path.isChildOf(otherPath)) {
         return true;
       }
+    }
+
+    return false;
+  }
+
+  private shouldSkipParentCandidate(
+    change: RawChange,
+    other: RawChange,
+  ): boolean {
+    if (other.type === 'modified' && !this.isTypeChangeReplacement(other)) {
+      return true;
+    }
+
+    if (change.type === 'moved' && other.type === 'added') {
+      return true;
+    }
+
+    if (change.type === 'moved' && other.type === 'moved') {
+      return this.hasIndependentRename(change);
     }
 
     return false;

--- a/src/core/schema-diff/ChangeCoalescer.ts
+++ b/src/core/schema-diff/ChangeCoalescer.ts
@@ -112,6 +112,12 @@ export class ChangeCoalescer {
         continue;
       }
 
+      if (change.type === 'moved' && other.type === 'moved') {
+        if (this.hasIndependentRename(change)) {
+          continue;
+        }
+      }
+
       const otherPath = this.getChangePath(other);
 
       if (path.isChildOf(otherPath)) {
@@ -124,6 +130,10 @@ export class ChangeCoalescer {
 
   private isTypeChangeReplacement(change: ModifiedChange): boolean {
     return change.baseNode.nodeType() !== change.currentNode.nodeType();
+  }
+
+  private hasIndependentRename(change: MovedChange): boolean {
+    return change.baseNode.name() !== change.currentNode.name();
   }
 
   private isAffectedByMove(

--- a/src/core/schema-patch/PatchGenerator.ts
+++ b/src/core/schema-patch/PatchGenerator.ts
@@ -94,22 +94,35 @@ export class PatchGenerator {
   }
 
   private generateMovePatches(moved: readonly MovedChange[]): JsonPatch[] {
+    const movedNodeIds = this.collectMovedNodeIds(moved);
+    const sorted = this.sortMovesParentFirst(moved);
     const patches: JsonPatch[] = [];
+    const appliedMoves: Array<{ from: string; to: string }> = [];
 
-    for (const change of moved) {
+    for (const change of sorted) {
       const basePath = this.baseTree.pathOf(change.baseNode.id());
       const currentPath = this.currentTree.pathOf(change.currentNode.id());
+      const adjustedFrom = this.adjustFromPath(
+        basePath.asJsonPointer(),
+        appliedMoves,
+      );
 
       patches.push({
         op: 'move',
-        from: basePath.asJsonPointer(),
+        from: adjustedFrom,
         path: currentPath.asJsonPointer(),
+      });
+
+      appliedMoves.push({
+        from: basePath.asJsonPointer(),
+        to: currentPath.asJsonPointer(),
       });
 
       const modifyPatch = this.generateModifyAfterMove(
         change.baseNode,
         change.currentNode,
         currentPath.asJsonPointer(),
+        movedNodeIds,
       );
       if (modifyPatch) {
         patches.push(modifyPatch);
@@ -119,12 +132,40 @@ export class PatchGenerator {
     return patches;
   }
 
+  private sortMovesParentFirst(
+    moved: readonly MovedChange[],
+  ): readonly MovedChange[] {
+    return [...moved].sort((a, b) => {
+      const pathA = this.baseTree.pathOf(a.baseNode.id()).asJsonPointer();
+      const pathB = this.baseTree.pathOf(b.baseNode.id()).asJsonPointer();
+      return pathA.length - pathB.length;
+    });
+  }
+
+  private adjustFromPath(
+    fromPath: string,
+    appliedMoves: ReadonlyArray<{ from: string; to: string }>,
+  ): string {
+    let adjusted = fromPath;
+    for (const move of appliedMoves) {
+      if (adjusted.startsWith(move.from + '/')) {
+        adjusted = move.to + adjusted.slice(move.from.length);
+      }
+    }
+    return adjusted;
+  }
+
   private generateModifyAfterMove(
     baseNode: SchemaNode,
     currentNode: SchemaNode,
     currentPath: string,
+    siblingMovedIds: Set<string>,
   ): JsonPatch | null {
     if (areNodesContentEqual(currentNode, baseNode, this.context)) {
+      return null;
+    }
+
+    if (this.isDifferenceExplainedByMoves(currentNode, baseNode, siblingMovedIds)) {
       return null;
     }
 
@@ -138,6 +179,48 @@ export class PatchGenerator {
       path: currentPath,
       value: currentSchema,
     };
+  }
+
+  private isDifferenceExplainedByMoves(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+    movedIds: Set<string>,
+  ): boolean {
+    if (!currentNode.isObject() || !baseNode.isObject()) {
+      return false;
+    }
+
+    const currentProps = currentNode.properties();
+    const baseProps = baseNode.properties();
+
+    if (currentProps.length !== baseProps.length) {
+      return false;
+    }
+
+    for (const prop of currentProps) {
+      const matchByName = baseProps.find((b) => b.name() === prop.name());
+      if (matchByName) {
+        if (!areNodesContentEqual(prop, matchByName, this.context)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (!movedIds.has(prop.id())) {
+        return false;
+      }
+
+      const matchById = baseProps.find((b) => b.id() === prop.id());
+      if (!matchById) {
+        return false;
+      }
+
+      if (!areNodesContentEqual(prop, matchById, this.context)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private generateAddPatches(

--- a/src/core/schema-patch/PatchGenerator.ts
+++ b/src/core/schema-patch/PatchGenerator.ts
@@ -114,7 +114,7 @@ export class PatchGenerator {
       });
 
       appliedMoves.push({
-        from: basePath.asJsonPointer(),
+        from: adjustedFrom,
         to: currentPath.asJsonPointer(),
       });
 
@@ -200,7 +200,7 @@ export class PatchGenerator {
     for (const prop of currentProps) {
       const matchByName = baseProps.find((b) => b.name() === prop.name());
       if (matchByName) {
-        if (!areNodesContentEqual(prop, matchByName, this.context)) {
+        if (!this.areNodesEqualAccountingMoves(prop, matchByName, movedIds)) {
           return false;
         }
         continue;
@@ -215,12 +215,24 @@ export class PatchGenerator {
         return false;
       }
 
-      if (!areNodesContentEqual(prop, matchById, this.context)) {
+      if (!this.areNodesEqualAccountingMoves(prop, matchById, movedIds)) {
         return false;
       }
     }
 
     return true;
+  }
+
+  private areNodesEqualAccountingMoves(
+    currentNode: SchemaNode,
+    baseNode: SchemaNode,
+    movedIds: Set<string>,
+  ): boolean {
+    if (areNodesContentEqual(currentNode, baseNode, this.context)) {
+      return true;
+    }
+
+    return this.isDifferenceExplainedByMoves(currentNode, baseNode, movedIds);
   }
 
   private generateAddPatches(

--- a/src/core/schema-patch/__tests__/PatchBuilder.nested.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.nested.spec.ts
@@ -9,6 +9,60 @@ import {
 } from './test-helpers.js';
 
 describe('PatchBuilder nested operations', () => {
+  it('generates two move patches when parent and child are both renamed', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj('oldParent', [str('oldChild', { id: 'child-id' })], {
+          id: 'parent-id',
+        }),
+      ]),
+      objRoot([
+        obj('newParent', [str('newChild', { id: 'child-id' })], {
+          id: 'parent-id',
+        }),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    const movePatches = patches.filter((p) => p.patch.op === 'move');
+    const replacePatches = patches.filter((p) => p.patch.op === 'replace');
+
+    expect(movePatches).toHaveLength(2);
+    expect(replacePatches).toHaveLength(0);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+
+  it('generates moves and replaces when parent and child are both renamed with description added', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj('oldParent', [str('oldChild', { id: 'child-id' })], {
+          id: 'parent-id',
+        }),
+      ]),
+      objRoot([
+        obj(
+          'newParent',
+          [str('newChild', { id: 'child-id', description: 'child desc' })],
+          { id: 'parent-id', description: 'parent desc' },
+        ),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    const movePatches = patches.filter((p) => p.patch.op === 'move');
+    const replacePatches = patches.filter((p) => p.patch.op === 'replace');
+
+    expect(movePatches).toHaveLength(2);
+    expect(replacePatches).toHaveLength(2);
+    expect(patches).toHaveLength(4);
+
+    expect(patches).toMatchSnapshot();
+  });
+
   it('generates replace patch for nested field modification', () => {
     const { base, current } = treePair(
       objRoot([obj('nested', [num('value', { default: 10 })])]),

--- a/src/core/schema-patch/__tests__/PatchBuilder.nested.spec.ts
+++ b/src/core/schema-patch/__tests__/PatchBuilder.nested.spec.ts
@@ -63,6 +63,99 @@ describe('PatchBuilder nested operations', () => {
     expect(patches).toMatchSnapshot();
   });
 
+  it('generates three move patches for deeply nested renames (parent, child, grandchild)', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj(
+          'oldParent',
+          [
+            obj(
+              'oldChild',
+              [str('oldGrandchild', { id: 'gc-id' })],
+              { id: 'child-id' },
+            ),
+          ],
+          { id: 'parent-id' },
+        ),
+      ]),
+      objRoot([
+        obj(
+          'newParent',
+          [
+            obj(
+              'newChild',
+              [str('newGrandchild', { id: 'gc-id' })],
+              { id: 'child-id' },
+            ),
+          ],
+          { id: 'parent-id' },
+        ),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    const movePatches = patches.filter((p) => p.patch.op === 'move');
+    const replacePatches = patches.filter((p) => p.patch.op === 'replace');
+
+    expect(movePatches).toHaveLength(3);
+    expect(replacePatches).toHaveLength(0);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates move and replace when parent renamed and child added', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj('oldParent', [str('existing')], { id: 'parent-id' }),
+      ]),
+      objRoot([
+        obj('newParent', [str('existing'), str('added')], {
+          id: 'parent-id',
+        }),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    const movePatches = patches.filter((p) => p.patch.op === 'move');
+    const replacePatches = patches.filter((p) => p.patch.op === 'replace');
+
+    expect(movePatches).toHaveLength(1);
+    expect(replacePatches).toHaveLength(1);
+
+    expect(patches).toMatchSnapshot();
+  });
+
+  it('generates move for parent and move for child when sibling stays unchanged', () => {
+    const { base, current } = treePair(
+      objRoot([
+        obj(
+          'oldParent',
+          [str('oldChild', { id: 'child-id' }), num('stable')],
+          { id: 'parent-id' },
+        ),
+      ]),
+      objRoot([
+        obj(
+          'newParent',
+          [str('newChild', { id: 'child-id' }), num('stable')],
+          { id: 'parent-id' },
+        ),
+      ]),
+    );
+
+    const patches = builder.build(current, base);
+
+    const movePatches = patches.filter((p) => p.patch.op === 'move');
+    const replacePatches = patches.filter((p) => p.patch.op === 'replace');
+
+    expect(movePatches).toHaveLength(2);
+    expect(replacePatches).toHaveLength(0);
+
+    expect(patches).toMatchSnapshot();
+  });
+
   it('generates replace patch for nested field modification', () => {
     const { base, current } = treePair(
       objRoot([obj('nested', [num('value', { default: 10 })])]),

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PatchBuilder nested operations generates move and replace when parent renamed and child added 1`] = `
+[
+  {
+    "fieldName": "newParent",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/oldParent",
+      "op": "move",
+      "path": "/properties/newParent",
+    },
+    "propertyChanges": [],
+  },
+  {
+    "fieldName": "newParent",
+    "patch": {
+      "op": "replace",
+      "path": "/properties/newParent",
+      "value": {
+        "additionalProperties": false,
+        "properties": {
+          "added": {
+            "default": "",
+            "type": "string",
+          },
+          "existing": {
+            "default": "",
+            "type": "string",
+          },
+        },
+        "required": [
+          "existing",
+          "added",
+        ],
+        "type": "object",
+      },
+    },
+    "propertyChanges": [],
+    "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder nested operations generates move for parent and move for child when sibling stays unchanged 1`] = `
+[
+  {
+    "fieldName": "newParent",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/oldParent",
+      "op": "move",
+      "path": "/properties/newParent",
+    },
+    "propertyChanges": [],
+  },
+  {
+    "fieldName": "newParent.newChild",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/newParent/properties/oldChild",
+      "op": "move",
+      "path": "/properties/newParent/properties/newChild",
+    },
+    "propertyChanges": [],
+  },
+]
+`;
+
 exports[`PatchBuilder nested operations generates move patch for renamed nested field 1`] = `
 [
   {
@@ -169,6 +239,44 @@ exports[`PatchBuilder nested operations generates replace patch for nested field
       },
     ],
     "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder nested operations generates three move patches for deeply nested renames (parent, child, grandchild) 1`] = `
+[
+  {
+    "fieldName": "newParent",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/oldParent",
+      "op": "move",
+      "path": "/properties/newParent",
+    },
+    "propertyChanges": [],
+  },
+  {
+    "fieldName": "newParent.newChild",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/newParent/properties/oldChild",
+      "op": "move",
+      "path": "/properties/newParent/properties/newChild",
+    },
+    "propertyChanges": [],
+  },
+  {
+    "fieldName": "newParent.newChild.newGrandchild",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/newParent/properties/newChild/properties/oldGrandchild",
+      "op": "move",
+      "path": "/properties/newParent/properties/newChild/properties/newGrandchild",
+    },
+    "propertyChanges": [],
   },
 ]
 `;

--- a/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
+++ b/src/core/schema-patch/__tests__/__snapshots__/PatchBuilder.nested.spec.ts.snap
@@ -16,6 +16,95 @@ exports[`PatchBuilder nested operations generates move patch for renamed nested 
 ]
 `;
 
+exports[`PatchBuilder nested operations generates moves and replaces when parent and child are both renamed with description added 1`] = `
+[
+  {
+    "fieldName": "newParent",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/oldParent",
+      "op": "move",
+      "path": "/properties/newParent",
+    },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "parent desc",
+      },
+    ],
+  },
+  {
+    "fieldName": "newParent",
+    "patch": {
+      "op": "replace",
+      "path": "/properties/newParent",
+      "value": {
+        "additionalProperties": false,
+        "description": "parent desc",
+        "properties": {
+          "newChild": {
+            "default": "",
+            "description": "child desc",
+            "type": "string",
+          },
+        },
+        "required": [
+          "newChild",
+        ],
+        "type": "object",
+      },
+    },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "parent desc",
+      },
+    ],
+    "typeChange": undefined,
+  },
+  {
+    "fieldName": "newParent.newChild",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/newParent/properties/oldChild",
+      "op": "move",
+      "path": "/properties/newParent/properties/newChild",
+    },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "child desc",
+      },
+    ],
+  },
+  {
+    "fieldName": "newParent.newChild",
+    "patch": {
+      "op": "replace",
+      "path": "/properties/newParent/properties/newChild",
+      "value": {
+        "default": "",
+        "description": "child desc",
+        "type": "string",
+      },
+    },
+    "propertyChanges": [
+      {
+        "from": undefined,
+        "property": "description",
+        "to": "child desc",
+      },
+    ],
+    "typeChange": undefined,
+  },
+]
+`;
+
 exports[`PatchBuilder nested operations generates multiple patches for multiple changes in one object 1`] = `
 [
   {
@@ -80,6 +169,33 @@ exports[`PatchBuilder nested operations generates replace patch for nested field
       },
     ],
     "typeChange": undefined,
+  },
+]
+`;
+
+exports[`PatchBuilder nested operations generates two move patches when parent and child are both renamed 1`] = `
+[
+  {
+    "fieldName": "newParent",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/oldParent",
+      "op": "move",
+      "path": "/properties/newParent",
+    },
+    "propertyChanges": [],
+  },
+  {
+    "fieldName": "newParent.newChild",
+    "isRename": true,
+    "movesIntoArray": undefined,
+    "patch": {
+      "from": "/properties/newParent/properties/oldChild",
+      "op": "move",
+      "path": "/properties/newParent/properties/newChild",
+    },
+    "propertyChanges": [],
   },
 ]
 `;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes nested rename handling so both parent and child renames produce correct move patches without redundant replaces. Also orders moves and rewrites paths to keep JSON Pointers valid during sequential moves.

- **Bug Fixes**
  - Coalescer preserves a child move when the child is renamed independently of a moved parent; still filters the child if its name did not change.
  - Patch generator sorts moves parent-first and adjusts each move’s from path based on earlier moves to avoid broken pointers.
  - Skips replace patches when differences are fully explained by sibling moves, using moved node IDs to detect this.
  - Added tests for parent+child renames and for renames with added descriptions; updated snapshots.

<sup>Written for commit 2bf1ccd9bd0715e1cec58df06b4778ee2fe1ea44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

