### PR TITLE
fix: non object root

### DIFF
--- a/src/core/schema-tree/SchemaTreeImpl.ts
+++ b/src/core/schema-tree/SchemaTreeImpl.ts
@@ -80,6 +80,10 @@ export class SchemaTreeImpl implements SchemaTree {
     return this._replacements.entries();
   }
 
+  clearReplacements(): void {
+    this._replacements.clear();
+  }
+
   addChildTo(parentId: string, node: SchemaNode): void {
     const parent = this.nodeById(parentId);
     if (parent.isNull()) {

--- a/src/core/schema-tree/types.ts
+++ b/src/core/schema-tree/types.ts
@@ -11,6 +11,7 @@ export interface SchemaTree {
   clone(): SchemaTree;
   trackReplacement(oldNodeId: string, newNodeId: string): void;
   replacements(): IterableIterator<[string, string]>;
+  clearReplacements(): void;
 
   addChildTo(parentId: string, node: SchemaNode): void;
   insertChildAt(parentId: string, index: number, node: SchemaNode): void;

--- a/src/model/schema-model/SchemaModelImpl.ts
+++ b/src/model/schema-model/SchemaModelImpl.ts
@@ -380,7 +380,7 @@ export class SchemaModelImpl implements SchemaModel {
 
   get isValid(): boolean {
     return (
-      this._currentTree.root().isObject() &&
+      !this._currentTree.root().isNull() &&
       this.validationErrors.length === 0 &&
       this.formulaErrors.length === 0
     );
@@ -396,6 +396,7 @@ export class SchemaModelImpl implements SchemaModel {
 
   markAsSaved(): void {
     this._baseTree = this._currentTree.clone();
+    this._currentTree.clearReplacements();
   }
 
   revert(): void {

--- a/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.patches.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import type { JsonObjectSchema } from '../../../types/index.js';
 import { createSchemaModel } from '../SchemaModelImpl.js';
-import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
+import { obj, str, arr } from '../../../mocks/schema.mocks.js';
 import {
   emptySchema,
   simpleSchema,

--- a/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
+import type { JsonObjectSchema } from '../../../types/index.js';
+import { str, num, bool, arr } from '../../../mocks/schema.mocks.js';
 import { createSchemaModel } from '../SchemaModelImpl.js';
 import {
   emptySchema,
@@ -116,6 +118,37 @@ describe('SchemaModel state management', () => {
 
     it('returns true for empty schema', () => {
       const model = createSchemaModel(emptySchema());
+
+      expect(model.isValid).toBe(true);
+    });
+
+    it('returns true for array root schema', () => {
+      const model = createSchemaModel(arr(str()) as unknown as JsonObjectSchema);
+
+      expect(model.isValid).toBe(true);
+    });
+
+    it('returns true for primitive string root schema', () => {
+      const model = createSchemaModel(str() as unknown as JsonObjectSchema);
+
+      expect(model.isValid).toBe(true);
+    });
+
+    it('returns true for primitive number root schema', () => {
+      const model = createSchemaModel(num() as unknown as JsonObjectSchema);
+
+      expect(model.isValid).toBe(true);
+    });
+
+    it('returns true for primitive boolean root schema', () => {
+      const model = createSchemaModel(bool() as unknown as JsonObjectSchema);
+
+      expect(model.isValid).toBe(true);
+    });
+
+    it('returns true for array root after replaceRoot', () => {
+      const model = createSchemaModel(emptySchema());
+      model.replaceRoot('string');
 
       expect(model.isValid).toBe(true);
     });

--- a/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.state.spec.ts
@@ -146,7 +146,7 @@ describe('SchemaModel state management', () => {
       expect(model.isValid).toBe(true);
     });
 
-    it('returns true for array root after replaceRoot', () => {
+    it('returns true for non-object root after replaceRoot', () => {
       const model = createSchemaModel(emptySchema());
       model.replaceRoot('string');
 

--- a/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.validation.spec.ts
@@ -197,12 +197,12 @@ describe('SchemaModel validation', () => {
       expect(model.isValid).toBe(false);
     });
 
-    it('returns false when root is not object', () => {
+    it('returns true when root is not object', () => {
       const model = createSchemaModel(simpleSchema());
 
       model.replaceRoot('array');
 
-      expect(model.isValid).toBe(false);
+      expect(model.isValid).toBe(true);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes validation and patch tracking when the schema root isn’t an object. Array and primitive roots are now valid and correctly handle dirty state, patches, save, and revert.

- **Bug Fixes**
  - Validation no longer requires an object root; only fails if root is null or there are errors.
  - Patches/dirty: unchanged non-object roots produce no patches; replaceRoot creates a single replace patch at path ""; revert restores the original root type.
  - Saving: added SchemaTree.clearReplacements() and call it in markAsSaved to clear patches after save.

<sup>Written for commit 1be89dcdf1c9d5130fc861032dd0a1f0fee3ac53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

