### PR TITLE
fix: schema diff

### DIFF
--- a/src/core/schema-diff/SchemaComparator.ts
+++ b/src/core/schema-diff/SchemaComparator.ts
@@ -141,6 +141,10 @@ function areFormulasEqual(
     baseNodeId,
   );
 
+  if (currentExpr === null || baseExpr === null) {
+    return false;
+  }
+
   return currentExpr === baseExpr;
 }
 
@@ -148,8 +152,12 @@ function getSerializedExpression(
   formula: Formula,
   tree: SchemaTree,
   nodeId: string,
-): string {
-  return FormulaSerializer.serializeExpression(tree, nodeId, formula, { strict: false });
+): string | null {
+  try {
+    return FormulaSerializer.serializeExpression(tree, nodeId, formula, { strict: false });
+  } catch {
+    return null;
+  }
 }
 
 function areObjectsEqual(

--- a/src/core/schema-patch/PatchEnricher.ts
+++ b/src/core/schema-patch/PatchEnricher.ts
@@ -110,7 +110,11 @@ export class PatchEnricher {
           if (!formula || !node) {
             return undefined;
           }
-          return FormulaSerializer.serializeExpression(tree, node.id(), formula, { strict: false });
+          try {
+            return FormulaSerializer.serializeExpression(tree, node.id(), formula, { strict: false });
+          } catch {
+            return undefined;
+          }
         },
         compare: (from, to) => from === to,
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents crashes in schema diff when formula serialization fails (e.g., after renaming a field to empty or an invalid identifier). Diffs now complete and patches build instead of throwing.

- **Bug Fixes**
  - SchemaComparator: catch serialization errors; treat failed serializations as unequal formulas.
  - PatchEnricher: guard formula serialization with try/catch; return undefined on failure.
  - Tests: added cases for renames to '' and '2price' to ensure no throw and patches are produced.

<sup>Written for commit 82d27829262401ed5a5b707391fc8fb03d1e34a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

