### PR TITLE
fix: json object

### DIFF
--- a/src/lib/__tests__/json-path-utils.spec.ts
+++ b/src/lib/__tests__/json-path-utils.spec.ts
@@ -121,7 +121,7 @@ describe('getValueByPath', () => {
   });
 
   it('handles nested null/undefined', () => {
-    const objWithNull = { a: null, b: { c: undefined } };
+    const objWithNull = { a: null, b: { c: undefined } } as unknown as JsonValue;
     expect(getValueByPath(objWithNull, 'a')).toBeNull();
     expect(getValueByPath(objWithNull, 'a.nested')).toBeUndefined();
     expect(getValueByPath(objWithNull, 'b.c')).toBeUndefined();
@@ -352,7 +352,7 @@ describe('hasPath', () => {
   });
 
   it('returns false for undefined value', () => {
-    const objWithUndefined: JsonValue = { field: undefined };
+    const objWithUndefined = { field: undefined } as unknown as JsonValue;
     expect(hasPath(objWithUndefined, 'field')).toBe(false);
   });
 

--- a/src/types/json.types.ts
+++ b/src/types/json.types.ts
@@ -1,4 +1,4 @@
-export type JsonObject = { [Key in string]?: JsonValue };
+export type JsonObject = { [Key in string]: JsonValue };
 
 export type JsonPrimitives = string | number | boolean;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changed JsonObject to require JsonValue for all keys, removing undefined from object properties and aligning the type with valid JSON. Updated tests to cast objects with undefined to JsonValue where needed to keep path utility checks intact.

<sup>Written for commit f4d974c7e79025432e786a96777a36cc96eca175. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

