### PR TITLE
fix: tracked value

### DIFF
--- a/src/model/value-node/ArrayValueNode.ts
+++ b/src/model/value-node/ArrayValueNode.ts
@@ -77,6 +77,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
   push(node: ValueNode): void {
     node.parent = this;
     this._items.push(node);
+    this.emit({ type: 'arrayPush', array: this, item: node });
   }
 
   insertAt(index: number, node: ValueNode): void {
@@ -85,6 +86,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     }
     node.parent = this;
     this._items.splice(index, 0, node);
+    this.emit({ type: 'arrayInsert', array: this, index, item: node });
   }
 
   removeAt(index: number): void {
@@ -95,6 +97,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     if (removed) {
       removed.parent = null;
     }
+    this.emit({ type: 'arrayRemove', array: this, index });
   }
 
   move(fromIndex: number, toIndex: number): void {
@@ -112,6 +115,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     if (item) {
       this._items.splice(toIndex, 0, item);
     }
+    this.emit({ type: 'arrayMove', array: this, fromIndex, toIndex });
   }
 
   replaceAt(index: number, node: ValueNode): void {
@@ -124,6 +128,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     }
     node.parent = this;
     this._items[index] = node;
+    this.emit({ type: 'arrayReplace', array: this, index, item: node });
   }
 
   clear(): void {
@@ -131,6 +136,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
       item.parent = null;
     }
     this._items.length = 0;
