### PR TITLE
feat: set value

### DIFF
--- a/src/model/value-node/ObjectValueNode.ts
+++ b/src/model/value-node/ObjectValueNode.ts
@@ -41,6 +41,7 @@ export class ObjectValueNode extends BaseValueNode implements IObjectValueNode {
       warnings: 'computed',
       addChild: 'action',
       removeChild: 'action',
+      setValue: 'action',
       commit: 'action',
       revert: 'action',
     });
@@ -84,6 +85,24 @@ export class ObjectValueNode extends BaseValueNode implements IObjectValueNode {
     if (node) {
       node.parent = null;
       this._children.delete(name);
+    }
+  }
+
+  setValue(value: Record<string, unknown>, options?: { internal?: boolean }): void {
+    for (const [key, child] of this._children) {
+      if (!(key in value)) {
+        continue;
+      }
+
+      const childValue = value[key];
+
+      if (child.isObject()) {
+        child.setValue(childValue as Record<string, unknown>, options);
+      } else if (child.isArray()) {
+        child.setValue(childValue as unknown[], options);
+      } else if (child.isPrimitive()) {
+        child.setValue(childValue, options);
+      }
     }
   }
 

--- a/src/model/value-node/README.md
+++ b/src/model/value-node/README.md
@@ -136,8 +136,11 @@ interface ObjectValueNode extends ValueNode, DirtyTrackable {
   addChild(node: ValueNode): void;
   removeChild(name: string): void;
   hasChild(name: string): boolean;
+  setValue(value: Record<string, unknown>, options?: { internal?: boolean }): void;
 }
 ```
+
+`setValue` performs a **partial update** — iterates existing children and updates only keys present in `value`. Unknown keys are ignored. Nested objects and arrays are updated recursively. Use `options.internal` to bypass readOnly/formula field restrictions.
 
 ### ArrayValueNode
 
@@ -157,8 +160,11 @@ interface ArrayValueNode extends ValueNode, DirtyTrackable {
   setNodeFactory(factory: NodeFactory): void;
   pushValue(value?: unknown): void;
   insertValueAt(index: number, value?: unknown): void;
+  setValue(value: unknown[], options?: { internal?: boolean }): void;
 }
 ```
+
+`setValue` performs a **full replacement** — updates existing items by index, grows (via NodeFactory) or shrinks the array to match the input length. For partial array updates, use `node.at(i).setValue(...)` instead.
 
 ### NodeFactory
 

