### PR TITLE
feat: create row model

### DIFF
--- a/src/core/value-path/ValuePath.ts
+++ b/src/core/value-path/ValuePath.ts
@@ -23,6 +23,23 @@ class ValuePathImpl
     return parts.join('');
   }
 
+  asJsonPointer(): string {
+    if (this.segs.length === 0) {
+      return '';
+    }
+
+    const parts: string[] = [];
+    for (const seg of this.segs) {
+      if (seg.isProperty()) {
+        parts.push(seg.propertyName());
+      } else if (seg.isIndex()) {
+        parts.push(String(seg.indexValue()));
+      }
+    }
+
+    return '/' + parts.join('/');
+  }
+
   parent(): ValuePath {
     if (this.segs.length <= 1) {
       return EMPTY_VALUE_PATH;

--- a/src/core/value-path/__tests__/ValuePath.spec.ts
+++ b/src/core/value-path/__tests__/ValuePath.spec.ts
@@ -84,6 +84,58 @@ describe('ValuePath', () => {
     });
   });
 
+  describe('asJsonPointer', () => {
+    it('returns empty string for empty path', () => {
+      expect(EMPTY_VALUE_PATH.asJsonPointer()).toBe('');
+    });
+
+    it('returns /name for single property', () => {
+      const path = createValuePath([new PropertySegment('name')]);
+      expect(path.asJsonPointer()).toBe('/name');
+    });
+
+    it('returns slash-separated for nested properties', () => {
+      const path = createValuePath([
+        new PropertySegment('address'),
+        new PropertySegment('city'),
+      ]);
+      expect(path.asJsonPointer()).toBe('/address/city');
+    });
+
+    it('returns numeric index for array access', () => {
+      const path = createValuePath([
+        new PropertySegment('items'),
+        new IndexSegment(0),
+      ]);
+      expect(path.asJsonPointer()).toBe('/items/0');
+    });
+
+    it('returns complex path correctly', () => {
+      const path = createValuePath([
+        new PropertySegment('users'),
+        new IndexSegment(0),
+        new PropertySegment('addresses'),
+        new IndexSegment(1),
+        new PropertySegment('city'),
+      ]);
+      expect(path.asJsonPointer()).toBe('/users/0/addresses/1/city');
+    });
+
+    it('handles standalone index', () => {
+      const path = createValuePath([new IndexSegment(0)]);
+      expect(path.asJsonPointer()).toBe('/0');
+    });
+
+    it('handles nested indices', () => {
+      const path = createValuePath([
+        new PropertySegment('matrix'),
+        new IndexSegment(0),
+        new IndexSegment(1),
+      ]);
+      expect(path.asJsonPointer()).toBe('/matrix/0/1');
+    });
+  });
+
   describe('parent', () => {
     it('returns empty path for single segment', () => {
       const path = createValuePath([new PropertySegment('name')]);

--- a/src/core/value-path/types.ts
+++ b/src/core/value-path/types.ts
@@ -10,6 +10,7 @@ export interface ValuePathSegment extends BasePathSegment {
 
 export interface ValuePath extends BasePath<ValuePathSegment, ValuePath> {
   asString(): string;
+  asJsonPointer(): string;
   child(name: string): ValuePath;
   childIndex(index: number): ValuePath;
 }

--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -211,7 +211,10 @@ const row = createRowModel({
 row.getValue('name');     // 'John'
 row.setValue('name', 'Jane');
 row.getPatches();         // [{ op: 'replace', path: '/name', value: 'Jane' }]
-row.nodeById(row.get('name').id); // ValueNode
+const nameNode = row.get('name');
+if (nameNode) {
+  row.nodeById(nameNode.id); // ValueNode
+}
 
 // No table context — navigation returns defaults
 row.tableModel;           // null
@@ -485,6 +488,6 @@ None
 
 11. **Auto FormulaEngine**: Each row gets its own FormulaEngine instance automatically attached to its ValueTree. Formulas defined in the schema are evaluated reactively without any manual setup.
 
-12. **Auto dispose on removeRow**: `removeRow()` automatically disposes the removed row, cleaning up FormulaEngine reactions. `dispose()` on TableModel disposes all rows at once.
+12. **Auto-dispose on removeRow**: `removeRow()` automatically disposes the removed row, cleaning up FormulaEngine reactions. `dispose()` on TableModel disposes all rows at once.
 
 13. **Standalone createRowModel**: `createRowModel()` provides the same row creation logic (NodeFactory + ValueTree + FormulaEngine) as `TableModel.addRow()`, but without a table context. `TableModel` uses it internally and adds `setTableModel(this)` on top.

--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -302,10 +302,12 @@ row.getValue('fullName'); // 'Jane Doe'
 
 ```typescript
 const row = table.getRow('user-1');
-const nameNode = row.get('name');
+const nameNode = row?.get('name');
 
 // Find node by its ID
-const found = row.nodeById(nameNode.id); // same node
+if (nameNode) {
+  const found = row.nodeById(nameNode.id); // same node
+}
 ```
 
 ### Change tracking and patches

--- a/src/model/table/row/RowModelImpl.ts
+++ b/src/model/table/row/RowModelImpl.ts
@@ -1,6 +1,5 @@
 import { makeAutoObservable } from '../../../core/reactivity/index.js';
 import type { Diagnostic } from '../../../core/validation/types.js';
-import type { JsonSchema } from '../../../types/schema.types.js';
 import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
 import { generateDefaultValue } from '../../default-value/index.js';
 import { FormulaEngine } from '../../value-formula/FormulaEngine.js';
@@ -126,7 +125,7 @@ export function createRowModel(options: RowModelOptions): RowModel {
   });
   const rowData =
     options.data ?? generateDefaultValue(options.schema, { refSchemas: options.refSchemas });
-  const rootNode = factory.createTree(options.schema as JsonSchema, rowData);
+  const rootNode = factory.createTree(options.schema, rowData);
   const valueTree = new ValueTree(rootNode);
 
   const formulaEngine = new FormulaEngine(valueTree);

--- a/src/model/table/row/RowModelImpl.ts
+++ b/src/model/table/row/RowModelImpl.ts
@@ -1,8 +1,13 @@
 import { makeAutoObservable } from '../../../core/reactivity/index.js';
 import type { Diagnostic } from '../../../core/validation/types.js';
+import type { JsonSchema } from '../../../types/schema.types.js';
 import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
+import { generateDefaultValue } from '../../default-value/index.js';
+import { FormulaEngine } from '../../value-formula/FormulaEngine.js';
+import { createNodeFactory } from '../../value-node/NodeFactory.js';
 import type { ValueNode } from '../../value-node/types.js';
-import type { RowModel, TableModelLike, ValueTreeLike } from './types.js';
+import { ValueTree } from '../../value-tree/ValueTree.js';
+import type { RowModel, RowModelOptions, TableModelLike, ValueTreeLike } from './types.js';
 
 const UNSET_INDEX = -1;
 
@@ -77,6 +82,10 @@ export class RowModelImpl implements RowModel {
     return this._tree.getPlainValue();
   }
 
+  nodeById(id: string): ValueNode | undefined {
+    return this._tree.nodeById(id);
+  }
+
   get isDirty(): boolean {
     return this._tree.isDirty;
   }
@@ -101,7 +110,27 @@ export class RowModelImpl implements RowModel {
     this._tree.revert();
   }
 
+  dispose(): void {
+    this._tree.dispose();
+  }
+
   setTableModel(tableModel: TableModelLike | null): void {
     this._tableModel = tableModel;
   }
+}
+
+export function createRowModel(options: RowModelOptions): RowModel {
+  const factory = createNodeFactory({
+    fkResolver: options.fkResolver,
+    refSchemas: options.refSchemas,
+  });
+  const rowData =
+    options.data ?? generateDefaultValue(options.schema, { refSchemas: options.refSchemas });
+  const rootNode = factory.createTree(options.schema as JsonSchema, rowData);
+  const valueTree = new ValueTree(rootNode);
+
+  const formulaEngine = new FormulaEngine(valueTree);
+  valueTree.setFormulaEngine(formulaEngine);
+
+  return new RowModelImpl(options.rowId, valueTree);
 }

--- a/src/model/table/row/index.ts
+++ b/src/model/table/row/index.ts
@@ -1,2 +1,2 @@
-export type { RowModel, TableModelLike, ValueTreeLike } from './types.js';
-export { RowModelImpl } from './RowModelImpl.js';
+export type { RowModel, RowModelOptions, TableModelLike, ValueTreeLike } from './types.js';
+export { RowModelImpl, createRowModel } from './RowModelImpl.js';

--- a/src/model/table/row/types.ts
+++ b/src/model/table/row/types.ts
@@ -1,9 +1,20 @@
 import type { Diagnostic } from '../../../core/validation/types.js';
+import type { JsonObjectSchema } from '../../../types/schema.types.js';
 import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
+import type { ForeignKeyResolver } from '../../foreign-key-resolver/ForeignKeyResolver.js';
+import type { RefSchemas } from '../../value-node/NodeFactory.js';
 import type { ValueNode } from '../../value-node/types.js';
 import type { ValueTreeLike } from '../../value-tree/types.js';
 
 export type { ValueTreeLike };
+
+export interface RowModelOptions {
+  rowId: string;
+  schema: JsonObjectSchema;
+  data?: unknown;
+  fkResolver?: ForeignKeyResolver;
+  refSchemas?: RefSchemas;
+}
 
 export interface TableModelLike {
   getRowIndex(rowId: string): number;
@@ -25,6 +36,8 @@ export interface RowModel {
   setValue(path: string, value: unknown): void;
   getPlainValue(): unknown;
 
+  nodeById(id: string): ValueNode | undefined;
+
   readonly isDirty: boolean;
   readonly isValid: boolean;
   readonly errors: readonly Diagnostic[];
@@ -32,4 +45,5 @@ export interface RowModel {
   getPatches(): readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
+  dispose(): void;
 }

--- a/src/model/table/types.ts
+++ b/src/model/table/types.ts
@@ -41,4 +41,5 @@ export interface TableModel {
   readonly isDirty: boolean;
   commit(): void;
   revert(): void;
+  dispose(): void;
 }

--- a/src/model/value-tree/ChangeTracker.ts
+++ b/src/model/value-tree/ChangeTracker.ts
@@ -1,0 +1,80 @@
+import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
+import type { Change } from './types.js';
+
+export class ChangeTracker {
+  private _changes: Change[] = [];
+
+  get changes(): readonly Change[] {
+    return this._changes;
+  }
+
+  get hasChanges(): boolean {
+    return this._changes.length > 0;
+  }
+
+  track(change: Change): void {
+    this._changes.push(change);
+  }
+
+  clear(): void {
+    this._changes = [];
+  }
+
+  toPatches(): readonly JsonValuePatch[] {
+    const patches: JsonValuePatch[] = [];
+
+    for (const change of this._changes) {
+      const converted = this.changeToPatch(change);
+      patches.push(...converted);
+    }
+
+    return patches;
+  }
+
+  private changeToPatch(change: Change): JsonValuePatch[] {
+    const path = change.path.asJsonPointer();
+
+    switch (change.type) {
+      case 'setValue':
+        return [{ op: 'replace', path, value: change.value }];
+
+      case 'addProperty':
+        return [{ op: 'add', path, value: change.value }];
+
+      case 'removeProperty':
+        return [{ op: 'remove', path }];
+
+      case 'arrayPush':
+        return [{ op: 'add', path: `${path}/-`, value: change.value }];
+
+      case 'arrayInsert':
+        return [
+          { op: 'add', path: `${path}/${change.index}`, value: change.value },
+        ];
+
+      case 'arrayRemove':
+        return [{ op: 'remove', path: `${path}/${change.index}` }];
+
+      case 'arrayMove':
+        return [
+          {
+            op: 'move',
+            from: `${path}/${change.fromIndex}`,
+            path: `${path}/${change.toIndex}`,
+          },
+        ];
+
+      case 'arrayReplace':
+        return [
+          {
+            op: 'replace',
+            path: `${path}/${change.index}`,
+            value: change.value,
+          },
+        ];
+
+      case 'arrayClear':
+        return [{ op: 'replace', path, value: [] }];
+    }
+  }
+}

--- a/src/model/value-tree/TreeIndex.ts
+++ b/src/model/value-tree/TreeIndex.ts
@@ -1,0 +1,124 @@
+import type { ValuePath } from '../../core/value-path/types.js';
+import {
+  createValuePath,
+  EMPTY_VALUE_PATH,
+} from '../../core/value-path/ValuePath.js';
+import {
+  PropertySegment,
+  IndexSegment,
+} from '../../core/value-path/ValuePathSegment.js';
+import type { ValueNode } from '../value-node/types.js';
+
+export class TreeIndex {
+  private readonly nodesById = new Map<string, ValueNode>();
+  private readonly pathCache = new Map<string, ValuePath>();
+
+  constructor(private readonly root: ValueNode) {
+    this.rebuild();
+  }
+
+  nodeById(id: string): ValueNode | undefined {
+    const node = this.nodesById.get(id);
+    if (node) {
+      return node;
+    }
+
+    this.rebuild();
+    return this.nodesById.get(id);
+  }
+
+  pathOf(node: ValueNode): ValuePath {
+    if (this.isInsideArray(node)) {
+      return this.computePath(node);
+    }
+
+    const cached = this.pathCache.get(node.id);
+    if (cached) {
+      return cached;
+    }
+
+    const path = this.computePath(node);
+    this.pathCache.set(node.id, path);
+    return path;
+  }
+
+  rebuild(): void {
+    this.nodesById.clear();
+    this.pathCache.clear();
+    this.indexNode(this.root);
+  }
+
+  registerNode(node: ValueNode): void {
+    this.indexNode(node);
+  }
+
+  invalidatePathsUnder(node: ValueNode): void {
+    this.pathCache.delete(node.id);
+    this.invalidateChildPaths(node);
+  }
+
+  private isInsideArray(node: ValueNode): boolean {
+    let current: ValueNode | null = node.parent;
+    while (current) {
+      if (current.isArray()) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  private indexNode(node: ValueNode): void {
+    this.nodesById.set(node.id, node);
+
+    if (node.isObject()) {
+      for (const child of node.children) {
+        this.indexNode(child);
+      }
+    } else if (node.isArray()) {
+      for (const item of node.value) {
+        this.indexNode(item);
+      }
+    }
+  }
+
+  private computePath(node: ValueNode): ValuePath {
+    const segments: Array<PropertySegment | IndexSegment> = [];
+    let current: ValueNode | null = node;
+
+    while (current?.parent) {
+      const parent: ValueNode = current.parent;
+
+      if (parent.isObject()) {
+        segments.unshift(new PropertySegment(current.name));
+      } else if (parent.isArray()) {
+        const index = parent.value.indexOf(current);
+        if (index >= 0) {
+          segments.unshift(new IndexSegment(index));
+        }
+      }
+
+      current = parent;
+    }
+
+    if (segments.length === 0) {
+      return EMPTY_VALUE_PATH;
+    }
+
+    return createValuePath(segments);
+  }
+
+  private invalidateChildPaths(node: ValueNode): void {
+    if (node.isObject()) {
+      for (const child of node.children) {
+        this.pathCache.delete(child.id);
+        this.invalidateChildPaths(child);
+      }
+    } else if (node.isArray()) {
+      for (const item of node.value) {
+        this.pathCache.delete(item.id);
+        this.invalidateChildPaths(item);
+      }
+    }
+  }
+}

--- a/src/model/value-tree/ValueTree.ts
+++ b/src/model/value-tree/ValueTree.ts
@@ -1,19 +1,48 @@
 import { makeAutoObservable } from '../../core/reactivity/index.js';
 import type { Diagnostic } from '../../core/validation/types.js';
+import type { ValuePath } from '../../core/value-path/types.js';
+import { EMPTY_VALUE_PATH } from '../../core/value-path/ValuePath.js';
 import { parseValuePath } from '../../core/value-path/ValuePathParser.js';
+import type { JsonValue } from '../../types/json.types.js';
 import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
 import type { DirtyTrackable, ValueNode } from '../value-node/types.js';
-import type { ValueTreeLike } from './types.js';
+import type { FormulaEngine } from '../value-formula/FormulaEngine.js';
+import { ChangeTracker } from './ChangeTracker.js';
+import { TreeIndex } from './TreeIndex.js';
+import type { Change, ValueTreeLike } from './types.js';
 
 export class ValueTree implements ValueTreeLike {
+  private readonly index: TreeIndex;
+  private readonly changeTracker: ChangeTracker;
+  private _formulaEngine: FormulaEngine | null = null;
+
   constructor(private readonly _root: ValueNode) {
+    this.index = new TreeIndex(_root);
+    this.changeTracker = new ChangeTracker();
+
     makeAutoObservable(this, {
       _root: false,
+      index: false,
+      changeTracker: false,
+      _formulaEngine: false,
     });
   }
 
   get root(): ValueNode {
     return this._root;
+  }
+
+  nodeById(id: string): ValueNode | undefined {
+    return this.index.nodeById(id);
+  }
+
+  pathOf(nodeOrId: ValueNode | string): ValuePath {
+    const node =
+      typeof nodeOrId === 'string' ? this.index.nodeById(nodeOrId) : nodeOrId;
+    if (!node) {
+      return EMPTY_VALUE_PATH;
+    }
+    return this.index.pathOf(node);
   }
 
   get(path: string): ValueNode | undefined {
@@ -54,7 +83,16 @@ export class ValueTree implements ValueTreeLike {
     if (!node.isPrimitive()) {
       throw new Error(`Cannot set value on non-primitive node: ${path}`);
     }
+
+    const oldValue = node.value as JsonValue;
     node.setValue(value);
+
+    this.changeTracker.track({
+      type: 'setValue',
+      path: this.index.pathOf(node),
+      value: value as JsonValue,
+      oldValue,
+    });
   }
 
   getPlainValue(): unknown {
@@ -78,7 +116,11 @@ export class ValueTree implements ValueTreeLike {
   }
 
   getPatches(): readonly JsonValuePatch[] {
-    return [];
+    return this.changeTracker.toPatches();
+  }
+
+  trackChange(change: Change): void {
+    this.changeTracker.track(change);
   }
 
   commit(): void {
@@ -86,6 +128,7 @@ export class ValueTree implements ValueTreeLike {
     if ('commit' in root && typeof root.commit === 'function') {
       root.commit();
     }
+    this.changeTracker.clear();
   }
 
   revert(): void {
@@ -93,5 +136,31 @@ export class ValueTree implements ValueTreeLike {
     if ('revert' in root && typeof root.revert === 'function') {
       root.revert();
     }
+    this.changeTracker.clear();
+  }
+
+  rebuildIndex(): void {
+    this.index.rebuild();
+  }
+
+  registerNode(node: ValueNode): void {
+    this.index.registerNode(node);
+  }
+
+  invalidatePathsUnder(node: ValueNode): void {
+    this.index.invalidatePathsUnder(node);
+  }
+
+  setFormulaEngine(engine: FormulaEngine): void {
+    this._formulaEngine = engine;
+  }
+
+  get formulaEngine(): FormulaEngine | null {
+    return this._formulaEngine;
+  }
+
+  dispose(): void {
+    this._formulaEngine?.dispose();
+    this._formulaEngine = null;
   }
 }

--- a/src/model/value-tree/__tests__/ChangeTracker.spec.ts
+++ b/src/model/value-tree/__tests__/ChangeTracker.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from '@jest/globals';
 import { createValuePath } from '../../../core/value-path/ValuePath.js';
 import { PropertySegment } from '../../../core/value-path/ValuePathSegment.js';
 import { ChangeTracker } from '../ChangeTracker.js';
-import type { Change } from '../types.js';
 
 function path(name: string) {
   return createValuePath([new PropertySegment(name)]);

--- a/src/model/value-tree/__tests__/ChangeTracker.spec.ts
+++ b/src/model/value-tree/__tests__/ChangeTracker.spec.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from '@jest/globals';
+import { createValuePath } from '../../../core/value-path/ValuePath.js';
+import { PropertySegment } from '../../../core/value-path/ValuePathSegment.js';
+import { ChangeTracker } from '../ChangeTracker.js';
+import type { Change } from '../types.js';
+
+function path(name: string) {
+  return createValuePath([new PropertySegment(name)]);
+}
+
+describe('ChangeTracker', () => {
+  describe('initial state', () => {
+    it('starts with no changes', () => {
+      const tracker = new ChangeTracker();
+
+      expect(tracker.hasChanges).toBe(false);
+      expect(tracker.changes).toHaveLength(0);
+    });
+  });
+
+  describe('track', () => {
+    it('tracks a change', () => {
+      const tracker = new ChangeTracker();
+
+      tracker.track({
+        type: 'setValue',
+        path: path('name'),
+        value: 'Jane',
+        oldValue: 'John',
+      });
+
+      expect(tracker.hasChanges).toBe(true);
+      expect(tracker.changes).toHaveLength(1);
+    });
+
+    it('accumulates multiple changes', () => {
+      const tracker = new ChangeTracker();
+
+      tracker.track({
+        type: 'setValue',
+        path: path('name'),
+        value: 'Jane',
+        oldValue: 'John',
+      });
+      tracker.track({
+        type: 'setValue',
+        path: path('age'),
+        value: 30,
+        oldValue: 25,
+      });
+
+      expect(tracker.changes).toHaveLength(2);
+    });
+  });
+
+  describe('clear', () => {
+    it('clears all changes', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'setValue',
+        path: path('name'),
+        value: 'Jane',
+        oldValue: 'John',
+      });
+
+      tracker.clear();
+
+      expect(tracker.hasChanges).toBe(false);
+      expect(tracker.changes).toHaveLength(0);
+    });
+  });
+
+  describe('toPatches', () => {
+    it('returns empty array when no changes', () => {
+      const tracker = new ChangeTracker();
+
+      expect(tracker.toPatches()).toEqual([]);
+    });
+
+    it('generates replace patch for setValue', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'setValue',
+        path: path('name'),
+        value: 'Jane',
+        oldValue: 'John',
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'replace', path: '/name', value: 'Jane' },
+      ]);
+    });
+
+    it('generates add patch for addProperty', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'addProperty',
+        path: path('email'),
+        value: 'test@example.com',
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'add', path: '/email', value: 'test@example.com' },
+      ]);
+    });
+
+    it('generates remove patch for removeProperty', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'removeProperty',
+        path: path('email'),
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'remove', path: '/email' },
+      ]);
+    });
+
+    it('generates add patch with /- for arrayPush', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'arrayPush',
+        path: path('items'),
+        value: { name: 'Item C' },
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'add', path: '/items/-', value: { name: 'Item C' } },
+      ]);
+    });
+
+    it('generates add patch with index for arrayInsert', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'arrayInsert',
+        path: path('items'),
+        index: 1,
+        value: { name: 'Inserted' },
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'add', path: '/items/1', value: { name: 'Inserted' } },
+      ]);
+    });
+
+    it('generates remove patch with index for arrayRemove', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'arrayRemove',
+        path: path('items'),
+        index: 0,
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'remove', path: '/items/0' },
+      ]);
+    });
+
+    it('generates move patch for arrayMove', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'arrayMove',
+        path: path('items'),
+        fromIndex: 0,
+        toIndex: 2,
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'move', from: '/items/0', path: '/items/2' },
+      ]);
+    });
+
+    it('generates replace patch with index for arrayReplace', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'arrayReplace',
+        path: path('items'),
+        index: 0,
+        value: { name: 'Replaced', price: 999 },
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'replace', path: '/items/0', value: { name: 'Replaced', price: 999 } },
+      ]);
+    });
+
+    it('generates replace with empty array for arrayClear', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'arrayClear',
+        path: path('items'),
+      });
+
+      expect(tracker.toPatches()).toEqual([
+        { op: 'replace', path: '/items', value: [] },
+      ]);
+    });
+
+    it('generates multiple patches for multiple changes', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'setValue',
+        path: path('name'),
+        value: 'Jane',
+        oldValue: 'John',
+      });
+      tracker.track({
+        type: 'arrayPush',
+        path: path('items'),
+        value: { name: 'New' },
+      });
+      tracker.track({
+        type: 'removeProperty',
+        path: path('obsolete'),
+      });
+
+      const patches = tracker.toPatches();
+
+      expect(patches).toHaveLength(3);
+      expect(patches[0]).toEqual({ op: 'replace', path: '/name', value: 'Jane' });
+      expect(patches[1]).toEqual({ op: 'add', path: '/items/-', value: { name: 'New' } });
+      expect(patches[2]).toEqual({ op: 'remove', path: '/obsolete' });
+    });
+
+    it('returns empty after clear', () => {
+      const tracker = new ChangeTracker();
+      tracker.track({
+        type: 'setValue',
+        path: path('name'),
+        value: 'Jane',
+        oldValue: 'John',
+      });
+
+      tracker.clear();
+
+      expect(tracker.toPatches()).toEqual([]);
+    });
+  });
+});