+    this.emit({ type: 'arrayClear', array: this });
   }
 
   setNodeFactory(factory: NodeFactory): void {

--- a/src/model/value-node/ArrayValueNode.ts
+++ b/src/model/value-node/ArrayValueNode.ts
@@ -97,7 +97,7 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     if (removed) {
       removed.parent = null;
     }
-    this.emit({ type: 'arrayRemove', array: this, index });
+    this.emit({ type: 'arrayRemove', array: this, index, item: removed! });
   }
 
   move(fromIndex: number, toIndex: number): void {
@@ -122,21 +122,20 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     if (index < 0 || index >= this._items.length) {
       throw new Error(`Index out of bounds: ${index}`);
     }
-    const oldNode = this._items[index];
-    if (oldNode) {
-      oldNode.parent = null;
-    }
+    const oldNode = this._items[index]!;
+    oldNode.parent = null;
     node.parent = this;
     this._items[index] = node;
-    this.emit({ type: 'arrayReplace', array: this, index, item: node });
+    this.emit({ type: 'arrayReplace', array: this, index, item: node, oldItem: oldNode });
   }
 
   clear(): void {
-    for (const item of this._items) {
+    const removed = [...this._items];
+    for (const item of removed) {
       item.parent = null;
     }
     this._items.length = 0;
-    this.emit({ type: 'arrayClear', array: this });
+    this.emit({ type: 'arrayClear', array: this, items: removed });
   }
 
   setNodeFactory(factory: NodeFactory): void {

--- a/src/model/value-node/BasePrimitiveValueNode.ts
+++ b/src/model/value-node/BasePrimitiveValueNode.ts
@@ -93,7 +93,11 @@ export abstract class BasePrimitiveValueNode<T extends string | number | boolean
     if (this.isReadOnly && !options?.internal) {
       throw new Error(`Cannot set value on read-only field: ${this.name}`);
     }
+    const oldValue = this._value;
     this._value = this.coerceValue(value);
+    if (!options?.internal) {
+      this.emit({ type: 'setValue', node: this, value: this._value, oldValue });
+    }
   }
 
   protected abstract coerceValue(value: unknown): T;

--- a/src/model/value-node/BaseValueNode.ts
+++ b/src/model/value-node/BaseValueNode.ts
@@ -1,7 +1,10 @@
+import { EventEmitter } from 'eventemitter3';
 import type { Diagnostic } from '../../core/validation/types.js';
 import type { JsonSchema } from '../../types/schema.types.js';
 import type {
   ArrayValueNode,
+  NodeChangeEvent,
+  NodeChangeListener,
   ObjectValueNode,
   PrimitiveValueNode,
   ValueNode,
@@ -25,11 +28,24 @@ export abstract class BaseValueNode implements ValueNode {
 
   private _parent: ValueNode | null = null;
   private readonly _name: string;
+  private readonly _emitter = new EventEmitter();
 
   constructor(id: string | undefined, name: string, schema: JsonSchema) {
     this.id = id ?? generateNodeId();
     this._name = name;
     this.schema = schema;
+  }
+
+  on(event: 'change', listener: NodeChangeListener): void {
+    this._emitter.on(event, listener);
+  }
+
+  off(event: 'change', listener: NodeChangeListener): void {
+    this._emitter.off(event, listener);
+  }
+
+  protected emit(changeEvent: NodeChangeEvent): void {
+    this._emitter.emit('change', changeEvent);
   }
 
   get parent(): ValueNode | null {

--- a/src/model/value-node/ObjectValueNode.ts
+++ b/src/model/value-node/ObjectValueNode.ts
@@ -78,6 +78,7 @@ export class ObjectValueNode extends BaseValueNode implements IObjectValueNode {
     }
     node.parent = this;
     this._children.set(node.name, node);
+    this.emit({ type: 'addChild', parent: this, child: node });
   }
 
   removeChild(name: string): void {
@@ -85,6 +86,7 @@ export class ObjectValueNode extends BaseValueNode implements IObjectValueNode {
     if (node) {
       node.parent = null;
       this._children.delete(name);
+      this.emit({ type: 'removeChild', parent: this, childName: name });
     }
   }
 

--- a/src/model/value-node/ObjectValueNode.ts
+++ b/src/model/value-node/ObjectValueNode.ts
@@ -86,7 +86,7 @@ export class ObjectValueNode extends BaseValueNode implements IObjectValueNode {
     if (node) {
       node.parent = null;
       this._children.delete(name);
-      this.emit({ type: 'removeChild', parent: this, childName: name });
+      this.emit({ type: 'removeChild', parent: this, childName: name, child: node });
     }
   }
 

--- a/src/model/value-node/__tests__/NodeChangeEvents.spec.ts
+++ b/src/model/value-node/__tests__/NodeChangeEvents.spec.ts
@@ -1,0 +1,277 @@
+import type { JsonArraySchema } from '../../../types/schema.types.js';
+import { str, arr, obj } from '../../../mocks/schema.mocks.js';
+import {
+  StringValueNode,
+  ObjectValueNode,
+  ArrayValueNode,
+  resetNodeIdCounter,
+  createNodeFactory,
+} from '../index.js';
+import type { NodeChangeEvent } from '../types.js';
+
+beforeEach(() => {
+  resetNodeIdCounter();
+});
+
+describe('NodeChangeEvents', () => {
+  describe('PrimitiveValueNode', () => {
+    it('emits setValue event on setValue()', () => {
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.setValue('Jane');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'setValue',
+        node,
+        value: 'Jane',
+        oldValue: 'John',
+      });
+    });
+
+    it('does not emit when options.internal is true', () => {
+      const schema = str({ formula: 'x' });
+      const node = new StringValueNode(undefined, 'name', schema, 'old');
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.setValue('computed', { internal: true });
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('supports off to unsubscribe', () => {
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
+      const events: NodeChangeEvent[] = [];
+      const listener = (e: NodeChangeEvent) => events.push(e);
+      node.on('change', listener);
+
+      node.setValue('Jane');
+      node.off('change', listener);
+      node.setValue('Bob');
+
+      expect(events).toHaveLength(1);
+    });
+  });
+
+  describe('ObjectValueNode', () => {
+    it('emits addChild event on addChild()', () => {
+      const parent = new ObjectValueNode(undefined, 'root', obj({}));
+      const child = new StringValueNode(undefined, 'name', str(), 'John');
+      const events: NodeChangeEvent[] = [];
+      parent.on('change', (e) => events.push(e));
+
+      parent.addChild(child);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'addChild',
+        parent,
+        child,
+      });
+    });
+
+    it('emits removeChild event on removeChild()', () => {
+      const child = new StringValueNode(undefined, 'name', str(), 'John');
+      const parent = new ObjectValueNode(undefined, 'root', obj({ name: str() }), [child]);
+      const events: NodeChangeEvent[] = [];
+      parent.on('change', (e) => events.push(e));
+
+      parent.removeChild('name');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'removeChild',
+        parent,
+        childName: 'name',
+      });
+    });
+
+    it('does not emit removeChild for non-existent child', () => {
+      const parent = new ObjectValueNode(undefined, 'root', obj({}));
+      const events: NodeChangeEvent[] = [];
+      parent.on('change', (e) => events.push(e));
+
+      parent.removeChild('missing');
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('does not emit from setValue (delegates to children)', () => {
+      const child = new StringValueNode(undefined, 'name', str(), 'John');
+      const parent = new ObjectValueNode(undefined, 'root', obj({ name: str() }), [child]);
+      const parentEvents: NodeChangeEvent[] = [];
+      parent.on('change', (e) => parentEvents.push(e));
+
+      parent.setValue({ name: 'Jane' });
+
+      expect(parentEvents).toHaveLength(0);
+    });
+  });
+
+  describe('ArrayValueNode', () => {
+    const createItem = (value: string) =>
+      new StringValueNode(undefined, '0', str(), value);
+
+    it('emits arrayPush on push()', () => {
+      const node = new ArrayValueNode(undefined, 'items', arr(str()));
+      const item = createItem('a');
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.push(item);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'arrayPush',
+        array: node,
+        item,
+      });
+    });
+
+    it('emits arrayInsert on insertAt()', () => {
+      const existing = createItem('a');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [existing]);
+      const item = createItem('b');
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.insertAt(0, item);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'arrayInsert',
+        array: node,
+        index: 0,
+        item,
+      });
+    });
+
+    it('emits arrayRemove on removeAt()', () => {
+      const item = createItem('a');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [item]);
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.removeAt(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'arrayRemove',
+        array: node,
+        index: 0,
+      });
+    });
+
+    it('emits arrayMove on move()', () => {
+      const item1 = createItem('a');
+      const item2 = createItem('b');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [item1, item2]);
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.move(0, 1);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'arrayMove',
+        array: node,
+        fromIndex: 0,
+        toIndex: 1,
+      });
+    });
+
+    it('does not emit arrayMove when fromIndex equals toIndex', () => {
+      const item = createItem('a');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [item]);
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.move(0, 0);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('emits arrayReplace on replaceAt()', () => {
+      const oldItem = createItem('a');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [oldItem]);
+      const newItem = createItem('b');
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.replaceAt(0, newItem);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'arrayReplace',
+        array: node,
+        index: 0,
+        item: newItem,
+      });
+    });
+
+    it('emits arrayClear on clear()', () => {
+      const item = createItem('a');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [item]);
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.clear();
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'arrayClear',
+        array: node,
+      });
+    });
+
+    it('emits multiple events from pushValue (push is the leaf)', () => {
+      const factory = createNodeFactory();
+      const schema = arr(str()) as JsonArraySchema;
+      const node = new ArrayValueNode(undefined, 'items', schema);
+      node.setNodeFactory(factory);
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.pushValue('hello');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.type).toBe('arrayPush');
+    });
+
+    it('emits events from setValue that grows array', () => {
+      const factory = createNodeFactory();
+      const schema = arr(str()) as JsonArraySchema;
+      const existing = new StringValueNode(undefined, '0', str(), 'a');
+      const node = new ArrayValueNode(undefined, 'items', schema, [existing]);
+      node.setNodeFactory(factory);
+      const arrayEvents: NodeChangeEvent[] = [];
+      const childEvents: NodeChangeEvent[] = [];
+      node.on('change', (e) => arrayEvents.push(e));
+      existing.on('change', (e) => childEvents.push(e));
+
+      node.setValue(['x', 'y']);
+
+      expect(childEvents).toHaveLength(1);
+      expect(childEvents[0]?.type).toBe('setValue');
+      const pushEvents = arrayEvents.filter((e) => e.type === 'arrayPush');
+      expect(pushEvents).toHaveLength(1);
+    });
+
+    it('emits events from setValue that shrinks array', () => {
+      const item1 = createItem('a');
+      const item2 = createItem('b');
+      const schema = arr(str()) as JsonArraySchema;
+      const node = new ArrayValueNode(undefined, 'items', schema, [item1, item2]);
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.setValue(['x']);
+
+      const removeEvents = events.filter((e) => e.type === 'arrayRemove');
+      expect(removeEvents).toHaveLength(1);
+    });
+  });
+});