--- a/src/model/value-node/types.ts
+++ b/src/model/value-node/types.ts
@@ -75,6 +75,7 @@ export interface ObjectValueNode extends ValueNode, DirtyTrackable {
   addChild(node: ValueNode): void;
   removeChild(name: string): void;
   hasChild(name: string): boolean;
+  setValue(value: Record<string, unknown>, options?: { internal?: boolean }): void;
 }
 
 export interface ArrayValueNode extends ValueNode, DirtyTrackable {
@@ -92,6 +93,7 @@ export interface ArrayValueNode extends ValueNode, DirtyTrackable {
   setNodeFactory(factory: NodeFactory): void;
   pushValue(value?: unknown): void;
   insertValueAt(index: number, value?: unknown): void;
+  setValue(value: unknown[], options?: { internal?: boolean }): void;
 }
 
 export interface ValueNodeOptions {

--- a/src/model/value-tree/README.md
+++ b/src/model/value-tree/README.md
@@ -64,7 +64,7 @@ interface ValueTreeLike {
   // Path-based access
   get(path: string): ValueNode | undefined;
   getValue(path: string): unknown;
-  setValue(path: string, value: unknown): void;
+  setValue(path: string, value: unknown, options?: { internal?: boolean }): void;
   getPlainValue(): unknown;
 
   // Node indexing
@@ -333,9 +333,6 @@ const tree = new ValueTree(rootNode);
 tree.get('missing.path'); // returns undefined
 tree.getValue('missing'); // returns undefined
 tree.setValue('missing', 'value'); // throws Error: Path not found: missing
-
-// Setting value on non-primitive
-tree.setValue('address', {}); // throws Error: Cannot set value on non-primitive node: address
 ```
 
 ## Dependencies
@@ -360,7 +357,7 @@ None
 
 3. **Path returns undefined**: `get()` and `getValue()` return undefined for invalid paths rather than throwing. This allows safe chaining with optional access.
 
-4. **setValue throws**: Unlike get operations, `setValue()` throws for invalid paths or non-primitive nodes. This prevents silent failures when writing data.
+4. **setValue throws for invalid paths**: Unlike get operations, `setValue()` throws for invalid paths. For object nodes it performs a partial update (only keys present in value), for array nodes it performs a full replacement (resize + update). Supports `options.internal` to bypass readOnly/formula restrictions.
 
 5. **Reactivity-aware**: Uses the global reactivity provider (MobX or noop). Configure via `setReactivityProvider()` for UI usage.
 

--- a/src/model/value-tree/ValueTree.ts
+++ b/src/model/value-tree/ValueTree.ts
@@ -94,7 +94,7 @@ export class ValueTree implements ValueTreeLike {
     this.changeTracker.track({
       type: 'setValue',
       path: this.index.pathOf(node),
-      value: value as JsonValue,
+      value: node.getPlainValue() as JsonValue,
       oldValue,
     });
   }

--- a/src/model/value-tree/ValueTree.ts
+++ b/src/model/value-tree/ValueTree.ts
@@ -75,17 +75,21 @@ export class ValueTree implements ValueTreeLike {
     return node?.getPlainValue();
   }
 
-  setValue(path: string, value: unknown): void {
+  setValue(path: string, value: unknown, options?: { internal?: boolean }): void {
     const node = this.get(path);
     if (!node) {
       throw new Error(`Path not found: ${path}`);
     }
-    if (!node.isPrimitive()) {
-      throw new Error(`Cannot set value on non-primitive node: ${path}`);
-    }
 
-    const oldValue = node.value as JsonValue;
-    node.setValue(value);
+    const oldValue = node.getPlainValue() as JsonValue;
+
+    if (node.isPrimitive()) {
+      node.setValue(value, options);
+    } else if (node.isObject()) {
+      node.setValue(value as Record<string, unknown>, options);
+    } else if (node.isArray()) {
+      node.setValue(value as unknown[], options);
+    }
 
     this.changeTracker.track({
       type: 'setValue',

--- a/src/model/value-tree/__tests__/ValueTree.spec.ts
+++ b/src/model/value-tree/__tests__/ValueTree.spec.ts
@@ -200,6 +200,28 @@ describe('ValueTree', () => {
       });
     });
 
+    it('tracks full value in patch after partial object update', () => {
+      const schema = obj({
+        profile: obj({
+          firstName: str(),
+          lastName: str(),
+        }),
+      });
+      const tree = createTree(schema, {
+        profile: { firstName: 'John', lastName: 'Doe' },
+      });
+
+      tree.setValue('profile', { firstName: 'Jane' });
+
+      const patches = tree.getPatches();
+      expect(patches).toHaveLength(1);
+      expect(patches[0]).toEqual({
+        op: 'replace',
+        path: '/profile',
+        value: { firstName: 'Jane', lastName: 'Doe' },
+      });
+    });
+
     it('sets deeply nested object value', () => {
       const schema = obj({
         profile: obj({

--- a/src/model/value-tree/types.ts
+++ b/src/model/value-tree/types.ts
@@ -72,7 +72,7 @@ export interface ValueTreeLike {
   readonly root: ValueNode;
   get(path: string): ValueNode | undefined;
   getValue(path: string): unknown;
-  setValue(path: string, value: unknown): void;
+  setValue(path: string, value: unknown, options?: { internal?: boolean }): void;
   getPlainValue(): unknown;
   readonly isDirty: boolean;
   readonly isValid: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add setValue to ObjectValueNode and ArrayValueNode, and extend ValueTree.setValue to update primitives, objects, and arrays. Supports recursive updates, array grow/shrink, and an internal option to bypass readOnly/formula rules; patches now record the final node value after updates.

- **New Features**
  - ObjectValueNode.setValue(value, options): partial update of existing keys; recursive.
  - ArrayValueNode.setValue(value, options): full replacement; updates by index, grow/shrink; recursive.
  - ValueTree.setValue(path, value, options): works for primitives/objects/arrays; propagates options; tracks patches with the updated full value.
  - Docs and tests added for semantics and options.internal (readOnly/formula behavior).

- **Migration**
  - ValueTree.setValue no longer throws for non-primitive nodes. If you relied on that error, update your code/tests.
  - Semantics: objects = partial update; arrays = full replacement (resize + update).

<sup>Written for commit 1356af0a65f5bff5b81fc340e456340dca27f271. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

