### PR TITLE
fix: formula errors

### DIFF
--- a/src/core/schema-serializer/SchemaSerializer.ts
+++ b/src/core/schema-serializer/SchemaSerializer.ts
@@ -179,7 +179,11 @@ export class SchemaSerializer {
       );
     }
 
-    return FormulaSerializer.toXFormula(this.tree, node.id(), formula);
+    try {
+      return FormulaSerializer.toXFormula(this.tree, node.id(), formula);
+    } catch {
+      return { version: 1, expression: '' };
+    }
   }
 
   private addMetadata<T extends JsonSchema>(schema: T, node: SchemaNode): T {

--- a/src/core/validation/formula/FormulaValidator.ts
+++ b/src/core/validation/formula/FormulaValidator.ts
@@ -16,10 +16,6 @@ function collectFormulaErrors(
   errors: TreeFormulaValidationError[],
   fieldPath: string,
 ): void {
-  if (node.isNull()) {
-    return;
-  }
-
   validateNodeFormula(node, tree, errors, fieldPath);
   collectChildErrors(node, tree, errors, fieldPath);
 }

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -354,12 +354,16 @@ export class SchemaModelImpl implements SchemaModel {
     if (!formula) {
       return '';
     }
-    return FormulaSerializer.serializeExpression(
-      this._currentTree,
-      nodeId,
-      formula,
-      { strict: false },
-    );
+    try {
+      return FormulaSerializer.serializeExpression(
+        this._currentTree,
+        nodeId,
+        formula,
+        { strict: false },
+      );
+    } catch {
+      return '';
+    }
   }
 
   get validationErrors(): SchemaValidationError[] {

--- a/src/model/schema-model/__tests__/SchemaModel.serializeFormula.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.serializeFormula.spec.ts
@@ -75,6 +75,36 @@ describe('SchemaModel serializeFormula', () => {
 
       expect(model.serializeFormula('non-existent')).toBe('');
     });
+
+    it('returns empty string when formula serialization fails after rename to empty', () => {
+      const schema = obj({
+        price: num(),
+        quantity: num(),
+        total: num({ readOnly: true, formula: 'price * quantity' }),
+      });
+      const model = createSchemaModel(schema);
+      const priceId = findNodeIdByName(model, 'price');
+      const totalId = findNodeIdByName(model, 'total');
+
+      model.renameField(priceId!, '');
+
+      expect(model.serializeFormula(totalId!)).toBe('');
+    });
+
+    it('returns empty string when formula serialization fails after rename to invalid identifier', () => {
+      const schema = obj({
+        price: num(),
+        quantity: num(),
+        total: num({ readOnly: true, formula: 'price * quantity' }),
+      });
+      const model = createSchemaModel(schema);
+      const priceId = findNodeIdByName(model, 'price');
+      const totalId = findNodeIdByName(model, 'total');
+
+      model.renameField(priceId!, '2price');
+
+      expect(model.serializeFormula(totalId!)).toBe('');
+    });
   });
 
   describe('serializeFormula reactivity', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents crashes and confusing errors when field renames break formulas. Serialization now falls back to empty expressions, and the validator reports clear “Invalid formula” errors.

- **Bug Fixes**
  - Serialization: catch failures in SchemaSerializer and SchemaModelImpl; return x-formula { version: 1, expression: '' } or '' instead of throwing.
  - Validation: serialize with strict: false, run validateFormulaSyntax, and report “Invalid formula …” or “Invalid formula expression” on failure (e.g., dependencies renamed to empty or invalid identifiers).
  - Tests: added cases covering rename-to-empty and rename-to-invalid-identifier to ensure empty formulas and proper error reporting.

<sup>Written for commit 4e49ea2878f62141f52baa8e9a317278defec71c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