--- a/src/model/value-node/__tests__/NodeChangeEvents.spec.ts
+++ b/src/model/value-node/__tests__/NodeChangeEvents.spec.ts
@@ -86,6 +86,7 @@ describe('NodeChangeEvents', () => {
         type: 'removeChild',
         parent,
         childName: 'name',
+        child,
       });
     });
 
@@ -149,7 +150,7 @@ describe('NodeChangeEvents', () => {
       });
     });
 
-    it('emits arrayRemove on removeAt()', () => {
+    it('emits arrayRemove on removeAt() with removed item', () => {
       const item = createItem('a');
       const node = new ArrayValueNode(undefined, 'items', arr(str()), [item]);
       const events: NodeChangeEvent[] = [];
@@ -162,6 +163,7 @@ describe('NodeChangeEvents', () => {
         type: 'arrayRemove',
         array: node,
         index: 0,
+        item,
       });
     });
 
@@ -194,7 +196,7 @@ describe('NodeChangeEvents', () => {
       expect(events).toHaveLength(0);
     });
 
-    it('emits arrayReplace on replaceAt()', () => {
+    it('emits arrayReplace on replaceAt() with old and new items', () => {
       const oldItem = createItem('a');
       const node = new ArrayValueNode(undefined, 'items', arr(str()), [oldItem]);
       const newItem = createItem('b');
@@ -209,12 +211,14 @@ describe('NodeChangeEvents', () => {
         array: node,
         index: 0,
         item: newItem,
+        oldItem,
       });
     });
 
-    it('emits arrayClear on clear()', () => {
-      const item = createItem('a');
-      const node = new ArrayValueNode(undefined, 'items', arr(str()), [item]);
+    it('emits arrayClear on clear() with removed items', () => {
+      const item1 = createItem('a');
+      const item2 = createItem('b');
+      const node = new ArrayValueNode(undefined, 'items', arr(str()), [item1, item2]);
       const events: NodeChangeEvent[] = [];
       node.on('change', (e) => events.push(e));
 
@@ -224,6 +228,7 @@ describe('NodeChangeEvents', () => {
       expect(events[0]).toEqual({
         type: 'arrayClear',
         array: node,
+        items: [item1, item2],
       });
     });
 

--- a/src/model/value-node/index.ts
+++ b/src/model/value-node/index.ts
@@ -7,6 +7,8 @@ export type {
   DirtyTrackable,
   FormulaDefinition,
   FormulaWarning,
+  NodeChangeEvent,
+  NodeChangeListener,
   ValueNodeOptions,
   PrimitiveNodeOptions,
   ObjectNodeOptions,

--- a/src/model/value-node/types.ts
+++ b/src/model/value-node/types.ts
@@ -28,6 +28,19 @@ export interface FormulaWarning {
   readonly computedValue: unknown;
 }
 
+export type NodeChangeEvent =
+  | { type: 'setValue'; node: ValueNode; value: unknown; oldValue: unknown }
+  | { type: 'addChild'; parent: ValueNode; child: ValueNode }
+  | { type: 'removeChild'; parent: ValueNode; childName: string }
+  | { type: 'arrayPush'; array: ValueNode; item: ValueNode }
+  | { type: 'arrayInsert'; array: ValueNode; index: number; item: ValueNode }
+  | { type: 'arrayRemove'; array: ValueNode; index: number }
+  | { type: 'arrayMove'; array: ValueNode; fromIndex: number; toIndex: number }
+  | { type: 'arrayReplace'; array: ValueNode; index: number; item: ValueNode }
+  | { type: 'arrayClear'; array: ValueNode };
+
+export type NodeChangeListener = (event: NodeChangeEvent) => void;
+
 export interface ValueNode {
   readonly id: string;
   readonly type: ValueType;
@@ -42,6 +55,9 @@ export interface ValueNode {
   isObject(): this is ObjectValueNode;
   isArray(): this is ArrayValueNode;
   isPrimitive(): this is PrimitiveValueNode;
+
+  on(event: 'change', listener: NodeChangeListener): void;
+  off(event: 'change', listener: NodeChangeListener): void;
 
   readonly errors: readonly Diagnostic[];
   readonly warnings: readonly Diagnostic[];

--- a/src/model/value-node/types.ts
+++ b/src/model/value-node/types.ts
@@ -31,13 +31,13 @@ export interface FormulaWarning {
 export type NodeChangeEvent =
   | { type: 'setValue'; node: ValueNode; value: unknown; oldValue: unknown }
   | { type: 'addChild'; parent: ValueNode; child: ValueNode }
-  | { type: 'removeChild'; parent: ValueNode; childName: string }
+  | { type: 'removeChild'; parent: ValueNode; childName: string; child: ValueNode }
   | { type: 'arrayPush'; array: ValueNode; item: ValueNode }
   | { type: 'arrayInsert'; array: ValueNode; index: number; item: ValueNode }
-  | { type: 'arrayRemove'; array: ValueNode; index: number }
+  | { type: 'arrayRemove'; array: ValueNode; index: number; item: ValueNode }
   | { type: 'arrayMove'; array: ValueNode; fromIndex: number; toIndex: number }
-  | { type: 'arrayReplace'; array: ValueNode; index: number; item: ValueNode }
-  | { type: 'arrayClear'; array: ValueNode };
+  | { type: 'arrayReplace'; array: ValueNode; index: number; item: ValueNode; oldItem: ValueNode }
+  | { type: 'arrayClear'; array: ValueNode; items: readonly ValueNode[] };
 
 export type NodeChangeListener = (event: NodeChangeEvent) => void;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds node change events and recursive ValueTree subscriptions so direct node mutations are tracked and converted into JSON patches. Prevents duplicate patches on tree.setValue and keeps subscriptions in sync on add/remove/replace, including arrays.

- **New Features**
  - NodeChangeEvent union and on/off API on ValueNode; emits setValue, add/remove child, and array push/insert/remove/move/replace/clear with useful payloads; respects internal flag.
  - ValueTree subscribes to the whole tree, adopts new nodes, and turns events into patches; invalidates paths under changed arrays.
  - Exposes NodeChangeEvent and NodeChangeListener types.

- **Bug Fixes**
  - Direct node mutations produce correct patches (replace/add/remove/move/replace/clear).
  - No duplicate patches from ValueTree.setValue via event suppression.
  - Cleans up subscriptions on remove/replace and dispose; resubscribes on revert. Added tests for events, patch generation, and subscription lifecycle.

<sup>Written for commit c20712a6d038935b9e780dd9334f670184e9f139. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

