### PR TITLE
feat: typed models

### DIFF
--- a/src/lib/__tests__/schema-helpers.spec.ts
+++ b/src/lib/__tests__/schema-helpers.spec.ts
@@ -1,0 +1,191 @@
+import { JsonSchemaTypeName } from '../../types/schema.types.js';
+import {
+  str,
+  num,
+  bool,
+  obj,
+  arr,
+  ref,
+  getStringSchema,
+  getNumberSchema,
+  getBooleanSchema,
+  getObjectSchema,
+  getArraySchema,
+  getRefSchema,
+  getReplacePatch,
+  getRemovePatch,
+  getAddPatch,
+  getMovePatch,
+} from '../schema-helpers.js';
+
+describe('schema-helpers', () => {
+  describe('str / getStringSchema', () => {
+    it('returns correct schema with defaults', () => {
+      const schema = str();
+      expect(schema).toEqual({
+        type: JsonSchemaTypeName.String,
+        default: '',
+      });
+    });
+
+    it('merges options', () => {
+      const schema = str({ required: true, minLength: 3, maxLength: 10 });
+      expect(schema.type).toBe(JsonSchemaTypeName.String);
+      expect(schema.default).toBe('');
+      expect(schema.required).toBe(true);
+      expect(schema.minLength).toBe(3);
+      expect(schema.maxLength).toBe(10);
+    });
+
+    it('overrides default value', () => {
+      const schema = str({ default: 'hello' });
+      expect(schema.default).toBe('hello');
+    });
+
+    it('adds x-formula when formula provided', () => {
+      const schema = str({ formula: 'A + B' });
+      expect(schema['x-formula']).toEqual({ version: 1, expression: 'A + B' });
+    });
+
+    it('does not add x-formula when formula is empty', () => {
+      const schema = str({});
+      expect(schema['x-formula']).toBeUndefined();
+    });
+
+    it('getStringSchema is equivalent to str', () => {
+      expect(getStringSchema({ minLength: 5 })).toEqual(str({ minLength: 5 }));
+    });
+  });
+
+  describe('num / getNumberSchema', () => {
+    it('returns correct schema with defaults', () => {
+      const schema = num();
+      expect(schema).toEqual({
+        type: JsonSchemaTypeName.Number,
+        default: 0,
+      });
+    });
+
+    it('merges options', () => {
+      const schema = num({ minimum: 0, maximum: 100 });
+      expect(schema.minimum).toBe(0);
+      expect(schema.maximum).toBe(100);
+    });
+
+    it('adds x-formula', () => {
+      const schema = num({ formula: 'x * 2' });
+      expect(schema['x-formula']).toEqual({ version: 1, expression: 'x * 2' });
+    });
+
+    it('getNumberSchema is equivalent to num', () => {
+      expect(getNumberSchema()).toEqual(num());
+    });
+  });
+
+  describe('bool / getBooleanSchema', () => {
+    it('returns correct schema with defaults', () => {
+      const schema = bool();
+      expect(schema).toEqual({
+        type: JsonSchemaTypeName.Boolean,
+        default: false,
+      });
+    });
+
+    it('overrides default value', () => {
+      const schema = bool({ default: true });
+      expect(schema.default).toBe(true);
+    });
+
+    it('adds x-formula', () => {
+      const schema = bool({ formula: 'a > b' });
+      expect(schema['x-formula']).toEqual({ version: 1, expression: 'a > b' });
+    });
+
+    it('getBooleanSchema is equivalent to bool', () => {
+      expect(getBooleanSchema()).toEqual(bool());
+    });
+  });
+
+  describe('obj / getObjectSchema', () => {
+    it('returns correct schema with properties', () => {
+      const schema = obj({ name: str(), age: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.additionalProperties).toBe(false);
+      expect(schema.required).toEqual(['age', 'name']);
+      expect(schema.properties.name.type).toBe(JsonSchemaTypeName.String);
+      expect(schema.properties.age.type).toBe(JsonSchemaTypeName.Number);
+    });
+
+    it('sorts required keys alphabetically', () => {
+      const schema = obj({ z: str(), a: str(), m: str() });
+      expect(schema.required).toEqual(['a', 'm', 'z']);
+    });
+
+    it('accepts options', () => {
+      const schema = obj({ x: str() }, { description: 'test' });
+      expect(schema.description).toBe('test');
+    });
+
+    it('getObjectSchema is equivalent to obj', () => {
+      const props = { name: str() };
+      expect(getObjectSchema(props)).toEqual(obj(props));
+    });
+  });
+
+  describe('arr / getArraySchema', () => {
+    it('returns correct schema with items', () => {
+      const schema = arr(str());
+      expect(schema.type).toBe(JsonSchemaTypeName.Array);
+      expect(schema.items.type).toBe(JsonSchemaTypeName.String);
+    });
+
+    it('accepts options', () => {
+      const schema = arr(num(), { description: 'numbers' });
+      expect(schema.description).toBe('numbers');
+    });
+
+    it('getArraySchema is equivalent to arr', () => {
+      expect(getArraySchema(str())).toEqual(arr(str()));
+    });
+  });
+
+  describe('ref / getRefSchema', () => {
+    it('returns ref schema', () => {
+      const schema = ref('users');
+      expect(schema).toEqual({ $ref: 'users' });
+    });
+
+    it('accepts options', () => {
+      const schema = ref('users', { title: 'User ref', deprecated: true });
+      expect(schema.$ref).toBe('users');
+      expect(schema.title).toBe('User ref');
+      expect(schema.deprecated).toBe(true);
+    });
+
+    it('getRefSchema is equivalent to ref', () => {
+      expect(getRefSchema('t')).toEqual(ref('t'));
+    });
+  });
+
+  describe('patch helpers', () => {
+    it('getReplacePatch', () => {
+      const patch = getReplacePatch({ path: '/name', value: str() });
+      expect(patch).toEqual({ op: 'replace', path: '/name', value: str() });
+    });
+
+    it('getRemovePatch', () => {
+      const patch = getRemovePatch({ path: '/name' });
+      expect(patch).toEqual({ op: 'remove', path: '/name' });
+    });
+
+    it('getAddPatch', () => {
+      const patch = getAddPatch({ path: '/name', value: num() });
+      expect(patch).toEqual({ op: 'add', path: '/name', value: num() });
+    });
+
+    it('getMovePatch', () => {
+      const patch = getMovePatch({ from: '/old', path: '/new' });
+      expect(patch).toEqual({ op: 'move', from: '/old', path: '/new' });
+    });
+  });
+});

--- a/src/lib/schema-helpers.ts
+++ b/src/lib/schema-helpers.ts
@@ -1,0 +1,158 @@
+import {
+  JsonArraySchema,
+  JsonBooleanSchema,
+  JsonNumberSchema,
+  JsonObjectSchema,
+  JsonRefSchema,
+  JsonSchema,
+  JsonSchemaTypeName,
+  JsonStringSchema,
+  XFormula,
+} from '../types/schema.types.js';
+import {
+  JsonPatchAdd,
+  JsonPatchMove,
+  JsonPatchRemove,
+  JsonPatchReplace,
+} from '../types/json-patch.types.js';
+
+export const getReplacePatch = ({
+  path,
+  value,
+}: {
+  path: string;
+  value: JsonSchema;
+}): JsonPatchReplace => ({
+  op: 'replace',
+  path,
+  value,
+});
+
+export const getRemovePatch = ({
+  path,
+}: {
+  path: string;
+}): JsonPatchRemove => ({
+  op: 'remove',
+  path,
+});
+
+export const getAddPatch = ({
+  path,
+  value,
+}: {
+  path: string;
+  value: JsonSchema;
+}): JsonPatchAdd => ({
+  op: 'add',
+  path,
+  value,
+});
+
+export const getMovePatch = ({
+  from,
+  path,
+}: {
+  from: string;
+  path: string;
+}): JsonPatchMove => ({
+  op: 'move',
+  from,
+  path,
+});
+
+export type StringSchemaOptions = Partial<
+  Omit<JsonStringSchema, 'type' | 'x-formula'> & { formula: string }
+>;
+
+export type NumberSchemaOptions = Partial<
+  Omit<JsonNumberSchema, 'type' | 'x-formula'> & { formula: string }
+>;
+
+export type BooleanSchemaOptions = Partial<
+  Omit<JsonBooleanSchema, 'type' | 'x-formula'> & { formula: string }
+>;
+
+export type ObjectSchemaOptions = Partial<Omit<JsonObjectSchema, 'type' | 'properties' | 'required'>>;
+
+export type ArraySchemaOptions = Partial<Omit<JsonArraySchema, 'type' | 'items'>>;
+
+export type RefSchemaOptions = Partial<Omit<JsonRefSchema, '$ref'>>;
+
+const buildFormula = (expression: string): XFormula => ({
+  version: 1,
+  expression,
+});
+
+export const getStringSchema = (params: StringSchemaOptions = {}): JsonStringSchema => {
+  const { formula, ...rest } = params;
+  return {
+    type: JsonSchemaTypeName.String,
+    ...rest,
+    default: rest.default ?? '',
+    ...(formula && { 'x-formula': buildFormula(formula) }),
+  };
+};
+
+export const getNumberSchema = (params: NumberSchemaOptions = {}): JsonNumberSchema => {
+  const { formula, ...rest } = params;
+  return {
+    type: JsonSchemaTypeName.Number,
+    ...rest,
+    default: rest.default ?? 0,
+    ...(formula && { 'x-formula': buildFormula(formula) }),
+  };
+};
+
+export const getBooleanSchema = (params: BooleanSchemaOptions = {}): JsonBooleanSchema => {
+  const { formula, ...rest } = params;
+  return {
+    type: JsonSchemaTypeName.Boolean,
+    ...rest,
+    default: rest.default ?? false,
+    ...(formula && { 'x-formula': buildFormula(formula) }),
+  };
+};
+
+export const getObjectSchema = <P extends Record<string, JsonSchema>>(
+  properties: P,
+  options: ObjectSchemaOptions = {},
+): JsonObjectSchema & { readonly properties: { readonly [K in keyof P]: P[K] } } => ({
+  type: JsonSchemaTypeName.Object,
+  additionalProperties: false,
+  required: Object.keys(properties).sort((a, b) => a.localeCompare(b)),
+  properties: properties as { readonly [K in keyof P]: P[K] },
+  ...options,
+});
+
+export const getArraySchema = <I extends JsonSchema>(
+  items: I,
+  options: ArraySchemaOptions = {},
+): JsonArraySchema & { readonly items: I } => ({
+  type: JsonSchemaTypeName.Array,
+  items,
+  ...options,
+});
+
+export const getRefSchema = ($ref: string, options: RefSchemaOptions = {}): JsonRefSchema => ({
+  $ref,
+  ...options,
+});
+
+export const str = (params: StringSchemaOptions = {}): JsonStringSchema => getStringSchema(params);
+export const num = (params: NumberSchemaOptions = {}): JsonNumberSchema => getNumberSchema(params);
+export const bool = (params: BooleanSchemaOptions = {}): JsonBooleanSchema =>
+  getBooleanSchema(params);
+export const obj = <P extends Record<string, JsonSchema>>(
+  properties: P,
+  options?: ObjectSchemaOptions,
+): JsonObjectSchema & { readonly properties: { readonly [K in keyof P]: P[K] } } =>
+  getObjectSchema(properties, options);
+export const arr = <I extends JsonSchema>(
+  items: I,
+  options?: ArraySchemaOptions,
+): JsonArraySchema & { readonly items: I } => getArraySchema(items, options);
+export const ref = ($ref: string, options?: RefSchemaOptions): JsonRefSchema =>
+  getRefSchema($ref, options);
+
+export type { ContentMediaType } from '../types/schema.types.js';

--- a/src/mocks/schema.mocks.ts
+++ b/src/mocks/schema.mocks.ts
@@ -1,156 +1,21 @@
-import {
-  JsonArraySchema,
-  JsonBooleanSchema,
-  JsonNumberSchema,
-  JsonObjectSchema,
-  JsonRefSchema,
-  JsonSchema,
-  JsonSchemaTypeName,
-  JsonStringSchema,
-  XFormula,
-} from '../types/schema.types.js';
-import {
-  JsonPatchAdd,
-  JsonPatchMove,
-  JsonPatchRemove,
-  JsonPatchReplace,
-} from '../types/json-patch.types.js';
-
-export const getReplacePatch = ({
-  path,
-  value,
-}: {
-  path: string;
-  value: JsonSchema;
-}): JsonPatchReplace => ({
-  op: 'replace',
-  path,
-  value,
-});
-
-export const getRemovePatch = ({
-  path,
-}: {
-  path: string;
-}): JsonPatchRemove => ({
-  op: 'remove',
-  path,
-});
-
-export const getAddPatch = ({
-  path,
-  value,
-}: {
-  path: string;
-  value: JsonSchema;
-}): JsonPatchAdd => ({
-  op: 'add',
-  path,
-  value,
-});
-
-export const getMovePatch = ({
-  from,
-  path,
-}: {
-  from: string;
-  path: string;
-}): JsonPatchMove => ({
-  op: 'move',
-  from,
-  path,
-});
-
-type StringSchemaOptions = Partial<
-  Omit<JsonStringSchema, 'type' | 'x-formula'> & { formula: string }
->;
-
-type NumberSchemaOptions = Partial<
-  Omit<JsonNumberSchema, 'type' | 'x-formula'> & { formula: string }
->;
-
-type BooleanSchemaOptions = Partial<
-  Omit<JsonBooleanSchema, 'type' | 'x-formula'> & { formula: string }
->;
-
-type ObjectSchemaOptions = Partial<Omit<JsonObjectSchema, 'type' | 'properties' | 'required'>>;
-
-type ArraySchemaOptions = Partial<Omit<JsonArraySchema, 'type' | 'items'>>;
-
-type RefSchemaOptions = Partial<Omit<JsonRefSchema, '$ref'>>;
-
-const buildFormula = (expression: string): XFormula => ({
-  version: 1,
-  expression,
-});
-
-export const getStringSchema = (params: StringSchemaOptions = {}): JsonStringSchema => {
-  const { formula, ...rest } = params;
-  return {
-    type: JsonSchemaTypeName.String,
-    ...rest,
-    default: rest.default ?? '',
-    ...(formula && { 'x-formula': buildFormula(formula) }),
-  };
-};
-
-export const getNumberSchema = (params: NumberSchemaOptions = {}): JsonNumberSchema => {
-  const { formula, ...rest } = params;
-  return {
-    type: JsonSchemaTypeName.Number,
-    ...rest,
-    default: rest.default ?? 0,
-    ...(formula && { 'x-formula': buildFormula(formula) }),
-  };
-};
-
-export const getBooleanSchema = (params: BooleanSchemaOptions = {}): JsonBooleanSchema => {
-  const { formula, ...rest } = params;
-  return {
-    type: JsonSchemaTypeName.Boolean,
-    ...rest,
-    default: rest.default ?? false,
-    ...(formula && { 'x-formula': buildFormula(formula) }),
-  };
-};
-
-export const getObjectSchema = (
-  properties: Record<string, JsonSchema>,
-  options: ObjectSchemaOptions = {},
-): JsonObjectSchema => ({
-  type: JsonSchemaTypeName.Object,
-  additionalProperties: false,
-  required: Object.keys(properties).sort((a, b) => a.localeCompare(b)),
-  properties,
-  ...options,
-});
-
-export const getArraySchema = (
-  items: JsonSchema,
-  options: ArraySchemaOptions = {},
-): JsonArraySchema => ({
-  type: JsonSchemaTypeName.Array,
-  items,
-  ...options,
-});
-
-export const getRefSchema = ($ref: string, options: RefSchemaOptions = {}): JsonRefSchema => ({
-  $ref,
-  ...options,
-});
-
-export const str = (params: StringSchemaOptions = {}): JsonStringSchema => getStringSchema(params);
-export const num = (params: NumberSchemaOptions = {}): JsonNumberSchema => getNumberSchema(params);
-export const bool = (params: BooleanSchemaOptions = {}): JsonBooleanSchema =>
-  getBooleanSchema(params);
-export const obj = (
-  properties: Record<string, JsonSchema>,
-  options?: ObjectSchemaOptions,
-): JsonObjectSchema => getObjectSchema(properties, options);
-export const arr = (items: JsonSchema, options?: ArraySchemaOptions): JsonArraySchema =>
-  getArraySchema(items, options);
-export const ref = ($ref: string, options?: RefSchemaOptions): JsonRefSchema =>
-  getRefSchema($ref, options);
+export {
+  getReplacePatch,
+  getRemovePatch,
+  getAddPatch,
+  getMovePatch,
+  getStringSchema,
+  getNumberSchema,
+  getBooleanSchema,
+  getObjectSchema,
+  getArraySchema,
+  getRefSchema,
+  str,
+  num,
+  bool,
+  obj,
+  arr,
+  ref,
+} from '../lib/schema-helpers.js';
 
 export type {
   StringSchemaOptions,
@@ -159,6 +24,5 @@ export type {
   ObjectSchemaOptions,
   ArraySchemaOptions,
   RefSchemaOptions,
-};
-
-export type { ContentMediaType } from '../types/schema.types.js';
+  ContentMediaType,
+} from '../lib/schema-helpers.js';

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -44,3 +44,8 @@ export type {
   RefSchemas,
 } from './value-node/index.js';
 export { NodeFactory as ValueNodeFactory } from './value-node/index.js';
+
+export { ValueTree } from './value-tree/index.js';
+export type { ValueTreeLike } from './value-tree/index.js';
+export { createTypedTree, typedNode } from './value-tree/index.js';
+export type { TypedValueTree } from './value-tree/index.js';

--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -63,7 +63,7 @@ Each row automatically gets:
 ```typescript
 interface RowModelOptions {
   rowId: string;
-  schema: JsonObjectSchema;
+  schema: JsonSchema;
   data?: unknown;          // defaults to schema defaults
   fkResolver?: ForeignKeyResolver;
   refSchemas?: RefSchemas;
@@ -72,9 +72,10 @@ interface RowModelOptions {
 
 ### createRowModel
 
-Factory for creating standalone rows without a table:
+Factory for creating standalone rows without a table. Uses overloads — when a typed schema is passed (via helpers like `obj()`, `str()` or `as const`), returns `TypedRowModel<S>` with full type safety. When an untyped `JsonSchema` is passed, returns plain `RowModel`:
 
 ```typescript
+function createRowModel<const S extends JsonSchema>(options: TypedRowModelOptions<S>): TypedRowModel<S>;
 function createRowModel(options: RowModelOptions): RowModel;
 ```
 
@@ -493,3 +494,5 @@ None
 12. **Auto-dispose on removeRow**: `removeRow()` automatically disposes the removed row, cleaning up FormulaEngine reactions. `dispose()` on TableModel disposes all rows at once.
 
 13. **Standalone createRowModel**: `createRowModel()` provides the same row creation logic (NodeFactory + ValueTree + FormulaEngine) as `TableModel.addRow()`, but without a table context. `TableModel` uses it internally and adds `setTableModel(this)` on top.
+
+14. **Typed Overloads**: Both `createRowModel()` and `createTableModel()` use TypeScript overloads. When schema preserves literal types (via helpers or `as const`), returns `TypedRowModel<S>` / `TypedTableModel<S>` with typed `getValue()`, `setValue()`, `getPlainValue()`. When schema is a plain `JsonSchema` / `JsonObjectSchema`, returns the untyped `RowModel` / `TableModel` as before. See `src/types/TYPED-API.md` for full documentation.

--- a/src/model/table/TableModelImpl.ts
+++ b/src/model/table/TableModelImpl.ts
@@ -6,6 +6,7 @@ import type { SchemaModel } from '../schema-model/types.js';
 import { createRowModel, RowModelImpl } from './row/RowModelImpl.js';
 import type { RowModel } from './row/types.js';
 import type { TableModel, TableModelOptions, RefSchemas } from './types.js';
+import type { TypedTableModel, TypedTableModelOptions } from './typed.js';
 
 export class TableModelImpl implements TableModel {
   private _tableId: string;
@@ -169,6 +170,10 @@ export class TableModelImpl implements TableModel {
   }
 }
 
+export function createTableModel<const S extends JsonObjectSchema>(
+  options: TypedTableModelOptions<S>,
+): TypedTableModel<S>;
+export function createTableModel(options: TableModelOptions): TableModel;
 export function createTableModel(options: TableModelOptions): TableModel {
   return new TableModelImpl(options);
 }

--- a/src/model/table/index.ts
+++ b/src/model/table/index.ts
@@ -1,3 +1,4 @@
 export * from './row/index.js';
 export type { TableModel, TableModelOptions, RowData, RefSchemas } from './types.js';
 export { TableModelImpl, createTableModel } from './TableModelImpl.js';
+export type { TypedTableModel, TypedTableModelOptions, TypedRowData } from './typed.js';

--- a/src/model/table/row/RowModelImpl.ts
+++ b/src/model/table/row/RowModelImpl.ts
@@ -1,5 +1,6 @@
 import { makeAutoObservable } from '../../../core/reactivity/index.js';
 import type { Diagnostic } from '../../../core/validation/types.js';
+import type { JsonSchema } from '../../../types/schema.types.js';
 import type { JsonValuePatch } from '../../../types/json-value-patch.types.js';
 import { generateDefaultValue } from '../../default-value/index.js';
 import { FormulaEngine } from '../../value-formula/FormulaEngine.js';
@@ -7,6 +8,7 @@ import { createNodeFactory } from '../../value-node/NodeFactory.js';
 import type { ValueNode } from '../../value-node/types.js';
 import { ValueTree } from '../../value-tree/ValueTree.js';
 import type { RowModel, RowModelOptions, TableModelLike, ValueTreeLike } from './types.js';
+import type { TypedRowModel, TypedRowModelOptions } from './typed.js';
 
 const UNSET_INDEX = -1;
 
@@ -118,6 +120,10 @@ export class RowModelImpl implements RowModel {
   }
 }
 
+export function createRowModel<const S extends JsonSchema>(
+  options: TypedRowModelOptions<S>,
+): TypedRowModel<S>;
+export function createRowModel(options: RowModelOptions): RowModel;
 export function createRowModel(options: RowModelOptions): RowModel {
   const factory = createNodeFactory({
     fkResolver: options.fkResolver,

--- a/src/model/table/row/index.ts
+++ b/src/model/table/row/index.ts
@@ -1,2 +1,3 @@
 export type { RowModel, RowModelOptions, TableModelLike, ValueTreeLike } from './types.js';
 export { RowModelImpl, createRowModel } from './RowModelImpl.js';
+export type { TypedRowModel, TypedRowModelOptions } from './typed.js';

--- a/src/model/table/row/typed.ts
+++ b/src/model/table/row/typed.ts
@@ -1,0 +1,20 @@
+import type { JsonSchema } from '../../../types/schema.types.js';
+import type {
+  InferValue,
+  NodeAtPath,
+  SchemaPaths,
+  ValueAtPath,
+} from '../../../types/typed.js';
+import type { RowModel, RowModelOptions } from './types.js';
+
+export interface TypedRowModel<S> extends RowModel {
+  get<P extends SchemaPaths<S>>(path: P): NodeAtPath<S, P>;
+  getValue<P extends SchemaPaths<S>>(path: P): ValueAtPath<S, P>;
+  setValue<P extends SchemaPaths<S>>(path: P, value: ValueAtPath<S, P>): void;
+  getPlainValue(): InferValue<S>;
+}
+
+export interface TypedRowModelOptions<S extends JsonSchema> extends Omit<RowModelOptions, 'schema' | 'data'> {
+  schema: S;
+  data?: InferValue<S>;
+}

--- a/src/model/table/typed.ts
+++ b/src/model/table/typed.ts
@@ -1,0 +1,22 @@
+import type { JsonObjectSchema } from '../../types/schema.types.js';
+import type { InferValue } from '../../types/typed.js';
+import type { TypedRowModel } from './row/typed.js';
+import type { TableModel, TableModelOptions } from './types.js';
+
+export interface TypedRowData<S> {
+  rowId: string;
+  data: InferValue<S>;
+}
+
+export interface TypedTableModel<S> extends TableModel {
+  readonly rows: readonly TypedRowModel<S>[];
+  addRow(rowId: string, data?: InferValue<S>): TypedRowModel<S>;
+  getRow(rowId: string): TypedRowModel<S> | undefined;
+  getRowAt(index: number): TypedRowModel<S> | undefined;
+}
+
+export interface TypedTableModelOptions<S extends JsonObjectSchema>
+  extends Omit<TableModelOptions, 'schema' | 'rows'> {
+  schema: S;
+  rows?: TypedRowData<S>[];
+}

--- a/src/model/type-transformer/transformers/RefTransformer.ts
+++ b/src/model/type-transformer/transformers/RefTransformer.ts
@@ -1,5 +1,5 @@
 import { createRefNode } from '../../../core/schema-node/index.js';
-import { obj, ref } from '../../../mocks/schema.mocks.js';
+import { obj, ref } from '../../../lib/schema-helpers.js';
 import type { TypeTransformer, TransformContext, TransformResult } from '../types.js';
 import { SchemaParser } from '../../schema-model/SchemaParser.js';
 

--- a/src/model/value-tree/index.ts
+++ b/src/model/value-tree/index.ts
@@ -2,3 +2,5 @@ export type { ValueTreeLike, Change, ChangeType } from './types.js';
 export { ValueTree } from './ValueTree.js';
 export { TreeIndex } from './TreeIndex.js';
 export { ChangeTracker } from './ChangeTracker.js';
+export { createTypedTree, typedNode } from './typed.js';
+export type { TypedValueTree } from './typed.js';

--- a/src/model/value-tree/typed.ts
+++ b/src/model/value-tree/typed.ts
@@ -1,0 +1,38 @@
+import type { JsonSchema } from '../../types/schema.types.js';
+import type {
+  InferNode,
+  InferValue,
+  NodeAtPath,
+  SchemaPaths,
+  ValueAtPath,
+} from '../../types/typed.js';
+import type { NodeFactoryOptions } from '../value-node/NodeFactory.js';
+import type { ValueNode } from '../value-node/types.js';
+import { createNodeFactory } from '../value-node/NodeFactory.js';
+import { ValueTree } from './ValueTree.js';
+import type { ValueTreeLike } from './types.js';
+
+export interface TypedValueTree<S> extends ValueTreeLike {
+  readonly root: InferNode<S>;
+  get<P extends SchemaPaths<S>>(path: P): NodeAtPath<S, P>;
+  getValue<P extends SchemaPaths<S>>(path: P): ValueAtPath<S, P>;
+  setValue<P extends SchemaPaths<S>>(
+    path: P,
+    value: ValueAtPath<S, P>,
+    options?: { internal?: boolean },
+  ): void;
+}
+
+export function typedNode<S extends JsonSchema>(node: ValueNode): InferNode<S> {
+  return node as InferNode<S>;
+}
+
+export function createTypedTree<const S extends JsonSchema>(
+  schema: S,
+  data: InferValue<S>,
+  options?: NodeFactoryOptions,
+): TypedValueTree<S> {
+  const factory = createNodeFactory(options);
+  const root = factory.createTree(schema, data);
+  return new ValueTree(root) as unknown as TypedValueTree<S>;
+}

--- a/src/types/TYPED-API.md
+++ b/src/types/TYPED-API.md
@@ -1,0 +1,336 @@
+# Typed Value API
+
+Compile-time type safety for schema-toolkit value trees. Zero runtime cost — pure type-level layer on top of the existing untyped API.
+
+## With helper functions
+
+```typescript
+import { obj, str, num, bool, arr, createTypedTree } from '@revisium/schema-toolkit';
+
+const schema = obj({
+  name: str(),
+  age: num(),
+  active: bool(),
+  address: obj({
+    city: str(),
+    zip: str(),
+  }),
+  tags: arr(str()),
+});
+
+const tree = createTypedTree(schema, {
+  name: 'John',
+  age: 30,
+  active: true,
+  address: { city: 'NYC', zip: '10001' },
+  tags: ['dev'],
+});
+
+// Chained access — full autocomplete and type safety
+tree.root.child('name').value;                        // string
+tree.root.child('address').child('city').value;       // string
+tree.root.child('tags').at(0)?.value;                 // string
+tree.root.child('address').getPlainValue();           // { city: string, zip: string }
+tree.root.getPlainValue();                            // full typed object
+
+// Type-safe setValue
+tree.root.child('name').setValue('Jane');              // OK
+tree.root.child('name').setValue(42);                  // TS Error!
+tree.root.child('address').setValue({ city: 'LA' });  // OK (Partial)
+
+// Path strings
+tree.get('address.city');        // TypedPrimitiveValueNode<string>
+tree.getValue('name');           // string
+tree.setValue('age', 25);        // OK
+tree.setValue('age', 'wrong');   // TS Error!
+```
+
+## From a plain TypeScript type (`SchemaFromValue`)
+
+If you already have a TypeScript type for your data, you can use `SchemaFromValue` to derive the schema shape automatically — no need to write schema objects at all:
+
+```typescript
+import type { SchemaFromValue, NodeFromValue, ValuePaths } from '@revisium/schema-toolkit';
+import type { TypedRowModel } from '@revisium/schema-toolkit';
+
+// Your plain TypeScript type
+type User = {
+  firstName: string;
+  age: number;
+  active: boolean;
+  address: {
+    city: string;
+    zip: string;
+  };
+  tags: string[];
+};
+
+// Derive schema type automatically
+type UserSchema = SchemaFromValue<User>;
+
+// Use with typed row model
+declare const row: TypedRowModel<UserSchema>;
+row.getValue('firstName');          // string
+row.getValue('address.city');       // string
+row.getPlainValue();                // User
+
+// Get typed node
+type UserNode = NodeFromValue<User>;
+// = TypedObjectValueNode<{ firstName: { type: 'string' }; age: { type: 'number' }; ... }>
+
+// Get all valid paths
+type UserPaths = ValuePaths<User>;
+// = 'firstName' | 'age' | 'active' | 'address' | 'address.city' | 'address.zip' | 'tags' | ...
+```
+
+## Typed RowModel and TableModel
+
+`createRowModel` and `createTableModel` use overloads: when a typed schema is passed (via helpers or `as const`), they return `TypedRowModel<S>` / `TypedTableModel<S>` with full type safety. When an untyped `JsonSchema` / `JsonObjectSchema` is passed, they return the plain `RowModel` / `TableModel` as before.
+
+### `createRowModel`
+
+```typescript
+import { obj, str, num, createRowModel } from '@revisium/schema-toolkit';
+
+// Typed — schema preserves literal types
+const schema = obj({
+  name: str(),
+  price: num(),
+});
+
+const row = createRowModel({
+  rowId: 'row-1',
+  schema,
+  data: { name: 'Widget', price: 9.99 },
+});
+
+row.getValue('name');              // string
+row.getValue('price');             // number
+row.getPlainValue();               // { name: string, price: number }
+row.setValue('price', 19.99);      // OK
+row.setValue('price', 'wrong');    // TS Error!
+```
+
+```typescript
+import { createRowModel } from '@revisium/schema-toolkit';
+import type { JsonObjectSchema } from '@revisium/schema-toolkit';
+
+// Untyped — plain RowModel, same as before
+const schema: JsonObjectSchema = getSchemaFromApi();
+const row = createRowModel({ rowId: 'row-1', schema, data });
+
+row.getValue('name');              // unknown
+row.getPlainValue();               // unknown
+```
+
+### `createTableModel`
+
+```typescript
+import { obj, str, num, bool, createTableModel } from '@revisium/schema-toolkit';
+
+// Typed
+const schema = obj({
+  title: str(),
+  price: num(),
+  inStock: bool(),
+});
+
+const table = createTableModel({
+  tableId: 'products',
+  schema,
+  rows: [
+    { rowId: 'p1', data: { title: 'Laptop', price: 999, inStock: true } },
+    { rowId: 'p2', data: { title: 'Mouse', price: 29, inStock: false } },
+  ],
+});
+
+// All rows are typed
+const row = table.getRow('p1');
+row?.getValue('title');            // string
+row?.getPlainValue();              // { title: string, price: number, inStock: boolean }
+
+// addRow is typed
+const newRow = table.addRow('p3', { title: 'KB', price: 79, inStock: true });
+newRow.setValue('price', 89);      // OK
+newRow.setValue('price', 'wrong'); // TS Error!
+```
+
+```typescript
+import { createTableModel } from '@revisium/schema-toolkit';
+import type { JsonObjectSchema } from '@revisium/schema-toolkit';
+
+// Untyped — plain TableModel, same as before
+const schema: JsonObjectSchema = getSchemaFromApi();
+const table = createTableModel({ tableId: 'products', schema, rows });
+
+table.getRow('p1')?.getValue('title');  // unknown
+table.addRow('p3', data);               // RowModel (untyped)
+```
+
+## Without helper functions (plain objects)
+
+If your schema comes from a runtime source (API, database, config file), or you simply prefer not to use the helper functions, you can define the schema type manually.
+
+### Option 1: `as const` assertion
+
+```typescript
+import { createTypedTree } from '@revisium/schema-toolkit';
+
+const schema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'age', 'address', 'tags'],
+  properties: {
+    name: { type: 'string', default: '' },
+    age: { type: 'number', default: 0 },
+    address: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['city', 'zip'],
+      properties: {
+        city: { type: 'string', default: '' },
+        zip: { type: 'string', default: '' },
+      },
+    },
+    tags: {
+      type: 'array',
+      items: { type: 'string', default: '' },
+    },
+  },
+} as const;
+
+const tree = createTypedTree(schema, {
+  name: 'John',
+  age: 30,
+  address: { city: 'NYC', zip: '10001' },
+  tags: ['dev'],
+});
+
+tree.root.child('name').value;   // string
+tree.root.child('age').value;    // number
+tree.getValue('address.city');   // string
+```
+
+The `as const` assertion preserves literal types (`'string'` instead of `string`), which is required for type inference to work.
+
+### Option 2: Explicit schema type declaration
+
+When you have a schema that comes from an external source at runtime, you can declare the schema type separately:
+
+```typescript
+import { createTypedTree } from '@revisium/schema-toolkit';
+
+type UserSchema = {
+  type: 'object';
+  additionalProperties: false;
+  required: string[];
+  properties: {
+    name: { type: 'string'; default: '' };
+    age: { type: 'number'; default: 0 };
+    address: {
+      type: 'object';
+      additionalProperties: false;
+      required: string[];
+      properties: {
+        city: { type: 'string'; default: '' };
+        zip: { type: 'string'; default: '' };
+      };
+    };
+  };
+};
+
+const schema: UserSchema = loadSchemaFromSomewhere();
+
+const tree = createTypedTree(schema, {
+  name: 'John',
+  age: 30,
+  address: { city: 'NYC', zip: '10001' },
+});
+
+tree.root.child('name').value;   // string
+tree.getValue('address.city');   // string
+```
+
+### Option 3: Plain TS type via `SchemaFromValue`
+
+The simplest approach — just declare your data type and derive everything else:
+
+```typescript
+import { createRowModel } from '@revisium/schema-toolkit';
+import type { SchemaFromValue } from '@revisium/schema-toolkit';
+
+type User = {
+  name: string;
+  age: number;
+  address: { city: string };
+};
+
+type UserSchema = SchemaFromValue<User>;
+
+// Pass a real JSON Schema object at runtime, but type it as UserSchema
+const schema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'age', 'address'],
+  properties: {
+    name: { type: 'string', default: '' },
+    age: { type: 'number', default: 0 },
+    address: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['city'],
+      properties: {
+        city: { type: 'string', default: '' },
+      },
+    },
+  },
+} as unknown as UserSchema;
+
+const row = createRowModel({
+  rowId: 'u1',
+  schema: schema as any,  // runtime schema is untyped
+  data: { name: 'John', age: 30, address: { city: 'NYC' } },
+});
+
+row.getValue('name');            // string
+row.getValue('address.city');    // string
+row.getPlainValue();             // User
+```
+
+### Option 4: Type an existing untyped node
+
+If you already have an untyped `ValueNode` (e.g., from the existing API), you can cast it:
+
+```typescript
+import { typedNode } from '@revisium/schema-toolkit';
+
+const typedRoot = typedNode<UserSchema>(untypedTree.root);
+typedRoot.child('name').value;  // string
+```
+
+## Type utilities reference
+
+| Type | Description |
+|------|-------------|
+| `InferValue<S>` | Maps schema type `S` to the plain TypeScript value |
+| `InferNode<S>` | Maps schema type `S` to the typed `ValueNode` interface |
+| `SchemaFromValue<T>` | Maps a plain TS value type `T` to a virtual schema shape |
+| `NodeFromValue<T>` | `InferNode<SchemaFromValue<T>>` — typed node from value type |
+| `ValuePaths<T>` | `SchemaPaths<SchemaFromValue<T>>` — valid paths from value type |
+| `SchemaPaths<S>` | Union of all valid dot-separated paths in schema `S` |
+| `SchemaAtPath<S, P>` | Resolves the sub-schema at path `P` within `S` |
+| `NodeAtPath<S, P>` | `InferNode<SchemaAtPath<S, P>>` |
+| `ValueAtPath<S, P>` | `InferValue<SchemaAtPath<S, P>>` |
+| `TypedValueTree<S>` | A `ValueTree` with typed `root`, `get()`, `getValue()`, `setValue()` |
+| `TypedRowModel<S>` | A `RowModel` with typed `get()`, `getValue()`, `setValue()`, `getPlainValue()` |
+| `TypedTableModel<S>` | A `TableModel` with typed `rows`, `addRow()`, `getRow()` |
+| `TypedPrimitiveValueNode<T>` | `PrimitiveValueNode` with narrowed `value: T` |
+| `TypedObjectValueNode<P>` | `ObjectValueNode` with typed `child()` and `getPlainValue()` |
+| `TypedArrayValueNode<I>` | `ArrayValueNode` with typed `at()` and `getPlainValue()` |
+
+## Limitations
+
+- Recursion depth ~8-10 levels (bails to `ValueNode` / `unknown` beyond that)
+- `$ref` schemas fall back to untyped (`ValueNode`)
+- Dynamic schemas loaded at runtime without type declarations use the untyped API
+- Path autocomplete may be slow for very wide/deep schemas in IDEs

--- a/src/types/__tests__/typed.spec.ts
+++ b/src/types/__tests__/typed.spec.ts
@@ -1,0 +1,447 @@
+import { str, num, bool, obj, arr } from '../../lib/schema-helpers.js';
+import { JsonSchemaTypeName } from '../schema.types.js';
+import type {
+  InferValue,
+  InferNode,
+  TypedPrimitiveValueNode,
+  TypedObjectValueNode,
+  TypedArrayValueNode,
+  SchemaPaths,
+  SchemaAtPath,
+  ValueAtPath,
+  SchemaFromValue,
+  NodeFromValue,
+  ValuePaths,
+} from '../typed.js';
+import type { ValueNode } from '../../model/value-node/types.js';
+import type { TypedValueTree } from '../../model/value-tree/typed.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function assert<_T extends true>() {}
+type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type Extends<A, B> = A extends B ? true : false;
+
+describe('typed API — compile-time type assertions', () => {
+  describe('InferValue', () => {
+    it('maps string schema to string', () => {
+      assert<Equal<InferValue<ReturnType<typeof str>>, string>>();
+    });
+
+    it('maps number schema to number', () => {
+      assert<Equal<InferValue<ReturnType<typeof num>>, number>>();
+    });
+
+    it('maps boolean schema to boolean', () => {
+      assert<Equal<InferValue<ReturnType<typeof bool>>, boolean>>();
+    });
+
+    it('maps object schema to typed object', () => {
+      expect(obj({ name: str(), age: num() }).type).toBe(JsonSchemaTypeName.Object);
+      assert<Equal<InferValue<ReturnType<typeof obj<{ name: ReturnType<typeof str>; age: ReturnType<typeof num> }>>>, { name: string; age: number }>>();
+    });
+
+    it('maps array schema to typed array', () => {
+      expect(arr(str()).type).toBe(JsonSchemaTypeName.Array);
+      assert<Equal<InferValue<ReturnType<typeof arr<ReturnType<typeof str>>>>, string[]>>();
+    });
+
+    it('maps nested object schema', () => {
+      const schema = obj({
+        address: obj({ city: str(), zip: str() }),
+        tags: arr(str()),
+      });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      assert<
+        Equal<InferValue<typeof schema>, { address: { city: string; zip: string }; tags: string[] }>
+      >();
+    });
+
+    it('maps plain object literal schema with as const', () => {
+      const schema = {
+        type: 'string' as const,
+        default: '',
+      };
+      expect(schema.type).toBe('string');
+      assert<Equal<InferValue<typeof schema>, string>>();
+    });
+
+    it('maps plain object literal for object schema with as const', () => {
+      const schema = {
+        type: 'object' as const,
+        additionalProperties: false as const,
+        required: ['name'] as string[],
+        properties: {
+          name: { type: 'string' as const, default: '' },
+        },
+      };
+      expect(schema.type).toBe('object');
+      assert<Equal<InferValue<typeof schema>, { name: string }>>();
+    });
+
+    it('maps plain object literal for array schema with as const', () => {
+      const schema = {
+        type: 'array' as const,
+        items: { type: 'number' as const, default: 0 },
+      };
+      expect(schema.type).toBe('array');
+      assert<Equal<InferValue<typeof schema>, number[]>>();
+    });
+  });
+
+  describe('InferNode', () => {
+    it('maps string schema to TypedPrimitiveValueNode<string>', () => {
+      assert<Equal<InferNode<ReturnType<typeof str>>, TypedPrimitiveValueNode<string>>>();
+    });
+
+    it('maps number schema to TypedPrimitiveValueNode<number>', () => {
+      assert<Equal<InferNode<ReturnType<typeof num>>, TypedPrimitiveValueNode<number>>>();
+    });
+
+    it('maps boolean schema to TypedPrimitiveValueNode<boolean>', () => {
+      assert<Equal<InferNode<ReturnType<typeof bool>>, TypedPrimitiveValueNode<boolean>>>();
+    });
+
+    it('maps object schema to TypedObjectValueNode', () => {
+      const schema = obj({ name: str() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Props = (typeof schema)['properties'];
+      assert<Equal<InferNode<typeof schema>, TypedObjectValueNode<Props>>>();
+    });
+
+    it('maps array schema to TypedArrayValueNode', () => {
+      const schema = arr(num());
+      expect(schema.type).toBe(JsonSchemaTypeName.Array);
+      type Items = (typeof schema)['items'];
+      assert<Equal<InferNode<typeof schema>, TypedArrayValueNode<Items>>>();
+    });
+
+    it('falls back to ValueNode for unknown schemas', () => {
+      assert<Equal<InferNode<{ $ref: string }>, ValueNode>>();
+    });
+  });
+
+  describe('typed node interface contracts', () => {
+    it('TypedObjectValueNode.child returns narrowed type for specific key', () => {
+      const schema = obj({ name: str(), count: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Props = (typeof schema)['properties'];
+      assert<Equal<InferNode<Props['name']>, TypedPrimitiveValueNode<string>>>();
+      assert<Equal<InferNode<Props['count']>, TypedPrimitiveValueNode<number>>>();
+    });
+
+    it('TypedObjectValueNode.getPlainValue returns typed object', () => {
+      const schema = obj({ flag: bool(), label: str() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Props = (typeof schema)['properties'];
+      type Node = TypedObjectValueNode<Props>;
+      type Value = ReturnType<Node['getPlainValue']>;
+      assert<Equal<Value, { flag: boolean; label: string }>>();
+    });
+
+    it('TypedArrayValueNode.at returns element node type', () => {
+      type Node = TypedArrayValueNode<ReturnType<typeof str>>;
+      type Item = ReturnType<Node['at']>;
+      assert<Equal<Item, TypedPrimitiveValueNode<string> | undefined>>();
+    });
+
+    it('TypedArrayValueNode.getPlainValue returns typed array', () => {
+      type Node = TypedArrayValueNode<ReturnType<typeof num>>;
+      type Value = ReturnType<Node['getPlainValue']>;
+      assert<Equal<Value, number[]>>();
+    });
+  });
+
+  describe('SchemaPaths', () => {
+    it('generates top-level property paths', () => {
+      const schema = obj({ name: str(), age: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Paths = SchemaPaths<typeof schema>;
+      assert<Extends<'name', Paths>>();
+      assert<Extends<'age', Paths>>();
+    });
+
+    it('generates nested property paths', () => {
+      const schema = obj({
+        address: obj({ city: str(), zip: str() }),
+      });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Paths = SchemaPaths<typeof schema>;
+      assert<Extends<'address', Paths>>();
+      assert<Extends<'address.city', Paths>>();
+      assert<Extends<'address.zip', Paths>>();
+    });
+
+    it('generates array index paths', () => {
+      const schema = obj({ tags: arr(str()) });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Paths = SchemaPaths<typeof schema>;
+      assert<Extends<'tags', Paths>>();
+      assert<Extends<`tags.[${number}]`, Paths>>();
+    });
+  });
+
+  describe('SchemaAtPath', () => {
+    it('resolves top-level property schema', () => {
+      const schema = obj({ name: str(), age: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      assert<Equal<SchemaAtPath<typeof schema, 'name'>, ReturnType<typeof str>>>();
+    });
+
+    it('resolves nested property schema', () => {
+      const schema = obj({
+        address: obj({ city: str() }),
+      });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      assert<Equal<SchemaAtPath<typeof schema, 'address.city'>, ReturnType<typeof str>>>();
+    });
+  });
+
+  describe('ValueAtPath', () => {
+    it('resolves value type at path', () => {
+      const schema = obj({ age: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      assert<Equal<ValueAtPath<typeof schema, 'age'>, number>>();
+    });
+
+    it('resolves nested value type', () => {
+      const schema = obj({
+        address: obj({ city: str() }),
+      });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      assert<Equal<ValueAtPath<typeof schema, 'address.city'>, string>>();
+    });
+  });
+
+  describe('TypedValueTree interface', () => {
+    it('root is typed', () => {
+      const schema = obj({ name: str() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Tree = TypedValueTree<typeof schema>;
+      type RootType = Tree['root'];
+      type Props = (typeof schema)['properties'];
+      assert<Equal<RootType, TypedObjectValueNode<Props>>>();
+    });
+  });
+
+  describe('plain object schemas (without helpers)', () => {
+    it('works with as const object schema', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name', 'age'],
+        properties: {
+          name: { type: 'string', default: '' },
+          age: { type: 'number', default: 0 },
+        },
+      } as const;
+      expect(schema.type).toBe('object');
+      assert<Equal<InferValue<typeof schema>, { name: string; age: number }>>();
+    });
+
+    it('works with as const nested schema', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+        required: ['address'],
+        properties: {
+          address: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['city'],
+            properties: {
+              city: { type: 'string', default: '' },
+            },
+          },
+        },
+      } as const;
+      expect(schema.type).toBe('object');
+      assert<Equal<InferValue<typeof schema>, { address: { city: string } }>>();
+    });
+
+    it('works with as const array schema', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+        required: ['tags'],
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string', default: '' },
+          },
+        },
+      } as const;
+      expect(schema.type).toBe('object');
+      assert<Equal<InferValue<typeof schema>, { tags: string[] }>>();
+    });
+
+    it('InferNode works with as const primitives', () => {
+      const strSchema = { type: 'string', default: '' } as const;
+      expect(strSchema.type).toBe('string');
+      assert<Equal<InferNode<typeof strSchema>, TypedPrimitiveValueNode<string>>>();
+    });
+
+    it('SchemaPaths works with as const schema', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name'],
+        properties: {
+          name: { type: 'string', default: '' },
+        },
+      } as const;
+      expect(schema.type).toBe('object');
+      assert<Extends<'name', SchemaPaths<typeof schema>>>();
+    });
+
+    it('SchemaAtPath works with as const schema', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name'],
+        properties: {
+          name: { type: 'string', default: '' },
+        },
+      } as const;
+      expect(schema.type).toBe('object');
+      assert<Equal<ValueAtPath<typeof schema, 'name'>, string>>();
+    });
+
+    it('works with manually typed schema interface', () => {
+      type MySchema = {
+        type: 'object';
+        additionalProperties: false;
+        required: string[];
+        properties: {
+          name: { type: 'string'; default: '' };
+          age: { type: 'number'; default: 0 };
+          active: { type: 'boolean'; default: false };
+        };
+      };
+
+      assert<Equal<InferValue<MySchema>, { name: string; age: number; active: boolean }>>();
+    });
+  });
+
+  describe('SchemaFromValue', () => {
+    it('maps string to string schema', () => {
+      assert<Equal<SchemaFromValue<string>, { type: 'string' }>>();
+    });
+
+    it('maps number to number schema', () => {
+      assert<Equal<SchemaFromValue<number>, { type: 'number' }>>();
+    });
+
+    it('maps boolean to boolean schema', () => {
+      assert<Equal<SchemaFromValue<boolean>, { type: 'boolean' }>>();
+    });
+
+    it('maps flat object to object schema', () => {
+      type T = { name: string; age: number };
+      type S = SchemaFromValue<T>;
+      assert<Equal<InferValue<S>, T>>();
+    });
+
+    it('maps nested object to nested object schema', () => {
+      type T = { address: { city: string; zip: string } };
+      type S = SchemaFromValue<T>;
+      assert<Equal<InferValue<S>, T>>();
+    });
+
+    it('maps array to array schema', () => {
+      type T = string[];
+      type S = SchemaFromValue<T>;
+      assert<Equal<InferValue<S>, T>>();
+    });
+
+    it('maps complex nested structure', () => {
+      type T = {
+        firstName: string;
+        age: number;
+        active: boolean;
+        nested: { value: number };
+        tags: string[];
+      };
+      type S = SchemaFromValue<T>;
+      assert<Equal<InferValue<S>, T>>();
+    });
+
+    it('roundtrips with InferValue', () => {
+      type Original = { x: number; y: { z: boolean } };
+      assert<Equal<InferValue<SchemaFromValue<Original>>, Original>>();
+    });
+  });
+
+  describe('NodeFromValue', () => {
+    it('maps string to TypedPrimitiveValueNode<string>', () => {
+      assert<Equal<NodeFromValue<string>, TypedPrimitiveValueNode<string>>>();
+    });
+
+    it('maps number to TypedPrimitiveValueNode<number>', () => {
+      assert<Equal<NodeFromValue<number>, TypedPrimitiveValueNode<number>>>();
+    });
+
+    it('maps object to TypedObjectValueNode', () => {
+      type T = { name: string };
+      type Node = NodeFromValue<T>;
+      type Props = SchemaFromValue<T>['properties'];
+      assert<Equal<Node, TypedObjectValueNode<Props>>>();
+    });
+  });
+
+  describe('ValuePaths', () => {
+    it('generates paths from value type', () => {
+      type T = { name: string; address: { city: string } };
+      type Paths = ValuePaths<T>;
+      assert<Extends<'name', Paths>>();
+      assert<Extends<'address', Paths>>();
+      assert<Extends<'address.city', Paths>>();
+    });
+
+    it('generates array paths from value type', () => {
+      type T = { tags: string[] };
+      type Paths = ValuePaths<T>;
+      assert<Extends<'tags', Paths>>();
+      assert<Extends<`tags.[${number}]`, Paths>>();
+    });
+  });
+
+  describe('TypedRowModel type contracts', () => {
+    it('typed row model narrows getValue return type', () => {
+      const schema = obj({ name: str(), age: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Row = import('../../model/table/row/typed.js').TypedRowModel<typeof schema>;
+      type NameValue = ReturnType<Row['getValue']>;
+
+      assert<Extends<string, NameValue>>();
+      assert<Extends<number, NameValue>>();
+    });
+
+    it('typed row model narrows getPlainValue return type', () => {
+      const schema = obj({ name: str(), count: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Row = import('../../model/table/row/typed.js').TypedRowModel<typeof schema>;
+      type Value = ReturnType<Row['getPlainValue']>;
+      assert<Equal<Value, { name: string; count: number }>>();
+    });
+  });
+
+  describe('TypedTableModel type contracts', () => {
+    it('typed table model returns typed rows', () => {
+      const schema = obj({ title: str() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Table = import('../../model/table/typed.js').TypedTableModel<typeof schema>;
+      type Row = Table['rows'][number];
+      type Value = ReturnType<Row['getPlainValue']>;
+      assert<Equal<Value, { title: string }>>();
+    });
+
+    it('typed table model addRow returns typed row', () => {
+      const schema = obj({ price: num() });
+      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      type Table = import('../../model/table/typed.js').TypedTableModel<typeof schema>;
+      type Row = ReturnType<Table['addRow']>;
+      type Value = ReturnType<Row['getPlainValue']>;
+      assert<Equal<Value, { price: number }>>();
+    });
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './json-value-patch.types.js';
 export * from './migration.types.js';
 export * from './schema.types.js';
 export * from './value-diff.types.js';
+export * from './typed.js';

--- a/src/types/typed.ts
+++ b/src/types/typed.ts
@@ -1,0 +1,216 @@
+import type { JsonSchemaTypeName } from './schema.types.js';
+import type {
+  ArrayValueNode,
+  ObjectValueNode,
+  PrimitiveValueNode,
+  ValueNode,
+} from '../model/value-node/types.js';
+
+// ---------------------------------------------------------------------------
+// InferValue — maps a JSON Schema type to the plain TypeScript value it holds
+// ---------------------------------------------------------------------------
+
+export type InferValue<S> =
+  S extends { readonly type: JsonSchemaTypeName.String } | { type: JsonSchemaTypeName.String }
+    ? string
+    : S extends { readonly type: 'string' } | { type: 'string' }
+      ? string
+      : S extends { readonly type: JsonSchemaTypeName.Number } | { type: JsonSchemaTypeName.Number }
+        ? number
+        : S extends { readonly type: 'number' } | { type: 'number' }
+          ? number
+          : S extends
+                | { readonly type: JsonSchemaTypeName.Boolean }
+                | { type: JsonSchemaTypeName.Boolean }
+            ? boolean
+            : S extends { readonly type: 'boolean' } | { type: 'boolean' }
+              ? boolean
+              : S extends {
+                    readonly type: JsonSchemaTypeName.Object;
+                    readonly properties: infer P;
+                  }
+                ? { [K in keyof P]: InferValue<P[K]> }
+                : S extends { type: JsonSchemaTypeName.Object; readonly properties: infer P }
+                  ? { [K in keyof P]: InferValue<P[K]> }
+                  : S extends { readonly type: 'object'; readonly properties: infer P }
+                    ? { [K in keyof P]: InferValue<P[K]> }
+                    : S extends { type: 'object'; readonly properties: infer P }
+                      ? { [K in keyof P]: InferValue<P[K]> }
+                      : S extends { type: 'object'; properties: infer P }
+                        ? { [K in keyof P]: InferValue<P[K]> }
+                        : S extends {
+                              readonly type: JsonSchemaTypeName.Array;
+                              readonly items: infer I;
+                            }
+                          ? InferValue<I>[]
+                          : S extends {
+                                type: JsonSchemaTypeName.Array;
+                                readonly items: infer I;
+                              }
+                            ? InferValue<I>[]
+                            : S extends {
+                                  readonly type: 'array';
+                                  readonly items: infer I;
+                                }
+                              ? InferValue<I>[]
+                              : S extends { type: 'array'; readonly items: infer I }
+                                ? InferValue<I>[]
+                                : S extends { type: 'array'; items: infer I }
+                                  ? InferValue<I>[]
+                                  : unknown;
+
+// ---------------------------------------------------------------------------
+// Typed node interfaces — extend untyped interfaces, narrow return types
+// ---------------------------------------------------------------------------
+
+export interface TypedPrimitiveValueNode<T extends string | number | boolean>
+  extends PrimitiveValueNode {
+  readonly value: T;
+  readonly baseValue: T;
+  getPlainValue(): T;
+  setValue(value: T, options?: { internal?: boolean }): void;
+}
+
+export interface TypedObjectValueNode<P> extends ObjectValueNode {
+  child<K extends keyof P & string>(name: K): InferNode<P[K]>;
+  getPlainValue(): { [K in keyof P]: InferValue<P[K]> };
+  setValue(
+    value: Partial<{ [K in keyof P]: InferValue<P[K]> }>,
+    options?: { internal?: boolean },
+  ): void;
+}
+
+export interface TypedArrayValueNode<I> extends ArrayValueNode {
+  at(index: number): InferNode<I> | undefined;
+  getPlainValue(): InferValue<I>[];
+  setValue(value: InferValue<I>[], options?: { internal?: boolean }): void;
+}
+
+// ---------------------------------------------------------------------------
+// InferNode — maps a JSON Schema type to the typed ValueNode interface
+// ---------------------------------------------------------------------------
+
+export type InferNode<S> =
+  S extends { readonly type: JsonSchemaTypeName.String } | { type: JsonSchemaTypeName.String }
+    ? TypedPrimitiveValueNode<string>
+    : S extends { readonly type: 'string' } | { type: 'string' }
+      ? TypedPrimitiveValueNode<string>
+      : S extends { readonly type: JsonSchemaTypeName.Number } | { type: JsonSchemaTypeName.Number }
+        ? TypedPrimitiveValueNode<number>
+        : S extends { readonly type: 'number' } | { type: 'number' }
+          ? TypedPrimitiveValueNode<number>
+          : S extends
+                | { readonly type: JsonSchemaTypeName.Boolean }
+                | { type: JsonSchemaTypeName.Boolean }
+            ? TypedPrimitiveValueNode<boolean>
+            : S extends { readonly type: 'boolean' } | { type: 'boolean' }
+              ? TypedPrimitiveValueNode<boolean>
+              : S extends {
+                    readonly type: JsonSchemaTypeName.Object;
+                    readonly properties: infer P;
+                  }
+                ? TypedObjectValueNode<P>
+                : S extends {
+                      type: JsonSchemaTypeName.Object;
+                      readonly properties: infer P;
+                    }
+                  ? TypedObjectValueNode<P>
+                  : S extends { readonly type: 'object'; readonly properties: infer P }
+                    ? TypedObjectValueNode<P>
+                    : S extends { type: 'object'; readonly properties: infer P }
+                      ? TypedObjectValueNode<P>
+                      : S extends { type: 'object'; properties: infer P }
+                        ? TypedObjectValueNode<P>
+                        : S extends {
+                              readonly type: JsonSchemaTypeName.Array;
+                              readonly items: infer I;
+                            }
+                          ? TypedArrayValueNode<I>
+                          : S extends {
+                                type: JsonSchemaTypeName.Array;
+                                readonly items: infer I;
+                              }
+                            ? TypedArrayValueNode<I>
+                            : S extends { readonly type: 'array'; readonly items: infer I }
+                              ? TypedArrayValueNode<I>
+                              : S extends { type: 'array'; readonly items: infer I }
+                                ? TypedArrayValueNode<I>
+                                : S extends { type: 'array'; items: infer I }
+                                  ? TypedArrayValueNode<I>
+                                  : ValueNode;
+
+// ---------------------------------------------------------------------------
+// Path string types — SchemaPaths, SchemaAtPath, NodeAtPath, ValueAtPath
+// ---------------------------------------------------------------------------
+
+type SchemaType<S> = S extends { readonly type: infer T } ? T : S extends { type: infer T } ? T : never;
+
+type SchemaProperties<S> = S extends { readonly properties: infer P }
+  ? P
+  : S extends { properties: infer P }
+    ? P
+    : never;
+
+type SchemaItems<S> = S extends { readonly items: infer I }
+  ? I
+  : S extends { items: infer I }
+    ? I
+    : never;
+
+type IsPrimitive<S> = SchemaType<S> extends 'string' | 'number' | 'boolean' ? true : false;
+
+export type SchemaPaths<S, Prefix extends string = ''> =
+  IsPrimitive<S> extends true
+    ? never
+    : SchemaType<S> extends 'object' | JsonSchemaTypeName.Object
+      ? {
+          [K in keyof SchemaProperties<S> & string]:
+            | `${Prefix}${K}`
+            | SchemaPaths<SchemaProperties<S>[K], `${Prefix}${K}.`>;
+        }[keyof SchemaProperties<S> & string]
+      : SchemaType<S> extends 'array' | JsonSchemaTypeName.Array
+        ? `${Prefix}[${number}]` | SchemaPaths<SchemaItems<S>, `${Prefix}[${number}].`>
+        : never;
+
+export type SchemaAtPath<S, Path extends string> = Path extends `${infer Key}.${infer Rest}`
+  ? Key extends `[${string}]`
+    ? SchemaAtPath<SchemaItems<S>, Rest>
+    : SchemaAtPath<
+        Key extends keyof SchemaProperties<S> ? SchemaProperties<S>[Key] : never,
+        Rest
+      >
+  : Path extends `[${string}]`
+    ? SchemaItems<S>
+    : Path extends keyof SchemaProperties<S>
+      ? SchemaProperties<S>[Path]
+      : never;
+
+export type NodeAtPath<S, Path extends string> = InferNode<SchemaAtPath<S, Path>>;
+export type ValueAtPath<S, Path extends string> = InferValue<SchemaAtPath<S, Path>>;
+
+// ---------------------------------------------------------------------------
+// SchemaFromValue — maps a plain TS value type to a virtual schema shape
+// ---------------------------------------------------------------------------
+
+type SchemaFromPrimitive<T> = T extends string
+  ? { type: 'string' }
+  : T extends number
+    ? { type: 'number' }
+    : T extends boolean
+      ? { type: 'boolean' }
+      : never;
+
+export type SchemaFromValue<T> = T extends string | number | boolean
+  ? SchemaFromPrimitive<T>
+  : T extends (infer E)[]
+    ? { type: 'array'; items: SchemaFromValue<E> }
+    : T extends Record<string, unknown>
+      ? { type: 'object'; properties: { [K in keyof T]: SchemaFromValue<T[K]> } }
+      : never;
+
+// ---------------------------------------------------------------------------
+// Value-type aware node / path helpers (accept plain TS value types)
+// ---------------------------------------------------------------------------
+
+export type NodeFromValue<T> = InferNode<SchemaFromValue<T>>;
+export type ValuePaths<T> = SchemaPaths<SchemaFromValue<T>>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a typed API for RowModel, TableModel, and ValueTree with schema-driven type inference and helper functions. Existing untyped usage remains fully compatible.

- New Features
  - Typed overloads: createRowModel/createTableModel return TypedRowModel/TypedTableModel when the schema preserves literal types; otherwise return the existing untyped models.
  - Typed ValueTree: createTypedTree and typedNode provide typed root/get/set by path; exported via model/value-tree and model/index.
  - Schema helpers: str, num, bool, obj, arr, ref and JSON Patch helpers moved to src/lib with tests.
  - Type utilities: InferValue, InferNode, SchemaPaths, SchemaFromValue, ValuePaths, NodeFromValue, and more (see TYPED-API.md).
  - Docs & tests: README Quick Start and a full Typed API guide; added comprehensive type tests and backward-compat tests for untyped schemas.

- Migration
  - No breaking changes. Untyped JsonSchema continues to return the existing API.
  - To opt in: pass a typed schema (via helpers or using as const) to get typed models and trees.

<sup>Written for commit 13a418d02917a1f0d85b09a686fead9743740f7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

