### PR TITLE
chore: bundle size

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   splitting: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   treeshake: true,
   external: ['events'],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled source maps in the tsup build to reduce package size and keep the published bundle lean. Removes map files from the output with no runtime impact.

<sup>Written for commit fc8a4f887c497ef4c1b51984e47877f69c7bf638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