--- a/src/model/value-tree/__tests__/TreeIndex.spec.ts
+++ b/src/model/value-tree/__tests__/TreeIndex.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { obj, str, arr } from '../../../mocks/schema.mocks.js';
-import type { JsonSchema } from '../../../types/schema.types.js';
+import type { JsonArraySchema, JsonSchema } from '../../../types/schema.types.js';
 import { createNodeFactory } from '../../value-node/NodeFactory.js';
 import { StringValueNode } from '../../value-node/StringValueNode.js';
 import type { ValueNode } from '../../value-node/types.js';
@@ -69,12 +69,7 @@ describe('TreeIndex', () => {
       const root = createTree(obj({ name: str() }), { name: 'test' });
       const index = new TreeIndex(root);
 
-      const newChild = new StringValueNode(
-        undefined,
-        'email',
-        { type: 'string', default: '' },
-        'test@example.com',
-      );
+      const newChild = new StringValueNode(undefined, 'email', str(), 'test@example.com');
       if (root.isObject()) {
         root.addChild(newChild);
       }
@@ -109,13 +104,8 @@ describe('TreeIndex', () => {
       const root = createTree(schema, { address: { city: 'NYC' } });
       const index = new TreeIndex(root);
 
-      const cityNode = root.isObject()
-        ? root.child('address')?.isObject()
-          ? root.child('address')!.isObject()
-            ? (root.child('address') as any).child('city')
-            : undefined
-          : undefined
-        : undefined;
+      const addressNode = root.isObject() ? root.child('address') : undefined;
+      const cityNode = addressNode?.isObject() ? addressNode.child('city') : undefined;
       expect(cityNode).toBeDefined();
       expect(index.pathOf(cityNode!).asJsonPointer()).toBe('/address/city');
     });
@@ -182,12 +172,7 @@ describe('TreeIndex', () => {
       const root = createTree(obj({ name: str() }), { name: 'test' });
       const index = new TreeIndex(root);
 
-      const newChild = new StringValueNode(
-        undefined,
-        'email',
-        { type: 'string', default: '' },
-        'value',
-      );
+      const newChild = new StringValueNode(undefined, 'email', str(), 'value');
       if (root.isObject()) {
         root.addChild(newChild);
       }
@@ -345,7 +330,7 @@ describe('TreeIndex', () => {
       if (itemsNode!.isArray()) {
         const newItem = factory.create(
           '0',
-          (schema.properties!.items as any).items,
+          (schema.properties!.items as JsonArraySchema).items,
           { name: 'new' },
         );
         itemsNode!.insertAt(0, newItem);
@@ -410,7 +395,7 @@ describe('TreeIndex', () => {
         const factory = createNodeFactory();
         const newItem = factory.create(
           '0',
-          (schema.properties!.items as any).items,
+          (schema.properties!.items as JsonArraySchema).items,
           { name: 'new' },
         );
         itemsNode.insertAt(0, newItem);
@@ -426,12 +411,7 @@ describe('TreeIndex', () => {
       const root = createTree(obj({ name: str() }), { name: 'test' });
       const index = new TreeIndex(root);
 
-      const newChild = new StringValueNode(
-        undefined,
-        'newField',
-        { type: 'string', default: '' },
-        'value',
-      );
+      const newChild = new StringValueNode(undefined, 'newField', str(), 'value');
       if (root.isObject()) {
         root.addChild(newChild);
       }

--- a/src/model/value-tree/__tests__/TreeIndex.spec.ts
+++ b/src/model/value-tree/__tests__/TreeIndex.spec.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect } from '@jest/globals';
+import { obj, str, arr } from '../../../mocks/schema.mocks.js';
+import type { JsonSchema } from '../../../types/schema.types.js';
+import { createNodeFactory } from '../../value-node/NodeFactory.js';
+import { StringValueNode } from '../../value-node/StringValueNode.js';
+import type { ValueNode } from '../../value-node/types.js';
+import { TreeIndex } from '../TreeIndex.js';
+
+function createTree(schema: JsonSchema, data: unknown): ValueNode {
+  const factory = createNodeFactory();
+  return factory.createTree(schema, data);
+}
+
+describe('TreeIndex', () => {
+  describe('nodeById', () => {
+    it('finds root node by id', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      expect(index.nodeById(root.id)).toBe(root);
+    });
+
+    it('finds child node by id', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const nameNode = root.isObject() ? root.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+      expect(index.nodeById(nameNode!.id)).toBe(nameNode);
+    });
+
+    it('finds deeply nested node by id', () => {
+      const schema = obj({
+        address: obj({
+          city: str(),
+        }),
+      });
+      const root = createTree(schema, { address: { city: 'NYC' } });
+      const index = new TreeIndex(root);
+
+      const addressNode = root.isObject() ? root.child('address') : undefined;
+      const cityNode =
+        addressNode?.isObject() ? addressNode.child('city') : undefined;
+      expect(cityNode).toBeDefined();
+      expect(index.nodeById(cityNode!.id)).toBe(cityNode);
+    });
+
+    it('finds array item by id', () => {
+      const schema = obj({
+        items: arr(obj({ name: str() })),
+      });
+      const root = createTree(schema, { items: [{ name: 'a' }, { name: 'b' }] });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const firstItem = itemsNode?.isArray() ? itemsNode.at(0) : undefined;
+      expect(firstItem).toBeDefined();
+      expect(index.nodeById(firstItem!.id)).toBe(firstItem);
+    });
+
+    it('returns undefined for unknown id', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      expect(index.nodeById('non-existent')).toBeUndefined();
+    });
+
+    it('rebuilds index and finds newly added node', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const newChild = new StringValueNode(
+        undefined,
+        'email',
+        { type: 'string', default: '' },
+        'test@example.com',
+      );
+      if (root.isObject()) {
+        root.addChild(newChild);
+      }
+
+      expect(index.nodeById(newChild.id)).toBe(newChild);
+    });
+  });
+
+  describe('pathOf', () => {
+    it('returns empty path for root node', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      expect(index.pathOf(root).isEmpty()).toBe(true);
+    });
+
+    it('returns property path for object child', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const nameNode = root.isObject() ? root.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+      expect(index.pathOf(nameNode!).asJsonPointer()).toBe('/name');
+    });
+
+    it('returns nested property path', () => {
+      const schema = obj({
+        address: obj({
+          city: str(),
+        }),
+      });
+      const root = createTree(schema, { address: { city: 'NYC' } });
+      const index = new TreeIndex(root);
+
+      const cityNode = root.isObject()
+        ? root.child('address')?.isObject()
+          ? root.child('address')!.isObject()
+            ? (root.child('address') as any).child('city')
+            : undefined
+          : undefined
+        : undefined;
+      expect(cityNode).toBeDefined();
+      expect(index.pathOf(cityNode!).asJsonPointer()).toBe('/address/city');
+    });
+
+    it('returns index path for array items', () => {
+      const schema = obj({
+        items: arr(str()),
+      });
+      const root = createTree(schema, { items: ['a', 'b', 'c'] });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const secondItem = itemsNode?.isArray() ? itemsNode.at(1) : undefined;
+      expect(secondItem).toBeDefined();
+      expect(index.pathOf(secondItem!).asJsonPointer()).toBe('/items/1');
+    });
+
+    it('returns nested path inside array item', () => {
+      const schema = obj({
+        items: arr(obj({ name: str() })),
+      });
+      const root = createTree(schema, { items: [{ name: 'first' }, { name: 'second' }] });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const secondItem = itemsNode?.isArray() ? itemsNode.at(1) : undefined;
+      const nameNode = secondItem?.isObject() ? secondItem.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+      expect(index.pathOf(nameNode!).asJsonPointer()).toBe('/items/1/name');
+    });
+
+    it('caches path for non-array nodes', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const nameNode = root.isObject() ? root.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+
+      const path1 = index.pathOf(nameNode!);
+      const path2 = index.pathOf(nameNode!);
+      expect(path1).toBe(path2);
+    });
+
+    it('does not cache path for nodes inside arrays', () => {
+      const schema = obj({
+        items: arr(str()),
+      });
+      const root = createTree(schema, { items: ['a'] });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const firstItem = itemsNode?.isArray() ? itemsNode.at(0) : undefined;
+      expect(firstItem).toBeDefined();
+
+      const path1 = index.pathOf(firstItem!);
+      const path2 = index.pathOf(firstItem!);
+      expect(path1.asJsonPointer()).toBe(path2.asJsonPointer());
+      expect(path1).not.toBe(path2);
+    });
+  });
+
+  describe('registerNode', () => {
+    it('registers a new node so nodeById finds it without rebuild', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const newChild = new StringValueNode(
+        undefined,
+        'email',
+        { type: 'string', default: '' },
+        'value',
+      );
+      if (root.isObject()) {
+        root.addChild(newChild);
+      }
+      index.registerNode(newChild);
+
+      expect(index.nodeById(newChild.id)).toBe(newChild);
+    });
+
+    it('registers node with nested children', () => {
+      const schema = obj({ name: str() });
+      const root = createTree(schema, { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const factory = createNodeFactory();
+      const nestedObj = factory.create(
+        'nested',
+        obj({ city: str() }),
+        { city: 'NYC' },
+      );
+      if (root.isObject()) {
+        root.addChild(nestedObj);
+      }
+      index.registerNode(nestedObj);
+
+      expect(index.nodeById(nestedObj.id)).toBe(nestedObj);
+      const cityNode = nestedObj.isObject() ? nestedObj.child('city') : undefined;
+      expect(cityNode).toBeDefined();
+      expect(index.nodeById(cityNode!.id)).toBe(cityNode);
+    });
+  });
+
+  describe('invalidatePathsUnder', () => {
+    it('invalidates cached path for node', () => {
+      const schema = obj({
+        data: obj({
+          name: str(),
+        }),
+      });
+      const root = createTree(schema, { data: { name: 'test' } });
+      const index = new TreeIndex(root);
+
+      const dataNode = root.isObject() ? root.child('data') : undefined;
+      const nameNode = dataNode?.isObject() ? dataNode.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+
+      const path1 = index.pathOf(nameNode!);
+      expect(path1.asJsonPointer()).toBe('/data/name');
+
+      index.invalidatePathsUnder(dataNode!);
+
+      const path2 = index.pathOf(nameNode!);
+      expect(path2.asJsonPointer()).toBe('/data/name');
+      expect(path2).not.toBe(path1);
+    });
+
+    it('invalidates paths for all children of object', () => {
+      const schema = obj({
+        data: obj({
+          name: str(),
+          age: str(),
+        }),
+      });
+      const root = createTree(schema, { data: { name: 'test', age: '25' } });
+      const index = new TreeIndex(root);
+
+      const dataNode = root.isObject() ? root.child('data') : undefined;
+      const nameNode = dataNode?.isObject() ? dataNode.child('name') : undefined;
+      const ageNode = dataNode?.isObject() ? dataNode.child('age') : undefined;
+      expect(nameNode).toBeDefined();
+      expect(ageNode).toBeDefined();
+
+      const namePath1 = index.pathOf(nameNode!);
+      const agePath1 = index.pathOf(ageNode!);
+
+      index.invalidatePathsUnder(dataNode!);
+
+      const namePath2 = index.pathOf(nameNode!);
+      const agePath2 = index.pathOf(ageNode!);
+      expect(namePath2).not.toBe(namePath1);
+      expect(agePath2).not.toBe(agePath1);
+    });
+
+    it('invalidates paths for array children', () => {
+      const schema = obj({
+        wrapper: obj({
+          items: arr(str()),
+        }),
+      });
+      const root = createTree(schema, { wrapper: { items: ['a', 'b'] } });
+      const index = new TreeIndex(root);
+
+      const wrapperNode = root.isObject() ? root.child('wrapper') : undefined;
+      const itemsNode = wrapperNode?.isObject() ? wrapperNode.child('items') : undefined;
+      expect(itemsNode?.isArray()).toBe(true);
+
+      index.pathOf(wrapperNode!);
+      index.pathOf(itemsNode!);
+
+      index.invalidatePathsUnder(wrapperNode!);
+
+      const itemsPath = index.pathOf(itemsNode!);
+      expect(itemsPath.asJsonPointer()).toBe('/wrapper/items');
+    });
+  });
+
+  describe('rebuild', () => {
+    it('clears and reindexes all nodes', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const nameNode = root.isObject() ? root.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+      expect(index.nodeById(nameNode!.id)).toBe(nameNode);
+
+      index.rebuild();
+
+      expect(index.nodeById(nameNode!.id)).toBe(nameNode);
+    });
+
+    it('clears path cache on rebuild', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const nameNode = root.isObject() ? root.child('name') : undefined;
+      expect(nameNode).toBeDefined();
+
+      const path1 = index.pathOf(nameNode!);
+      index.rebuild();
+      const path2 = index.pathOf(nameNode!);
+
+      expect(path1.asJsonPointer()).toBe(path2.asJsonPointer());
+      expect(path1).not.toBe(path2);
+    });
+  });
+
+  describe('path cache invalidation with array mutations', () => {
+    const schema = obj({
+      items: arr(obj({ name: str() })),
+    });
+
+    it('returns correct path after array insert at beginning', () => {
+      const factory = createNodeFactory();
+      const root = factory.createTree(schema, {
+        items: [{ name: 'first' }, { name: 'second' }],
+      });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      expect(itemsNode?.isArray()).toBe(true);
+
+      const originalSecond = itemsNode!.isArray() ? itemsNode!.at(1) : undefined;
+      expect(originalSecond).toBeDefined();
+      expect(originalSecond!.getPlainValue()).toEqual({ name: 'second' });
+
+      if (itemsNode!.isArray()) {
+        const newItem = factory.create(
+          '0',
+          (schema.properties!.items as any).items,
+          { name: 'new' },
+        );
+        itemsNode!.insertAt(0, newItem);
+        index.registerNode(newItem);
+      }
+
+      expect(index.pathOf(originalSecond!).asJsonPointer()).toBe('/items/2');
+    });
+
+    it('returns correct path after array remove', () => {
+      const root = createTree(schema, {
+        items: [{ name: 'first' }, { name: 'second' }, { name: 'third' }],
+      });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const originalThird = itemsNode?.isArray() ? itemsNode.at(2) : undefined;
+      expect(originalThird).toBeDefined();
+
+      if (itemsNode?.isArray()) {
+        itemsNode.removeAt(0);
+      }
+
+      expect(index.pathOf(originalThird!).asJsonPointer()).toBe('/items/1');
+    });
+
+    it('returns correct path after array move', () => {
+      const root = createTree(schema, {
+        items: [{ name: 'first' }, { name: 'second' }, { name: 'third' }],
+      });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const originalFirst = itemsNode?.isArray() ? itemsNode.at(0) : undefined;
+      const originalThird = itemsNode?.isArray() ? itemsNode.at(2) : undefined;
+      expect(originalFirst).toBeDefined();
+      expect(originalThird).toBeDefined();
+
+      if (itemsNode?.isArray()) {
+        itemsNode.move(0, 2);
+      }
+
+      expect(index.pathOf(originalFirst!).asJsonPointer()).toBe('/items/2');
+      expect(index.pathOf(originalThird!).asJsonPointer()).toBe('/items/1');
+    });
+
+    it('nested node paths update after parent array mutation', () => {
+      const root = createTree(schema, {
+        items: [{ name: 'first' }, { name: 'second' }],
+      });
+      const index = new TreeIndex(root);
+
+      const itemsNode = root.isObject() ? root.child('items') : undefined;
+      const secondItem = itemsNode?.isArray() ? itemsNode.at(1) : undefined;
+      const nestedName = secondItem?.isObject()
+        ? secondItem.child('name')
+        : undefined;
+      expect(nestedName).toBeDefined();
+      expect(index.pathOf(nestedName!).asJsonPointer()).toBe('/items/1/name');
+
+      if (itemsNode?.isArray()) {
+        const factory = createNodeFactory();
+        const newItem = factory.create(
+          '0',
+          (schema.properties!.items as any).items,
+          { name: 'new' },
+        );
+        itemsNode.insertAt(0, newItem);
+        index.registerNode(newItem);
+      }
+
+      expect(index.pathOf(nestedName!).asJsonPointer()).toBe('/items/2/name');
+    });
+  });
+
+  describe('object mutations', () => {
+    it('nodeById finds node after object child add', () => {
+      const root = createTree(obj({ name: str() }), { name: 'test' });
+      const index = new TreeIndex(root);
+
+      const newChild = new StringValueNode(
+        undefined,
+        'newField',
+        { type: 'string', default: '' },
+        'value',
+      );
+      if (root.isObject()) {
+        root.addChild(newChild);
+      }
+      index.registerNode(newChild);
+
+      expect(index.nodeById(newChild.id)).toBe(newChild);
+      expect(index.pathOf(newChild).asJsonPointer()).toBe('/newField');
+    });
+  });
+});

--- a/src/model/value-tree/__tests__/ValueTree.spec.ts
+++ b/src/model/value-tree/__tests__/ValueTree.spec.ts
@@ -3,6 +3,7 @@ import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
 import type { Diagnostic } from '../../../core/validation/types.js';
 import { FormulaEngine } from '../../value-formula/FormulaEngine.js';
 import { createNodeFactory } from '../../value-node/NodeFactory.js';
+import { StringValueNode } from '../../value-node/StringValueNode.js';
 import type { ValueNode } from '../../value-node/types.js';
 import { ValueType } from '../../value-node/types.js';
 import { ValueTree } from '../ValueTree.js';
@@ -203,7 +204,7 @@ describe('ValueTree', () => {
       const minimalRoot: ValueNode = {
         id: 'mock-root',
         type: ValueType.String,
-        schema: { type: 'string', default: '' },
+        schema: str(),
         parent: null,
         name: '',
         value: 'test',
@@ -491,13 +492,7 @@ describe('ValueTree', () => {
     it('registers new node in index', () => {
       const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
 
-      const { StringValueNode } = require('../../value-node/StringValueNode.js');
-      const newNode = new StringValueNode(
-        undefined,
-        'email',
-        { type: 'string', default: '' },
-        'test@example.com',
-      );
+      const newNode = new StringValueNode(undefined, 'email', str(), 'test@example.com');
       if (tree.root.isObject()) {
         tree.root.addChild(newNode);
       }

--- a/src/model/value-tree/index.ts
+++ b/src/model/value-tree/index.ts
@@ -1,2 +1,4 @@
-export type { ValueTreeLike } from './types.js';
+export type { ValueTreeLike, Change, ChangeType } from './types.js';
 export { ValueTree } from './ValueTree.js';
+export { TreeIndex } from './TreeIndex.js';
+export { ChangeTracker } from './ChangeTracker.js';

--- a/src/model/value-tree/types.ts
+++ b/src/model/value-tree/types.ts
@@ -1,6 +1,72 @@
 import type { Diagnostic } from '../../core/validation/types.js';
+import type { ValuePath } from '../../core/value-path/types.js';
+import type { JsonValue } from '../../types/json.types.js';
 import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
 import type { ValueNode } from '../value-node/types.js';
+
+interface BaseChange {
+  readonly path: ValuePath;
+}
+
+export interface SetValueChange extends BaseChange {
+  readonly type: 'setValue';
+  readonly value: JsonValue;
+  readonly oldValue: JsonValue;
+}
+
+export interface AddPropertyChange extends BaseChange {
+  readonly type: 'addProperty';
+  readonly value: JsonValue;
+}
+
+export interface RemovePropertyChange extends BaseChange {
+  readonly type: 'removeProperty';
+}
+
+export interface ArrayPushChange extends BaseChange {
+  readonly type: 'arrayPush';
+  readonly value: JsonValue;
+}
+
+export interface ArrayInsertChange extends BaseChange {
+  readonly type: 'arrayInsert';
+  readonly index: number;
+  readonly value: JsonValue;
+}
+
+export interface ArrayRemoveChange extends BaseChange {
+  readonly type: 'arrayRemove';
+  readonly index: number;
+}
+
+export interface ArrayMoveChange extends BaseChange {
+  readonly type: 'arrayMove';
+  readonly fromIndex: number;
+  readonly toIndex: number;
+}
+
+export interface ArrayReplaceChange extends BaseChange {
+  readonly type: 'arrayReplace';
+  readonly index: number;
+  readonly value: JsonValue;
+}
+
+export interface ArrayClearChange extends BaseChange {
+  readonly type: 'arrayClear';
+}
+
+export type Change =
+  | SetValueChange
+  | AddPropertyChange
+  | RemovePropertyChange
+  | ArrayPushChange
+  | ArrayInsertChange
+  | ArrayRemoveChange
+  | ArrayMoveChange
+  | ArrayReplaceChange
+  | ArrayClearChange;
+
+export type ChangeType = Change['type'];
 
 export interface ValueTreeLike {
   readonly root: ValueNode;
@@ -14,4 +80,7 @@ export interface ValueTreeLike {
   getPatches(): readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
+  nodeById(id: string): ValueNode | undefined;
+  pathOf(nodeOrId: ValueNode | string): ValuePath;
+  dispose(): void;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a standalone RowModel factory and wires it into TableModel so rows get defaults, formulas, node lookup, change tracking (JSON Patches), and proper cleanup. Extends ValueTree with a TreeIndex, ChangeTracker, and JSON Pointer paths for patches; patches now clear on commit/revert.

- **New Features**
  - createRowModel(options): builds a row with ValueTree + FormulaEngine; used by TableModel.addRow.
  - TableModel: removeRow now disposes the row; new dispose() to clean up all rows.
  - RowModel: nodeById(id), getPatches(), dispose(); read/write APIs unchanged.
  - ValueTree: nodeById(id), pathOf(node|id), getPatches(), trackChange(), setFormulaEngine()/dispose(); adds internal TreeIndex + ChangeTracker; commit()/revert() clear patches.
  - ValuePath: asJsonPointer() to produce JSON Patch paths (e.g., /items/0/name).

- **Migration**
  - Call table.dispose() when tearing down a table to release row reactions.
  - No manual row formula cleanup needed; removeRow() and dispose() handle it.
  - For standalone rows, use createRowModel({ rowId, schema, data?, fkResolver?, refSchemas? }).

<sup>Written for commit b84fc1be19e81c4539976fa46b7fda8c359a8577. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

