### PR TITLE
chore: deprecated enum

### DIFF
--- a/src/core/schema-serializer/SchemaSerializer.ts
+++ b/src/core/schema-serializer/SchemaSerializer.ts
@@ -11,7 +11,7 @@ import type {
   JsonRefSchema,
   XFormula,
 } from '../../types/index.js';
-import { JsonSchemaTypeName } from '../../types/index.js';
+
 import { FormulaSerializer } from '../schema-formula/index.js';
 
 export class SchemaSerializer {
@@ -71,7 +71,7 @@ export class SchemaSerializer {
     }
 
     const result: JsonObjectSchema = {
-      type: JsonSchemaTypeName.Object,
+      type: 'object',
       properties,
       additionalProperties: false,
       required,
@@ -87,7 +87,7 @@ export class SchemaSerializer {
     }
 
     const result: JsonArraySchema = {
-      type: JsonSchemaTypeName.Array,
+      type: 'array',
       items: this.serialize(items),
     };
 
@@ -119,7 +119,7 @@ export class SchemaSerializer {
 
   private serializeString(node: SchemaNode): JsonStringSchema {
     const result: JsonStringSchema = {
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: (node.defaultValue() as string) ?? '',
     };
 
@@ -144,7 +144,7 @@ export class SchemaSerializer {
 
   private serializeNumber(node: SchemaNode): JsonNumberSchema {
     const result: JsonNumberSchema = {
-      type: JsonSchemaTypeName.Number,
+      type: 'number',
       default: (node.defaultValue() as number) ?? 0,
     };
 
@@ -159,7 +159,7 @@ export class SchemaSerializer {
 
   private serializeBoolean(node: SchemaNode): JsonBooleanSchema {
     const result: JsonBooleanSchema = {
-      type: JsonSchemaTypeName.Boolean,
+      type: 'boolean',
       default: (node.defaultValue() as boolean) ?? false,
     };
 

--- a/src/lib/__tests__/schema-helpers.spec.ts
+++ b/src/lib/__tests__/schema-helpers.spec.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import {
   str,
   num,
@@ -23,14 +22,14 @@ describe('schema-helpers', () => {
     it('returns correct schema with defaults', () => {
       const schema = str();
       expect(schema).toEqual({
-        type: JsonSchemaTypeName.String,
+        type: 'string',
         default: '',
       });
     });
 
     it('merges options', () => {
       const schema = str({ required: true, minLength: 3, maxLength: 10 });
-      expect(schema.type).toBe(JsonSchemaTypeName.String);
+      expect(schema.type).toBe('string');
       expect(schema.default).toBe('');
       expect(schema.required).toBe(true);
       expect(schema.minLength).toBe(3);
@@ -61,7 +60,7 @@ describe('schema-helpers', () => {
     it('returns correct schema with defaults', () => {
       const schema = num();
       expect(schema).toEqual({
-        type: JsonSchemaTypeName.Number,
+        type: 'number',
         default: 0,
       });
     });
@@ -86,7 +85,7 @@ describe('schema-helpers', () => {
     it('returns correct schema with defaults', () => {
       const schema = bool();
       expect(schema).toEqual({
-        type: JsonSchemaTypeName.Boolean,
+        type: 'boolean',
         default: false,
       });
     });
@@ -109,11 +108,11 @@ describe('schema-helpers', () => {
   describe('obj / getObjectSchema', () => {
     it('returns correct schema with properties', () => {
       const schema = obj({ name: str(), age: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       expect(schema.additionalProperties).toBe(false);
       expect(schema.required).toEqual(['age', 'name']);
-      expect(schema.properties.name.type).toBe(JsonSchemaTypeName.String);
-      expect(schema.properties.age.type).toBe(JsonSchemaTypeName.Number);
+      expect(schema.properties.name.type).toBe('string');
+      expect(schema.properties.age.type).toBe('number');
     });
 
     it('sorts required keys alphabetically', () => {
@@ -135,8 +134,8 @@ describe('schema-helpers', () => {
   describe('arr / getArraySchema', () => {
     it('returns correct schema with items', () => {
       const schema = arr(str());
-      expect(schema.type).toBe(JsonSchemaTypeName.Array);
-      expect(schema.items.type).toBe(JsonSchemaTypeName.String);
+      expect(schema.type).toBe('array');
+      expect(schema.items.type).toBe('string');
     });
 
     it('accepts options', () => {

--- a/src/lib/applyPatches.ts
+++ b/src/lib/applyPatches.ts
@@ -1,4 +1,4 @@
-import { JsonSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonSchema } from '../types/schema.types.js';
 import {
   JsonPatchAdd,
   JsonPatchMove,
@@ -28,9 +28,9 @@ export const applyReplacePatch = (
     return patchStore;
   }
 
-  if (parent.type === JsonSchemaTypeName.Object) {
+  if (parent.type === 'object') {
     parent.migratePropertyWithStore(foundStore.name, patchStore);
-  } else if (parent.type === JsonSchemaTypeName.Array) {
+  } else if (parent.type === 'array') {
     parent.migrateItems(patchStore);
   } else {
     throw new Error('Invalid parent');
@@ -50,7 +50,7 @@ export const applyRemovePatch = (
     throw new Error('Parent does not exist');
   }
 
-  if (parent.type !== JsonSchemaTypeName.Object) {
+  if (parent.type !== 'object') {
     throw new Error('Cannot remove from non-object');
   }
 
@@ -71,7 +71,7 @@ export const applyAddPatch = (
     throw new Error('Parent does not exist');
   }
 
-  if (foundParent.type !== JsonSchemaTypeName.Object) {
+  if (foundParent.type !== 'object') {
     throw new Error('Cannot add to non-object');
   }
 
@@ -108,7 +108,7 @@ export const applyMovePatch = (
     throw new Error('Cannot move from or to non-existent parent');
   }
 
-  if (foundFromParent.type !== JsonSchemaTypeName.Object) {
+  if (foundFromParent.type !== 'object') {
     throw new Error('Cannot move from non-object parent');
   }
 
@@ -116,14 +116,14 @@ export const applyMovePatch = (
 
   const isMovedPropertyInSameParentPatch =
     foundFromParent === foundToParent &&
-    foundFromParent.type === JsonSchemaTypeName.Object &&
+    foundFromParent.type === 'object' &&
     foundFromParent.getProperty(fromField);
 
   if (isMovedPropertyInSameParentPatch) {
     return foundFromParent.changeName(fromField, toField);
   }
 
-  if (foundToParent.type === JsonSchemaTypeName.Object) {
+  if (foundToParent.type === 'object') {
     if (foundToParent.getProperty(toField)) {
       foundToParent.removeProperty(toField);
     }
@@ -132,7 +132,7 @@ export const applyMovePatch = (
     return;
   }
 
-  if (foundToParent.type === JsonSchemaTypeName.Array) {
+  if (foundToParent.type === 'array') {
     foundFromParent.removeProperty(fromField);
     foundToParent.replaceItems(foundFromField);
 

--- a/src/lib/createJsonSchemaStore.ts
+++ b/src/lib/createJsonSchemaStore.ts
@@ -2,7 +2,6 @@ import {
   JsonObjectSchema,
   JsonSchema,
   JsonSchemaPrimitives,
-  JsonSchemaTypeName,
 } from '../types/schema.types.js';
 import { JsonArrayStore } from '../model/schema/json-array.store.js';
 import { JsonBooleanStore } from '../model/schema/json-boolean.store.js';
@@ -31,12 +30,12 @@ export const createJsonSchemaStore = (
     saveSharedFields(refStore, schema);
     refStore.$ref = schema.$ref;
     return refStore;
-  } else if (schema.type === JsonSchemaTypeName.Object) {
+  } else if (schema.type === 'object') {
     const objectStore = createJsonObjectSchemaStore(schema, refs);
     saveSharedFields(objectStore, schema);
 
     return objectStore;
-  } else if (schema.type === JsonSchemaTypeName.Array) {
+  } else if (schema.type === 'array') {
     const itemsStore = createJsonSchemaStore(schema.items, refs);
     const arrayStore = new JsonArrayStore(itemsStore);
     saveSharedFields(arrayStore, schema);
@@ -75,7 +74,7 @@ export const createJsonObjectSchemaStore = (
 export const createPrimitiveStoreBySchema = (
   schema: JsonSchemaPrimitives,
 ): JsonSchemaStorePrimitives => {
-  if (schema.type === JsonSchemaTypeName.String) {
+  if (schema.type === 'string') {
     const stringStore = new JsonStringStore();
     stringStore.foreignKey = schema.foreignKey;
     stringStore.format = schema.format;
@@ -84,11 +83,11 @@ export const createPrimitiveStoreBySchema = (
     stringStore.pattern = schema.pattern;
     stringStore['x-formula'] = schema['x-formula'];
     return stringStore;
-  } else if (schema.type === JsonSchemaTypeName.Number) {
+  } else if (schema.type === 'number') {
     const numberStore = new JsonNumberStore();
     numberStore['x-formula'] = schema['x-formula'];
     return numberStore;
-  } else if (schema.type === JsonSchemaTypeName.Boolean) {
+  } else if (schema.type === 'boolean') {
     const booleanStore = new JsonBooleanStore();
     booleanStore['x-formula'] = schema['x-formula'];
     return booleanStore;

--- a/src/lib/createJsonValueStore.ts
+++ b/src/lib/createJsonValueStore.ts
@@ -4,7 +4,6 @@ import {
   JsonPrimitives,
   JsonValue,
 } from '../types/json.types.js';
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonArrayStore } from '../model/schema/json-array.store.js';
 import { JsonObjectStore } from '../model/schema/json-object.store.js';
 import {
@@ -26,9 +25,9 @@ export const createJsonValueStore = (
   rowId: string,
   rawValue: JsonValue,
 ): JsonValueStore => {
-  if (schema.type === JsonSchemaTypeName.Object) {
+  if (schema.type === 'object') {
     return createJsonObjectValueStore(schema, rowId, rawValue as JsonObject);
-  } else if (schema.type === JsonSchemaTypeName.Array) {
+  } else if (schema.type === 'array') {
     return createJsonArrayValueStore(schema, rowId, rawValue as JsonArray);
   } else {
     return createPrimitiveValueStore(schema, rowId, rawValue as JsonPrimitives);
@@ -75,11 +74,11 @@ export const createPrimitiveValueStore = (
   rowId: string,
   rawValue: JsonPrimitives,
 ): JsonValueStorePrimitives => {
-  if (schema.type === JsonSchemaTypeName.String) {
+  if (schema.type === 'string') {
     return new JsonStringValueStore(schema, rowId, rawValue as string | null);
-  } else if (schema.type === JsonSchemaTypeName.Number) {
+  } else if (schema.type === 'number') {
     return new JsonNumberValueStore(schema, rowId, rawValue as number | null);
-  } else if (schema.type === JsonSchemaTypeName.Boolean) {
+  } else if (schema.type === 'boolean') {
     return new JsonBooleanValueStore(schema, rowId, rawValue as boolean | null);
   } else {
     throw new Error('this type is not allowed');

--- a/src/lib/getDBJsonPathByJsonSchemaStore.ts
+++ b/src/lib/getDBJsonPathByJsonSchemaStore.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 
 export const getDBJsonPathByJsonSchemaStore = (
@@ -9,9 +8,9 @@ export const getDBJsonPathByJsonSchemaStore = (
   let path = '';
 
   while (node.parent) {
-    if (node.parent.type === JsonSchemaTypeName.Object) {
+    if (node.parent.type === 'object') {
       path = `.${node.name}${path}`;
-    } else if (node.parent.type === JsonSchemaTypeName.Array) {
+    } else if (node.parent.type === 'array') {
       path = `[*]${path}`;
     }
 

--- a/src/lib/getForeignKeyPatchesFromSchema.ts
+++ b/src/lib/getForeignKeyPatchesFromSchema.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonPatch, JsonPatchReplace } from '../types/json-patch.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 import { getPathByStore } from './getPathByStore.js';
@@ -12,7 +11,7 @@ export const getForeignKeyPatchesFromSchema = (
 
   traverseStore(store, (item) => {
     if (
-      item.type === JsonSchemaTypeName.String &&
+      item.type === 'string' &&
       item.foreignKey === options.tableId
     ) {
       item.foreignKey = options.nextTableId;

--- a/src/lib/getForeignKeysFromSchema.ts
+++ b/src/lib/getForeignKeysFromSchema.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 import { traverseStore } from './traverseStore.js';
 
@@ -6,7 +5,7 @@ export const getForeignKeysFromSchema = (store: JsonSchemaStore): string[] => {
   const foreignKeys = new Set<string>();
 
   traverseStore(store, (item) => {
-    if (item.type === JsonSchemaTypeName.String && item.foreignKey) {
+    if (item.type === 'string' && item.foreignKey) {
       foreignKeys.add(item.foreignKey);
     }
   });

--- a/src/lib/getForeignKeysFromValue.ts
+++ b/src/lib/getForeignKeysFromValue.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonValueStore } from '../model/value/json-value.store.js';
 import { traverseValue } from './traverseValue.js';
 
@@ -13,7 +12,7 @@ export const getForeignKeysFromValue = (
   const foreignKeys = new Map<string, Set<string>>();
 
   traverseValue(value, (item) => {
-    if (item.type === JsonSchemaTypeName.String && item.foreignKey) {
+    if (item.type === 'string' && item.foreignKey) {
       let tableForeignKey = foreignKeys.get(item.foreignKey);
 
       if (!tableForeignKey) {

--- a/src/lib/getInvalidFieldNamesInSchema.ts
+++ b/src/lib/getInvalidFieldNamesInSchema.ts
@@ -1,4 +1,4 @@
-import { JsonSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonSchema } from '../types/schema.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 import { createJsonSchemaStore } from './createJsonSchemaStore.js';
 import { traverseStore } from './traverseStore.js';
@@ -13,7 +13,7 @@ export const getInvalidFieldNamesInSchema = (
   const invalidFields: JsonSchemaStore[] = [];
 
   traverseStore(schemaStore, (item) => {
-    if (item.parent?.type === JsonSchemaTypeName.Object) {
+    if (item.parent?.type === 'object') {
       if (!validateJsonFieldName(item.name)) {
         invalidFields.push(item);
       }

--- a/src/lib/getJsonSchemaStoreByPath.ts
+++ b/src/lib/getJsonSchemaStoreByPath.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 
 export const getJsonSchemaStoreByPath = (
@@ -24,7 +23,7 @@ export const getJsonSchemaStoreByPath = (
   let currentPath = '';
 
   while (currentToken) {
-    if (currentStore.type === JsonSchemaTypeName.Object) {
+    if (currentStore.type === 'object') {
       if (currentToken !== 'properties') {
         throw new Error(
           `Expected "${currentPath}/properties/*" instead of ${currentPath}/${currentToken}/*`,
@@ -49,7 +48,7 @@ export const getJsonSchemaStoreByPath = (
       currentPath = `${currentPath}/${currentToken}`;
 
       currentToken = tokens.shift();
-    } else if (currentStore.type === JsonSchemaTypeName.Array) {
+    } else if (currentStore.type === 'array') {
       if (currentToken !== 'items') {
         throw new Error(
           `Expected "${currentPath}/items/*" instead of ${currentPath}/${currentToken}/*`,

--- a/src/lib/getPathByStore.ts
+++ b/src/lib/getPathByStore.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 
 export const getPathByStore = (store: JsonSchemaStore): string => {
@@ -7,9 +6,9 @@ export const getPathByStore = (store: JsonSchemaStore): string => {
   let path = '';
 
   while (node.parent) {
-    if (node.parent.type === JsonSchemaTypeName.Object) {
+    if (node.parent.type === 'object') {
       path = `/properties/${node.name}${path}`;
-    } else if (node.parent.type === JsonSchemaTypeName.Array) {
+    } else if (node.parent.type === 'array') {
       path = `/items${path}`;
     }
 

--- a/src/lib/replaceForeignKeyValue.ts
+++ b/src/lib/replaceForeignKeyValue.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonValueStore } from '../model/value/json-value.store.js';
 import { traverseValue } from './traverseValue.js';
 
@@ -16,7 +15,7 @@ export const replaceForeignKeyValue = (
 
   traverseValue(options.valueStore, (item) => {
     if (
-      item.type === JsonSchemaTypeName.String &&
+      item.type === 'string' &&
       item.foreignKey === options.foreignKey &&
       item.value === options.value
     ) {

--- a/src/lib/schema-helpers.ts
+++ b/src/lib/schema-helpers.ts
@@ -5,7 +5,6 @@ import {
   JsonObjectSchema,
   JsonRefSchema,
   JsonSchema,
-  JsonSchemaTypeName,
   JsonStringSchema,
   XFormula,
 } from '../types/schema.types.js';
@@ -87,7 +86,7 @@ const buildFormula = (expression: string): XFormula => ({
 export const getStringSchema = (params: StringSchemaOptions = {}): JsonStringSchema => {
   const { formula, ...rest } = params;
   return {
-    type: JsonSchemaTypeName.String,
+    type: 'string',
     ...rest,
     default: rest.default ?? '',
     ...(formula && { 'x-formula': buildFormula(formula) }),
@@ -97,7 +96,7 @@ export const getStringSchema = (params: StringSchemaOptions = {}): JsonStringSch
 export const getNumberSchema = (params: NumberSchemaOptions = {}): JsonNumberSchema => {
   const { formula, ...rest } = params;
   return {
-    type: JsonSchemaTypeName.Number,
+    type: 'number',
     ...rest,
     default: rest.default ?? 0,
     ...(formula && { 'x-formula': buildFormula(formula) }),
@@ -107,7 +106,7 @@ export const getNumberSchema = (params: NumberSchemaOptions = {}): JsonNumberSch
 export const getBooleanSchema = (params: BooleanSchemaOptions = {}): JsonBooleanSchema => {
   const { formula, ...rest } = params;
   return {
-    type: JsonSchemaTypeName.Boolean,
+    type: 'boolean',
     ...rest,
     default: rest.default ?? false,
     ...(formula && { 'x-formula': buildFormula(formula) }),
@@ -118,7 +117,7 @@ export const getObjectSchema = <P extends Record<string, JsonSchema>>(
   properties: P,
   options: ObjectSchemaOptions = {},
 ): JsonObjectSchema & { readonly properties: { readonly [K in keyof P]: P[K] } } => ({
-  type: JsonSchemaTypeName.Object,
+  type: 'object',
   additionalProperties: false,
   required: Object.keys(properties).sort((a, b) => a.localeCompare(b)),
   properties: properties as { readonly [K in keyof P]: P[K] },
@@ -129,7 +128,7 @@ export const getArraySchema = <I extends JsonSchema>(
   items: I,
   options: ArraySchemaOptions = {},
 ): JsonArraySchema & { readonly items: I } => ({
-  type: JsonSchemaTypeName.Array,
+  type: 'array',
   items,
   ...options,
 });

--- a/src/lib/traverseStore.ts
+++ b/src/lib/traverseStore.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonSchemaStore } from '../model/schema/json-schema.store.js';
 
 export const traverseStore = (
@@ -7,11 +6,11 @@ export const traverseStore = (
 ) => {
   callback(store);
 
-  if (store.type === JsonSchemaTypeName.Object) {
+  if (store.type === 'object') {
     Object.values(store.properties).forEach((item) => {
       traverseStore(item, callback);
     });
-  } else if (store.type === JsonSchemaTypeName.Array) {
+  } else if (store.type === 'array') {
     traverseStore(store.items, callback);
   }
 };

--- a/src/lib/traverseValue.ts
+++ b/src/lib/traverseValue.ts
@@ -1,4 +1,3 @@
-import { JsonSchemaTypeName } from '../types/schema.types.js';
 import { JsonValueStore } from '../model/value/json-value.store.js';
 
 export const traverseValue = (
@@ -7,11 +6,11 @@ export const traverseValue = (
 ) => {
   callback(store);
 
-  if (store.type === JsonSchemaTypeName.Object) {
+  if (store.type === 'object') {
     Object.values(store.value).forEach((item) => {
       traverseValue(item, callback);
     });
-  } else if (store.type === JsonSchemaTypeName.Array) {
+  } else if (store.type === 'array') {
     store.value.forEach((itemValue) => {
       traverseValue(itemValue, callback);
     });

--- a/src/model/default-value/generateDefaultValue.ts
+++ b/src/model/default-value/generateDefaultValue.ts
@@ -1,8 +1,7 @@
-import {
-  JsonSchemaTypeName,
-  type JsonArraySchema,
-  type JsonObjectSchema,
-  type JsonSchema,
+import type {
+  JsonArraySchema,
+  JsonObjectSchema,
+  JsonSchema,
 } from '../../types/schema.types.js';
 import type { GenerateDefaultValueOptions } from './types.js';
 
@@ -15,11 +14,11 @@ function isRefSchema(schema: JsonSchema): schema is { $ref: string } {
 }
 
 function isObjectSchema(schema: JsonSchema): schema is JsonObjectSchema {
-  return 'type' in schema && schema.type === JsonSchemaTypeName.Object;
+  return 'type' in schema && schema.type === 'object';
 }
 
 function isArraySchema(schema: JsonSchema): schema is JsonArraySchema {
-  return 'type' in schema && schema.type === JsonSchemaTypeName.Array;
+  return 'type' in schema && schema.type === 'array';
 }
 
 function hasDefaultValue(schema: JsonSchema): boolean {
@@ -32,11 +31,11 @@ function generatePrimitiveDefault(schema: JsonSchema): unknown {
   }
 
   switch (schema.type) {
-    case JsonSchemaTypeName.String:
+    case 'string':
       return DEFAULT_STRING;
-    case JsonSchemaTypeName.Number:
+    case 'number':
       return DEFAULT_NUMBER;
-    case JsonSchemaTypeName.Boolean:
+    case 'boolean':
       return DEFAULT_BOOLEAN;
     default:
       return undefined;

--- a/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
+++ b/src/model/foreign-key-resolver/ForeignKeyResolverImpl.ts
@@ -1,8 +1,7 @@
 import { makeAutoObservable, observable, runInAction } from '../../core/reactivity/index.js';
-import {
-  JsonSchemaTypeName,
-  type JsonObjectSchema,
-  type JsonSchema,
+import type {
+  JsonObjectSchema,
+  JsonSchema,
 } from '../../types/schema.types.js';
 import {
   ForeignKeyNotFoundError,
@@ -376,7 +375,7 @@ export class ForeignKeyResolverImpl implements ForeignKeyResolver {
   }
 
   private getForeignKeyFromSchema(schema: JsonSchema): string | undefined {
-    if ('type' in schema && schema.type === JsonSchemaTypeName.String) {
+    if ('type' in schema && schema.type === 'string') {
       return schema.foreignKey;
     }
     return undefined;

--- a/src/model/schema-model/SchemaParser.ts
+++ b/src/model/schema-model/SchemaParser.ts
@@ -9,7 +9,6 @@ import type {
   JsonBooleanSchema,
   XFormula,
 } from '../../types/index.js';
-import { JsonSchemaTypeName } from '../../types/index.js';
 import type { SchemaNode, NodeMetadata } from '../../core/schema-node/index.js';
 import {
   createObjectNode,
@@ -78,15 +77,15 @@ export class SchemaParser {
 
     const schemaWithType = schema as JsonSchemaWithoutRef;
     switch (schemaWithType.type) {
-      case JsonSchemaTypeName.Object:
+      case 'object':
         return this.parseObject(schemaWithType, name, parentRef);
-      case JsonSchemaTypeName.Array:
+      case 'array':
         return this.parseArray(schemaWithType, name, parentRef);
-      case JsonSchemaTypeName.String:
+      case 'string':
         return this.parseString(schemaWithType, name, parentRef);
-      case JsonSchemaTypeName.Number:
+      case 'number':
         return this.parseNumber(schemaWithType, name, parentRef);
-      case JsonSchemaTypeName.Boolean:
+      case 'boolean':
         return this.parseBoolean(schemaWithType, name, parentRef);
       default:
         throw new Error(`Unknown schema type: ${(schemaWithType as { type: string }).type}`);

--- a/src/model/schema-model/__tests__/SchemaModel.basic.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaModel.basic.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { createSchemaModel } from '../SchemaModelImpl.js';
 import { obj, str } from '../../../mocks/schema.mocks.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
 import {
   emptySchema,
   simpleSchema,
@@ -236,8 +235,8 @@ describe('SchemaModel basic operations', () => {
 
     it('resolves ref to array schema', () => {
       const tagsSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
+        type: 'array',
+        items: { type: 'string', default: '' },
       } as const;
 
       const schema = obj({
@@ -259,7 +258,7 @@ describe('SchemaModel basic operations', () => {
 
     it('resolves ref to primitive schema', () => {
       const statusSchema = {
-        type: JsonSchemaTypeName.String,
+        type: 'string',
         default: 'active',
       } as const;
 

--- a/src/model/schema-model/__tests__/SchemaParser.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaParser.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { serializeAst } from '@revisium/formula';
 import { createSchemaTree } from '../../../core/schema-tree/index.js';
-import { JsonSchemaTypeName } from '../../../types/index.js';
 import type { JsonObjectSchema, JsonSchema } from '../../../types/index.js';
 import { SchemaParser } from '../SchemaParser.js';
 import {
@@ -131,10 +130,10 @@ describe('SchemaParser', () => {
 
   describe('refSchemas resolution', () => {
     const fileSchema: JsonObjectSchema = {
-      type: JsonSchemaTypeName.Object,
+      type: 'object',
       properties: {
-        url: { type: JsonSchemaTypeName.String, default: '' },
-        size: { type: JsonSchemaTypeName.Number, default: 0 },
+        url: { type: 'string', default: '' },
+        size: { type: 'number', default: 0 },
       },
       additionalProperties: false,
       required: ['url', 'size'],
@@ -146,7 +145,7 @@ describe('SchemaParser', () => {
 
     it('resolves $ref to object schema when found in refSchemas', () => {
       const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           image: { $ref: 'urn:schema:file' },
         },
@@ -171,7 +170,7 @@ describe('SchemaParser', () => {
 
     it('creates RefNode when $ref is not found in refSchemas', () => {
       const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           unknown: { $ref: 'urn:schema:unknown' },
         },
@@ -190,12 +189,12 @@ describe('SchemaParser', () => {
 
     it('resolves $ref to array schema', () => {
       const arrayRefSchema: JsonSchema = {
-        type: JsonSchemaTypeName.Array,
-        items: { type: JsonSchemaTypeName.String, default: '' },
+        type: 'array',
+        items: { type: 'string', default: '' },
       };
 
       const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           tags: { $ref: 'urn:schema:tags' },
         },
@@ -218,12 +217,12 @@ describe('SchemaParser', () => {
 
     it('resolves $ref to primitive schema', () => {
       const stringRefSchema: JsonSchema = {
-        type: JsonSchemaTypeName.String,
+        type: 'string',
         default: 'default-value',
       };
 
       const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           status: { $ref: 'urn:schema:status' },
         },
@@ -244,7 +243,7 @@ describe('SchemaParser', () => {
 
     it('preserves metadata from $ref schema', () => {
       const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           image: {
             $ref: 'urn:schema:file',
@@ -265,7 +264,7 @@ describe('SchemaParser', () => {
 
     it('does not resolve nested $ref inside resolved schema', () => {
       const nestedRefSchema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           nested: { $ref: 'urn:schema:unknown' },
         },
@@ -274,7 +273,7 @@ describe('SchemaParser', () => {
       };
 
       const schema: JsonObjectSchema = {
-        type: JsonSchemaTypeName.Object,
+        type: 'object',
         properties: {
           wrapper: { $ref: 'urn:schema:wrapper' },
         },

--- a/src/model/schema/json-array.store.ts
+++ b/src/model/schema/json-array.store.ts
@@ -3,7 +3,6 @@ import { JsonArray } from '../../types/json.types.js';
 import {
   JsonArraySchema,
   JsonRefSchema,
-  JsonSchemaTypeName,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
 import { JsonArrayValueStore } from '../value/json-array-value.store.js';
@@ -20,7 +19,7 @@ export type ReplaceItemsEvent = {
 };
 
 export class JsonArrayStore implements JsonArraySchema {
-  public readonly type = JsonSchemaTypeName.Array;
+  public readonly type = 'array' as const;
 
   public $ref: string = '';
   public name: string = '';

--- a/src/model/schema/json-boolean.store.ts
+++ b/src/model/schema/json-boolean.store.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from 'eventemitter3';
 import {
   JsonBooleanSchema,
   JsonRefSchema,
-  JsonSchemaTypeName,
   XFormula,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
@@ -14,7 +13,7 @@ export class JsonBooleanStore
   extends EventEmitter
   implements JsonBooleanSchema
 {
-  public readonly type = JsonSchemaTypeName.Boolean;
+  public readonly type = 'boolean' as const;
 
   public $ref: string = '';
   public name: string = '';

--- a/src/model/schema/json-number.store.ts
+++ b/src/model/schema/json-number.store.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from 'eventemitter3';
 import {
   JsonNumberSchema,
   JsonRefSchema,
-  JsonSchemaTypeName,
   XFormula,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
@@ -11,7 +10,7 @@ import { JsonNumberValueStore } from '../value/json-number-value.store.js';
 import { addSharedFieldsFromState } from '../../lib/addSharedFieldsFromStore.js';
 
 export class JsonNumberStore extends EventEmitter implements JsonNumberSchema {
-  public readonly type = JsonSchemaTypeName.Number;
+  public readonly type = 'number' as const;
 
   public $ref: string = '';
   public name: string = '';

--- a/src/model/schema/json-object.store.ts
+++ b/src/model/schema/json-object.store.ts
@@ -4,7 +4,6 @@ import {
   JsonObjectSchema,
   JsonRefSchema,
   JsonSchema,
-  JsonSchemaTypeName,
 } from '../../types/schema.types.js';
 import { JsonSchemaStore } from './json-schema.store.js';
 import { JsonObjectValueStore } from '../value/json-object-value.store.js';
@@ -24,7 +23,7 @@ export type ChangeNameEvent = {
 };
 
 export class JsonObjectStore implements JsonObjectSchema {
-  public readonly type = JsonSchemaTypeName.Object;
+  public readonly type = 'object' as const;
 
   public $ref: string = '';
   public name: string = '';

--- a/src/model/schema/json-string.store.ts
+++ b/src/model/schema/json-string.store.ts
@@ -2,7 +2,6 @@ import { nanoid } from 'nanoid';
 import { EventEmitter } from 'eventemitter3';
 import {
   JsonRefSchema,
-  JsonSchemaTypeName,
   JsonStringSchema,
   XFormula,
 } from '../../types/schema.types.js';
@@ -11,7 +10,7 @@ import { JsonStringValueStore } from '../value/json-string-value.store.js';
 import { addSharedFieldsFromState } from '../../lib/addSharedFieldsFromStore.js';
 
 export class JsonStringStore extends EventEmitter implements JsonStringSchema {
-  public readonly type = JsonSchemaTypeName.String;
+  public readonly type = 'string' as const;
 
   public $ref: string = '';
   public name: string = '';

--- a/src/model/value-node/NumberValueNode.ts
+++ b/src/model/value-node/NumberValueNode.ts
@@ -1,6 +1,5 @@
 import type { Diagnostic } from '../../core/validation/types.js';
 import type { JsonSchema } from '../../types/schema.types.js';
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { BasePrimitiveValueNode } from './BasePrimitiveValueNode.js';
 import { ValueType } from './types.js';
 
@@ -31,7 +30,7 @@ export class NumberValueNode extends BasePrimitiveValueNode<number> {
   protected override computeErrors(): readonly Diagnostic[] {
     const errors: Diagnostic[] = [];
 
-    if (!('type' in this.schema) || this.schema.type !== JsonSchemaTypeName.Number) {
+    if (!('type' in this.schema) || this.schema.type !== 'number') {
       return errors;
     }
 

--- a/src/model/value/json-array-value.store.ts
+++ b/src/model/value/json-array-value.store.ts
@@ -1,5 +1,4 @@
 import { JsonArray, JsonValue } from '../../types/json.types.js';
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import {
   JsonArrayStore,
   MigrateItemsEvent,
@@ -10,7 +9,7 @@ import { JsonValueStore, JsonValueStoreParent } from './json-value.store.js';
 import { getTransformation } from './value-transformation.js';
 
 export class JsonArrayValueStore {
-  public readonly type = JsonSchemaTypeName.Array;
+  public readonly type = 'array' as const;
 
   public index: number;
 

--- a/src/model/value/json-boolean-value.store.ts
+++ b/src/model/value/json-boolean-value.store.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { JsonBooleanStore } from '../schema/json-boolean.store.js';
 import { JsonValueStoreParent } from './json-value.store.js';
 
 export class JsonBooleanValueStore {
-  public readonly type = JsonSchemaTypeName.Boolean;
+  public readonly type = 'boolean' as const;
 
   public readonly index: number;
 

--- a/src/model/value/json-number-value.store.ts
+++ b/src/model/value/json-number-value.store.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { JsonNumberStore } from '../schema/json-number.store.js';
 import { JsonValueStoreParent } from './json-value.store.js';
 
 export class JsonNumberValueStore {
-  public readonly type = JsonSchemaTypeName.Number;
+  public readonly type = 'number' as const;
 
   public readonly index: number;
 

--- a/src/model/value/json-object-value.store.ts
+++ b/src/model/value/json-object-value.store.ts
@@ -1,7 +1,6 @@
 import { createJsonValueStore } from '../../lib/createJsonValueStore.js';
 import { JsonSchemaStore } from '../../model/schema';
 import { JsonObject, JsonValue } from '../../types/json.types.js';
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import {
   AddedPropertyEvent,
   ChangeNameEvent,
@@ -13,7 +12,7 @@ import { JsonValueStore, JsonValueStoreParent } from './json-value.store.js';
 import { getTransformation } from './value-transformation.js';
 
 export class JsonObjectValueStore {
-  public readonly type = JsonSchemaTypeName.Object;
+  public readonly type = 'object' as const;
 
   public index: number;
 
@@ -91,7 +90,7 @@ export class JsonObjectValueStore {
     let current: JsonValueStore | null = this.parent;
 
     while (current) {
-      if (current.type === JsonSchemaTypeName.Object) {
+      if (current.type === 'object') {
         for (const [, fieldValue] of Object.entries(current.value)) {
           if (fieldValue.schema === targetSchema) {
             return fieldValue.getPlainValue();

--- a/src/model/value/json-string-value.store.ts
+++ b/src/model/value/json-string-value.store.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { JsonStringStore } from '../schema/json-string.store.js';
 import { JsonValueStoreParent } from './json-value.store.js';
 
 export class JsonStringValueStore {
-  public readonly type = JsonSchemaTypeName.String;
+  public readonly type = 'string' as const;
 
   public readonly index: number;
 

--- a/src/model/value/value-transformation.ts
+++ b/src/model/value/value-transformation.ts
@@ -1,4 +1,4 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
+import type { JsonSchemaType } from '../../types/schema.types.js';
 import { JsonArrayStore } from '../schema/json-array.store.js';
 import { JsonSchemaStore } from '../schema/json-schema.store.js';
 import { JsonObjectStore } from '../schema/json-object.store.js';
@@ -95,33 +95,33 @@ export const fromArrayToObject = (
 
 const replaceTransformationsMapper: ReplaceTransformationsMapper = [
   {
-    fromType: JsonSchemaTypeName.Number,
-    toType: JsonSchemaTypeName.String,
+    fromType: 'number',
+    toType: 'string',
     transformation: fromNumberToString as Transformation,
   },
   {
-    fromType: JsonSchemaTypeName.String,
-    toType: JsonSchemaTypeName.Number,
+    fromType: 'string',
+    toType: 'number',
     transformation: fromStringToNumber as Transformation,
   },
   {
-    fromType: JsonSchemaTypeName.Boolean,
-    toType: JsonSchemaTypeName.String,
+    fromType: 'boolean',
+    toType: 'string',
     transformation: fromBooleanToString as Transformation,
   },
   {
-    fromType: JsonSchemaTypeName.String,
-    toType: JsonSchemaTypeName.Boolean,
+    fromType: 'string',
+    toType: 'boolean',
     transformation: fromStringToBoolean as Transformation,
   },
   {
-    fromType: JsonSchemaTypeName.Boolean,
-    toType: JsonSchemaTypeName.Number,
+    fromType: 'boolean',
+    toType: 'number',
     transformation: fromBooleanToNumber as Transformation,
   },
   {
-    fromType: JsonSchemaTypeName.Number,
-    toType: JsonSchemaTypeName.Boolean,
+    fromType: 'number',
+    toType: 'boolean',
     transformation: fromNumberToBoolean as Transformation,
   },
 ];
@@ -203,8 +203,8 @@ export const getTransformation = (
 };
 
 const findTransformation = (
-  from: JsonSchemaTypeName,
-  to: JsonSchemaTypeName,
+  from: JsonSchemaType,
+  to: JsonSchemaType,
 ): Transformation | undefined => {
   if (from === to) {
     return equal;
@@ -221,7 +221,7 @@ const findTransformation = (
 
 type Transformation = (value: unknown, defaultValue?: unknown) => unknown;
 type ReplaceTransformationsMapper = {
-  fromType: JsonSchemaTypeName;
-  toType: JsonSchemaTypeName;
+  fromType: JsonSchemaType;
+  toType: JsonSchemaType;
   transformation: Transformation;
 }[];

--- a/src/plugins/__tests__/file-schema.spec.ts
+++ b/src/plugins/__tests__/file-schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { fileSchema } from '../file-schema.js';
 
 describe('fileSchema', () => {
   it('should have correct type', () => {
-    expect(fileSchema.type).toBe(JsonSchemaTypeName.Object);
+    expect(fileSchema.type).toBe('object');
   });
 
   it('should have all required properties', () => {
@@ -54,7 +53,7 @@ describe('fileSchema', () => {
     readOnlyStringProps.forEach((prop) => {
       it(`should have ${prop} as readOnly string with empty default`, () => {
         expect(fileSchema.properties[prop]).toStrictEqual({
-          type: JsonSchemaTypeName.String,
+          type: 'string',
           default: '',
           readOnly: true,
         });
@@ -63,7 +62,7 @@ describe('fileSchema', () => {
 
     it('should have fileName as writable string with empty default', () => {
       expect(fileSchema.properties.fileName).toStrictEqual({
-        type: JsonSchemaTypeName.String,
+        type: 'string',
         default: '',
       });
     });
@@ -75,7 +74,7 @@ describe('fileSchema', () => {
     numberProps.forEach((prop) => {
       it(`should have ${prop} as number with 0 default`, () => {
         expect(fileSchema.properties[prop]).toStrictEqual({
-          type: JsonSchemaTypeName.Number,
+          type: 'number',
           default: 0,
           readOnly: true,
         });
@@ -85,47 +84,47 @@ describe('fileSchema', () => {
 
   it('should match expected structure', () => {
     expect(fileSchema).toStrictEqual({
-      type: JsonSchemaTypeName.Object,
+      type: 'object',
       properties: {
         status: {
-          type: JsonSchemaTypeName.String,
+          type: 'string',
           default: '',
           readOnly: true,
         },
         fileId: {
-          type: JsonSchemaTypeName.String,
+          type: 'string',
           default: '',
           readOnly: true,
         },
-        url: { type: JsonSchemaTypeName.String, default: '', readOnly: true },
-        fileName: { type: JsonSchemaTypeName.String, default: '' },
+        url: { type: 'string', default: '', readOnly: true },
+        fileName: { type: 'string', default: '' },
         hash: {
-          type: JsonSchemaTypeName.String,
+          type: 'string',
           default: '',
           readOnly: true,
         },
         extension: {
-          type: JsonSchemaTypeName.String,
+          type: 'string',
           default: '',
           readOnly: true,
         },
         mimeType: {
-          type: JsonSchemaTypeName.String,
+          type: 'string',
           default: '',
           readOnly: true,
         },
         size: {
-          type: JsonSchemaTypeName.Number,
+          type: 'number',
           default: 0,
           readOnly: true,
         },
         width: {
-          type: JsonSchemaTypeName.Number,
+          type: 'number',
           default: 0,
           readOnly: true,
         },
         height: {
-          type: JsonSchemaTypeName.Number,
+          type: 'number',
           default: 0,
           readOnly: true,
         },

--- a/src/plugins/__tests__/row-created-at.schema.spec.ts
+++ b/src/plugins/__tests__/row-created-at.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowCreatedAtSchema } from '../row-created-at.schema.js';
 
 describe('rowCreatedAtSchema', () => {
   it('should have correct type', () => {
-    expect(rowCreatedAtSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowCreatedAtSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowCreatedAtSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowCreatedAtSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/__tests__/row-created-id.schema.spec.ts
+++ b/src/plugins/__tests__/row-created-id.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowCreatedIdSchema } from '../row-created-id.schema.js';
 
 describe('rowCreatedIdSchema', () => {
   it('should have correct type', () => {
-    expect(rowCreatedIdSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowCreatedIdSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowCreatedIdSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowCreatedIdSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/__tests__/row-hash.schema.spec.ts
+++ b/src/plugins/__tests__/row-hash.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowHashSchema } from '../row-hash.schema.js';
 
 describe('rowHashSchema', () => {
   it('should have correct type', () => {
-    expect(rowHashSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowHashSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowHashSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowHashSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/__tests__/row-id.schema.spec.ts
+++ b/src/plugins/__tests__/row-id.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowIdSchema } from '../row-id.schema.js';
 
 describe('rowIdSchema', () => {
   it('should have correct type', () => {
-    expect(rowIdSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowIdSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowIdSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowIdSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/__tests__/row-published-at.schema.spec.ts
+++ b/src/plugins/__tests__/row-published-at.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowPublishedAtSchema } from '../row-published-at.schema.js';
 
 describe('rowPublishedAtSchema', () => {
   it('should have correct type', () => {
-    expect(rowPublishedAtSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowPublishedAtSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowPublishedAtSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowPublishedAtSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
     });
   });

--- a/src/plugins/__tests__/row-schema-hash.schema.spec.ts
+++ b/src/plugins/__tests__/row-schema-hash.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowSchemaHashSchema } from '../row-schema-hash.schema.js';
 
 describe('rowSchemaHashSchema', () => {
   it('should have correct type', () => {
-    expect(rowSchemaHashSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowSchemaHashSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowSchemaHashSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowSchemaHashSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/__tests__/row-updated-at.schema.spec.ts
+++ b/src/plugins/__tests__/row-updated-at.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowUpdatedAtSchema } from '../row-updated-at.schema.js';
 
 describe('rowUpdatedAtSchema', () => {
   it('should have correct type', () => {
-    expect(rowUpdatedAtSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowUpdatedAtSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowUpdatedAtSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowUpdatedAtSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/__tests__/row-version-id.schema.spec.ts
+++ b/src/plugins/__tests__/row-version-id.schema.spec.ts
@@ -1,9 +1,8 @@
-import { JsonSchemaTypeName } from '../../types/schema.types.js';
 import { rowVersionIdSchema } from '../row-version-id.schema.js';
 
 describe('rowVersionIdSchema', () => {
   it('should have correct type', () => {
-    expect(rowVersionIdSchema.type).toBe(JsonSchemaTypeName.String);
+    expect(rowVersionIdSchema.type).toBe('string');
   });
 
   it('should have empty string as default', () => {
@@ -16,7 +15,7 @@ describe('rowVersionIdSchema', () => {
 
   it('should match expected structure', () => {
     expect(rowVersionIdSchema).toStrictEqual({
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     });

--- a/src/plugins/file-schema.ts
+++ b/src/plugins/file-schema.ts
@@ -1,40 +1,40 @@
-import { JsonObjectSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonObjectSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const fileSchema: JsonObjectSchema = {
-  type: JsonSchemaTypeName.Object,
+  type: 'object',
   properties: {
-    status: { type: JsonSchemaTypeName.String, default: '', readOnly: true },
-    fileId: { type: JsonSchemaTypeName.String, default: '', readOnly: true },
-    url: { type: JsonSchemaTypeName.String, default: '', readOnly: true },
-    fileName: { type: JsonSchemaTypeName.String, default: '' },
+    status: { type: 'string', default: '', readOnly: true },
+    fileId: { type: 'string', default: '', readOnly: true },
+    url: { type: 'string', default: '', readOnly: true },
+    fileName: { type: 'string', default: '' },
     hash: {
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     },
     extension: {
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     },
     mimeType: {
-      type: JsonSchemaTypeName.String,
+      type: 'string',
       default: '',
       readOnly: true,
     },
     size: {
-      type: JsonSchemaTypeName.Number,
+      type: 'number',
       default: 0,
       readOnly: true,
     },
     width: {
-      type: JsonSchemaTypeName.Number,
+      type: 'number',
       default: 0,
       readOnly: true,
     },
     height: {
-      type: JsonSchemaTypeName.Number,
+      type: 'number',
       default: 0,
       readOnly: true,
     },

--- a/src/plugins/row-created-at.schema.ts
+++ b/src/plugins/row-created-at.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowCreatedAtSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/plugins/row-created-id.schema.ts
+++ b/src/plugins/row-created-id.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowCreatedIdSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/plugins/row-hash.schema.ts
+++ b/src/plugins/row-hash.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowHashSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/plugins/row-id.schema.ts
+++ b/src/plugins/row-id.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowIdSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/plugins/row-published-at.schema.ts
+++ b/src/plugins/row-published-at.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowPublishedAtSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
 };
 

--- a/src/plugins/row-schema-hash.schema.ts
+++ b/src/plugins/row-schema-hash.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowSchemaHashSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/plugins/row-updated-at.schema.ts
+++ b/src/plugins/row-updated-at.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowUpdatedAtSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/plugins/row-version-id.schema.ts
+++ b/src/plugins/row-version-id.schema.ts
@@ -1,8 +1,8 @@
-import { JsonStringSchema, JsonSchemaTypeName } from '../types/schema.types.js';
+import { JsonStringSchema } from '../types/schema.types.js';
 import { SystemSchemaIds } from '../consts/system-schema-ids.js';
 
 export const rowVersionIdSchema: JsonStringSchema = {
-  type: JsonSchemaTypeName.String,
+  type: 'string',
   default: '',
   readOnly: true,
 };

--- a/src/types/__tests__/typed.spec.ts
+++ b/src/types/__tests__/typed.spec.ts
@@ -1,5 +1,4 @@
 import { str, num, bool, obj, arr } from '../../lib/schema-helpers.js';
-import { JsonSchemaTypeName } from '../schema.types.js';
 import type {
   InferValue,
   InferNode,
@@ -36,12 +35,12 @@ describe('typed API — compile-time type assertions', () => {
     });
 
     it('maps object schema to typed object', () => {
-      expect(obj({ name: str(), age: num() }).type).toBe(JsonSchemaTypeName.Object);
+      expect(obj({ name: str(), age: num() }).type).toBe('object');
       assert<Equal<InferValue<ReturnType<typeof obj<{ name: ReturnType<typeof str>; age: ReturnType<typeof num> }>>>, { name: string; age: number }>>();
     });
 
     it('maps array schema to typed array', () => {
-      expect(arr(str()).type).toBe(JsonSchemaTypeName.Array);
+      expect(arr(str()).type).toBe('array');
       assert<Equal<InferValue<ReturnType<typeof arr<ReturnType<typeof str>>>>, string[]>>();
     });
 
@@ -50,7 +49,7 @@ describe('typed API — compile-time type assertions', () => {
         address: obj({ city: str(), zip: str() }),
         tags: arr(str()),
       });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       assert<
         Equal<InferValue<typeof schema>, { address: { city: string; zip: string }; tags: string[] }>
       >();
@@ -103,14 +102,14 @@ describe('typed API — compile-time type assertions', () => {
 
     it('maps object schema to TypedObjectValueNode', () => {
       const schema = obj({ name: str() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Props = (typeof schema)['properties'];
       assert<Equal<InferNode<typeof schema>, TypedObjectValueNode<Props>>>();
     });
 
     it('maps array schema to TypedArrayValueNode', () => {
       const schema = arr(num());
-      expect(schema.type).toBe(JsonSchemaTypeName.Array);
+      expect(schema.type).toBe('array');
       type Items = (typeof schema)['items'];
       assert<Equal<InferNode<typeof schema>, TypedArrayValueNode<Items>>>();
     });
@@ -123,7 +122,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('typed node interface contracts', () => {
     it('TypedObjectValueNode.child returns narrowed type for specific key', () => {
       const schema = obj({ name: str(), count: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Props = (typeof schema)['properties'];
       assert<Equal<InferNode<Props['name']>, TypedPrimitiveValueNode<string>>>();
       assert<Equal<InferNode<Props['count']>, TypedPrimitiveValueNode<number>>>();
@@ -131,7 +130,7 @@ describe('typed API — compile-time type assertions', () => {
 
     it('TypedObjectValueNode.getPlainValue returns typed object', () => {
       const schema = obj({ flag: bool(), label: str() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Props = (typeof schema)['properties'];
       type Node = TypedObjectValueNode<Props>;
       type Value = ReturnType<Node['getPlainValue']>;
@@ -154,7 +153,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('SchemaPaths', () => {
     it('generates top-level property paths', () => {
       const schema = obj({ name: str(), age: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Paths = SchemaPaths<typeof schema>;
       assert<Extends<'name', Paths>>();
       assert<Extends<'age', Paths>>();
@@ -164,7 +163,7 @@ describe('typed API — compile-time type assertions', () => {
       const schema = obj({
         address: obj({ city: str(), zip: str() }),
       });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Paths = SchemaPaths<typeof schema>;
       assert<Extends<'address', Paths>>();
       assert<Extends<'address.city', Paths>>();
@@ -173,7 +172,7 @@ describe('typed API — compile-time type assertions', () => {
 
     it('generates array index paths', () => {
       const schema = obj({ tags: arr(str()) });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Paths = SchemaPaths<typeof schema>;
       assert<Extends<'tags', Paths>>();
       assert<Extends<`tags.[${number}]`, Paths>>();
@@ -183,7 +182,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('SchemaAtPath', () => {
     it('resolves top-level property schema', () => {
       const schema = obj({ name: str(), age: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       assert<Equal<SchemaAtPath<typeof schema, 'name'>, ReturnType<typeof str>>>();
     });
 
@@ -191,7 +190,7 @@ describe('typed API — compile-time type assertions', () => {
       const schema = obj({
         address: obj({ city: str() }),
       });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       assert<Equal<SchemaAtPath<typeof schema, 'address.city'>, ReturnType<typeof str>>>();
     });
   });
@@ -199,7 +198,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('ValueAtPath', () => {
     it('resolves value type at path', () => {
       const schema = obj({ age: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       assert<Equal<ValueAtPath<typeof schema, 'age'>, number>>();
     });
 
@@ -207,7 +206,7 @@ describe('typed API — compile-time type assertions', () => {
       const schema = obj({
         address: obj({ city: str() }),
       });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       assert<Equal<ValueAtPath<typeof schema, 'address.city'>, string>>();
     });
   });
@@ -215,7 +214,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('TypedValueTree interface', () => {
     it('root is typed', () => {
       const schema = obj({ name: str() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Tree = TypedValueTree<typeof schema>;
       type RootType = Tree['root'];
       type Props = (typeof schema)['properties'];
@@ -408,7 +407,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('TypedRowModel type contracts', () => {
     it('typed row model narrows getValue return type', () => {
       const schema = obj({ name: str(), age: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Row = import('../../model/table/row/typed.js').TypedRowModel<typeof schema>;
       type NameValue = ReturnType<Row['getValue']>;
 
@@ -418,7 +417,7 @@ describe('typed API — compile-time type assertions', () => {
 
     it('typed row model narrows getPlainValue return type', () => {
       const schema = obj({ name: str(), count: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Row = import('../../model/table/row/typed.js').TypedRowModel<typeof schema>;
       type Value = ReturnType<Row['getPlainValue']>;
       assert<Equal<Value, { name: string; count: number }>>();
@@ -428,7 +427,7 @@ describe('typed API — compile-time type assertions', () => {
   describe('TypedTableModel type contracts', () => {
     it('typed table model returns typed rows', () => {
       const schema = obj({ title: str() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Table = import('../../model/table/typed.js').TypedTableModel<typeof schema>;
       type Row = Table['rows'][number];
       type Value = ReturnType<Row['getPlainValue']>;
@@ -437,7 +436,7 @@ describe('typed API — compile-time type assertions', () => {
 
     it('typed table model addRow returns typed row', () => {
       const schema = obj({ price: num() });
-      expect(schema.type).toBe(JsonSchemaTypeName.Object);
+      expect(schema.type).toBe('object');
       type Table = import('../../model/table/typed.js').TypedTableModel<typeof schema>;
       type Row = ReturnType<Table['addRow']>;
       type Value = ReturnType<Row['getPlainValue']>;

--- a/src/types/schema.types.ts
+++ b/src/types/schema.types.ts
@@ -1,3 +1,4 @@
+/** @deprecated Use string literals ('string', 'number', etc.) or the `JsonSchemaType` union instead. */
 export enum JsonSchemaTypeName {
   String = 'string',
   Number = 'number',
@@ -5,6 +6,8 @@ export enum JsonSchemaTypeName {
   Object = 'object',
   Array = 'array',
 }
+
+export type JsonSchemaType = 'string' | 'number' | 'boolean' | 'object' | 'array';
 
 export type XFormula = {
   version: 1;
@@ -26,7 +29,7 @@ export type ContentMediaType =
   | 'application/yaml';
 
 export type JsonStringSchema = {
-  type: JsonSchemaTypeName.String;
+  type: 'string';
   default: string;
   foreignKey?: string;
   readOnly?: boolean;
@@ -44,7 +47,7 @@ export type JsonStringSchema = {
 } & JsonSchemaSharedFields;
 
 export type JsonNumberSchema = {
-  type: JsonSchemaTypeName.Number;
+  type: 'number';
   default: number;
   readOnly?: boolean;
   title?: string;
@@ -57,7 +60,7 @@ export type JsonNumberSchema = {
 } & JsonSchemaSharedFields;
 
 export type JsonBooleanSchema = {
-  type: JsonSchemaTypeName.Boolean;
+  type: 'boolean';
   default: boolean;
   readOnly?: boolean;
   title?: string;
@@ -72,7 +75,7 @@ export type JsonSchemaPrimitives =
   | JsonBooleanSchema;
 
 export type JsonObjectSchema = {
-  type: JsonSchemaTypeName.Object;
+  type: 'object';
   additionalProperties: false;
   required: string[];
   properties: Record<string, JsonSchema>;
@@ -82,7 +85,7 @@ export type JsonObjectSchema = {
 } & JsonSchemaSharedFields;
 
 export type JsonArraySchema = {
-  type: JsonSchemaTypeName.Array;
+  type: 'array';
   items: JsonSchema;
   title?: string;
   description?: string;

--- a/src/types/typed.ts
+++ b/src/types/typed.ts
@@ -1,4 +1,3 @@
-import type { JsonSchemaTypeName } from './schema.types.js';
 import type {
   ArrayValueNode,
   ObjectValueNode,
@@ -31,11 +30,11 @@ type IsPrimitive<S> = IsNever<SchemaType<S>> extends true ? false : SchemaType<S
 // InferValue — maps a JSON Schema type to the plain TypeScript value it holds
 // ---------------------------------------------------------------------------
 
-type PrimitiveValue<T> = T extends 'string' | JsonSchemaTypeName.String
+type PrimitiveValue<T> = T extends 'string'
   ? string
-  : T extends 'number' | JsonSchemaTypeName.Number
+  : T extends 'number'
     ? number
-    : T extends 'boolean' | JsonSchemaTypeName.Boolean
+    : T extends 'boolean'
       ? boolean
       : never;
 
@@ -44,9 +43,9 @@ export type InferValue<S> =
     ? unknown
     : IsPrimitive<S> extends true
       ? PrimitiveValue<SchemaType<S>>
-      : SchemaType<S> extends 'object' | JsonSchemaTypeName.Object
+      : SchemaType<S> extends 'object'
         ? { [K in keyof SchemaProperties<S>]: InferValue<SchemaProperties<S>[K]> }
-        : SchemaType<S> extends 'array' | JsonSchemaTypeName.Array
+        : SchemaType<S> extends 'array'
           ? InferValue<SchemaItems<S>>[]
           : unknown;
 
@@ -81,11 +80,11 @@ export interface TypedArrayValueNode<I> extends ArrayValueNode {
 // InferNode — maps a JSON Schema type to the typed ValueNode interface
 // ---------------------------------------------------------------------------
 
-type PrimitiveNode<T> = T extends 'string' | JsonSchemaTypeName.String
+type PrimitiveNode<T> = T extends 'string'
   ? TypedPrimitiveValueNode<string>
-  : T extends 'number' | JsonSchemaTypeName.Number
+  : T extends 'number'
     ? TypedPrimitiveValueNode<number>
-    : T extends 'boolean' | JsonSchemaTypeName.Boolean
+    : T extends 'boolean'
       ? TypedPrimitiveValueNode<boolean>
       : never;
 
@@ -94,9 +93,9 @@ export type InferNode<S> =
     ? ValueNode
     : IsPrimitive<S> extends true
       ? PrimitiveNode<SchemaType<S>>
-      : SchemaType<S> extends 'object' | JsonSchemaTypeName.Object
+      : SchemaType<S> extends 'object'
         ? TypedObjectValueNode<SchemaProperties<S>>
-        : SchemaType<S> extends 'array' | JsonSchemaTypeName.Array
+        : SchemaType<S> extends 'array'
           ? TypedArrayValueNode<SchemaItems<S>>
           : ValueNode;
 
@@ -107,13 +106,13 @@ export type InferNode<S> =
 export type SchemaPaths<S, Prefix extends string = ''> =
   IsPrimitive<S> extends true
     ? never
-    : SchemaType<S> extends 'object' | JsonSchemaTypeName.Object
+    : SchemaType<S> extends 'object'
       ? {
           [K in keyof SchemaProperties<S> & string]:
             | `${Prefix}${K}`
             | SchemaPaths<SchemaProperties<S>[K], `${Prefix}${K}.`>;
         }[keyof SchemaProperties<S> & string]
-      : SchemaType<S> extends 'array' | JsonSchemaTypeName.Array
+      : SchemaType<S> extends 'array'
         ? `${Prefix}[${number}]` | SchemaPaths<SchemaItems<S>, `${Prefix}[${number}].`>
         : never;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deprecated JsonSchemaTypeName and switched schema.type checks to string literals across the codebase. Added a JsonSchemaType union and updated stores, parsers, helpers, and tests to use 'string', 'number', 'boolean', 'object', and 'array'.

- **Refactors**
  - Replaced JsonSchemaTypeName usage with string literals in serializers, schema/value stores, traversal, patch helpers, foreign key utilities, plugins, and tests.
  - Introduced JsonSchemaType union; marked the enum as deprecated in schema.types.ts.
  - Updated typed.ts and value-transformation to rely on the union and literals.
  - No functional changes; behavior and defaults remain the same.

- **Migration**
  - Replace JsonSchemaTypeName.* references with string literals.
  - Prefer JsonSchemaType for typing over the enum. The enum remains for backward compatibility but is deprecated.

<sup>Written for commit cb2bbc25c48c53090347cfd79ce203ba1c56117c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

