### PR TITLE
fix: observable patches

### DIFF
--- a/src/model/table/README.md
+++ b/src/model/table/README.md
@@ -39,7 +39,7 @@ Each row automatically gets:
 │  │   - index, prev, next (navigation)                      │    │
 │  │   - delegates: get, getValue, setValue, isDirty, etc.   │    │
 │  │   - nodeById(id): node lookup by ID                     │    │
-│  │   - getPatches(): JSON Patch generation                 │    │
+│  │   - patches: JSON Patch generation                      │    │
 │  │   - dispose(): cleanup FormulaEngine reactions           │    │
 │  └─────────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────────┘
@@ -143,7 +143,7 @@ interface RowModel {
   readonly errors: readonly Diagnostic[];
 
   // Patch operations (delegated to ValueTree)
-  getPatches(): readonly JsonValuePatch[];
+  readonly patches: readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
 
@@ -168,7 +168,7 @@ interface ValueTreeLike {
   readonly isDirty: boolean;
   readonly isValid: boolean;
   readonly errors: readonly Diagnostic[];
-  getPatches(): readonly JsonValuePatch[];
+  readonly patches: readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
   dispose(): void;
@@ -211,7 +211,7 @@ const row = createRowModel({
 // All row operations work the same as table rows
 row.getValue('name');     // 'John'
 row.setValue('name', 'Jane');
-row.getPatches();         // [{ op: 'replace', path: '/name', value: 'Jane' }]
+row.patches;         // [{ op: 'replace', path: '/name', value: 'Jane' }]
 const nameNode = row.get('name');
 if (nameNode) {
   row.nodeById(nameNode.id); // ValueNode
@@ -316,14 +316,14 @@ if (nameNode) {
 ```typescript
 const row = table.getRow('user-1');
 
-row.getPatches(); // []
+row.patches; // []
 
 row.setValue('name', 'Jane');
-row.getPatches(); // [{ op: 'replace', path: '/name', value: 'Jane' }]
+row.patches; // [{ op: 'replace', path: '/name', value: 'Jane' }]
 
 // Patches clear after commit
 row.commit();
-row.getPatches(); // []
+row.patches; // []
 ```
 
 ### Rename tracking

--- a/src/model/table/__tests__/TableModel.spec.ts
+++ b/src/model/table/__tests__/TableModel.spec.ts
@@ -502,7 +502,7 @@ describe('TableModel', () => {
     });
   });
 
-  describe('getPatches', () => {
+  describe('patches', () => {
     it('row returns patches after changes', () => {
       const table = createTableModel({
         tableId: 'users',
@@ -513,7 +513,7 @@ describe('TableModel', () => {
       const row = table.getRow('user-1');
       row!.setValue('name', 'Jane');
 
-      expect(row!.getPatches()).toEqual([
+      expect(row!.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
       ]);
     });
@@ -529,7 +529,7 @@ describe('TableModel', () => {
       row!.setValue('name', 'Jane');
       row!.commit();
 
-      expect(row!.getPatches()).toEqual([]);
+      expect(row!.patches).toEqual([]);
     });
   });
 

--- a/src/model/table/row/RowModelImpl.ts
+++ b/src/model/table/row/RowModelImpl.ts
@@ -99,8 +99,8 @@ export class RowModelImpl implements RowModel {
     return this._tree.errors;
   }
 
-  getPatches(): readonly JsonValuePatch[] {
-    return this._tree.getPatches();
+  get patches(): readonly JsonValuePatch[] {
+    return this._tree.patches;
   }
 
   commit(): void {

--- a/src/model/table/row/__tests__/RowModel.spec.ts
+++ b/src/model/table/row/__tests__/RowModel.spec.ts
@@ -24,7 +24,7 @@ class MockValueTree implements ValueTreeLike {
   getValueCalls: string[] = [];
   setValueCalls: Array<{ path: string; value: unknown }> = [];
   getPlainValueCalls = 0;
-  getPatchesCalls = 0;
+  patchesCalls = 0;
   commitCalls = 0;
   revertCalls = 0;
   disposeCalls = 0;
@@ -65,8 +65,8 @@ class MockValueTree implements ValueTreeLike {
     return this._plainValue;
   }
 
-  getPatches(): readonly JsonValuePatch[] {
-    this.getPatchesCalls++;
+  get patches(): readonly JsonValuePatch[] {
+    this.patchesCalls++;
     return this._patches;
   }
 
@@ -293,14 +293,14 @@ describe('RowModelImpl', () => {
   });
 
   describe('patch operations delegation', () => {
-    it('delegates getPatches to tree', () => {
+    it('delegates patches to tree', () => {
       const patches: JsonValuePatch[] = [{ op: 'replace', path: '/name', value: 'Jane' }];
       mockTree.setPatches(patches);
       const row = new RowModelImpl('row-1', mockTree);
 
-      const result = row.getPatches();
+      const result = row.patches;
 
-      expect(mockTree.getPatchesCalls).toBe(1);
+      expect(mockTree.patchesCalls).toBe(1);
       expect(result).toBe(patches);
     });
 
@@ -472,7 +472,7 @@ describe('createRowModel', () => {
 
     row.setValue('name', 'Jane');
 
-    expect(row.getPatches()).toEqual([
+    expect(row.patches).toEqual([
       { op: 'replace', path: '/name', value: 'Jane' },
     ]);
   });
@@ -503,7 +503,7 @@ describe('createRowModel', () => {
 
     expect(row.isDirty).toBe(false);
     expect(row.getValue('name')).toBe('Jane');
-    expect(row.getPatches()).toEqual([]);
+    expect(row.patches).toEqual([]);
   });
 
   it('supports dispose', () => {
@@ -547,7 +547,7 @@ describe('createRowModel', () => {
       });
 
       expect(row.getValue('total')).toBe(50);
-      expect(row.getPatches()).toEqual([]);
+      expect(row.patches).toEqual([]);
     });
 
     it('is not dirty after init with formulas', () => {
@@ -583,7 +583,7 @@ describe('createRowModel', () => {
       row.setValue('price', 20);
 
       expect(row.getValue('total')).toBe(100);
-      const patches = row.getPatches();
+      const patches = row.patches;
       expect(patches).toEqual([{ op: 'replace', path: '/price', value: 20 }]);
     });
 
@@ -605,14 +605,14 @@ describe('createRowModel', () => {
       expect(row.getValue('subtotal')).toBe(200);
       expect(row.getValue('tax')).toBe(20);
       expect(row.getValue('total')).toBe(220);
-      expect(row.getPatches()).toEqual([]);
+      expect(row.patches).toEqual([]);
 
       row.setValue('quantity', 3);
 
       expect(row.getValue('subtotal')).toBe(300);
       expect(row.getValue('tax')).toBe(30);
       expect(row.getValue('total')).toBe(330);
-      const patches = row.getPatches();
+      const patches = row.patches;
       expect(patches).toEqual([{ op: 'replace', path: '/quantity', value: 3 }]);
     });
 
@@ -665,7 +665,7 @@ describe('createRowModel', () => {
       row.commit();
 
       expect(row.isDirty).toBe(false);
-      expect(row.getPatches()).toEqual([]);
+      expect(row.patches).toEqual([]);
     });
   });
 

--- a/src/model/table/row/types.ts
+++ b/src/model/table/row/types.ts
@@ -42,7 +42,7 @@ export interface RowModel {
   readonly isValid: boolean;
   readonly errors: readonly Diagnostic[];
 
-  getPatches(): readonly JsonValuePatch[];
+  readonly patches: readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
   dispose(): void;

--- a/src/model/value-tree/ChangeTracker.ts
+++ b/src/model/value-tree/ChangeTracker.ts
@@ -1,8 +1,13 @@
+import { makeAutoObservable } from '../../core/reactivity/index.js';
 import type { JsonValuePatch } from '../../types/json-value-patch.types.js';
 import type { Change } from './types.js';
 
 export class ChangeTracker {
   private _changes: Change[] = [];
+
+  constructor() {
+    makeAutoObservable(this);
+  }
 
   get changes(): readonly Change[] {
     return this._changes;
@@ -20,7 +25,7 @@ export class ChangeTracker {
     this._changes = [];
   }
 
-  toPatches(): readonly JsonValuePatch[] {
+  get patches(): readonly JsonValuePatch[] {
     const patches: JsonValuePatch[] = [];
 
     for (const change of this._changes) {

--- a/src/model/value-tree/README.md
+++ b/src/model/value-tree/README.md
@@ -21,7 +21,7 @@ Key capabilities:
 │  ValueTree                                                      │
 │    - get(path), getValue(path), setValue(path, value)           │
 │    - nodeById(id), pathOf(node)         → TreeIndex             │
-│    - getPatches(), trackChange()        → ChangeTracker         │
+│    - patches, trackChange()             → ChangeTracker         │
 │    - setFormulaEngine(), formulaEngine  → FormulaEngine         │
 │    - isDirty, commit(), revert()                                │
 │    - dispose()                                                  │
@@ -32,7 +32,7 @@ Key capabilities:
 ┌──────────────┐ ┌──────────────┐ ┌──────────────────┐
 │  TreeIndex   │ │ChangeTracker │ │  FormulaEngine   │
 │  nodeById()  │ │  track()     │ │  (value-formula) │
-│  pathOf()    │ │  toPatches() │ │  reactive eval   │
+│  pathOf()    │ │  patches     │ │  reactive eval   │
 │  rebuild()   │ │  clear()     │ │  dispose()       │
 └──────────────┘ └──────────────┘ └──────────────────┘
           │
@@ -81,7 +81,7 @@ interface ValueTreeLike {
   readonly errors: readonly Diagnostic[];
 
   // Patches
-  getPatches(): readonly JsonValuePatch[];
+  readonly patches: readonly JsonValuePatch[];
 
   // Lifecycle
   dispose(): void;
@@ -174,7 +174,7 @@ class ChangeTracker {
   readonly hasChanges: boolean;
   track(change: Change): void;
   clear(): void;
-  toPatches(): readonly JsonValuePatch[];
+  readonly patches: readonly JsonValuePatch[];
 }
 ```
 
@@ -242,13 +242,13 @@ empty.isEmpty(); // true
 ```typescript
 const tree = new ValueTree(rootNode);
 
-tree.getPatches(); // []
+tree.patches; // []
 
 tree.setValue('name', 'Jane');
-tree.getPatches(); // [{ op: 'replace', path: '/name', value: 'Jane' }]
+tree.patches; // [{ op: 'replace', path: '/name', value: 'Jane' }]
 
 tree.setValue('age', 25);
-tree.getPatches(); // [
+tree.patches; // [
 //   { op: 'replace', path: '/name', value: 'Jane' },
 //   { op: 'replace', path: '/age', value: 25 },
 // ]
@@ -262,7 +262,7 @@ tree.trackChange({
 
 // commit() and revert() clear patches
 tree.commit();
-tree.getPatches(); // []
+tree.patches; // []
 ```
 
 ### Formula support

--- a/src/model/value-tree/ValueTree.ts
+++ b/src/model/value-tree/ValueTree.ts
@@ -32,7 +32,6 @@ export class ValueTree implements ValueTreeLike {
     makeAutoObservable(this, {
       _root: false,
       index: false,
-      changeTracker: false,
       _nodeChangeListener: false,
       _formulaEngine: false,
       _suppressEvents: false,
@@ -135,8 +134,8 @@ export class ValueTree implements ValueTreeLike {
     return this._root.errors;
   }
 
-  getPatches(): readonly JsonValuePatch[] {
-    return this.changeTracker.toPatches();
+  get patches(): readonly JsonValuePatch[] {
+    return this.changeTracker.patches;
   }
 
   trackChange(change: Change): void {

--- a/src/model/value-tree/__tests__/ChangeTracker.spec.ts
+++ b/src/model/value-tree/__tests__/ChangeTracker.spec.ts
@@ -69,11 +69,11 @@ describe('ChangeTracker', () => {
     });
   });
 
-  describe('toPatches', () => {
+  describe('patches', () => {
     it('returns empty array when no changes', () => {
       const tracker = new ChangeTracker();
 
-      expect(tracker.toPatches()).toEqual([]);
+      expect(tracker.patches).toEqual([]);
     });
 
     it('generates replace patch for setValue', () => {
@@ -85,7 +85,7 @@ describe('ChangeTracker', () => {
         oldValue: 'John',
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
       ]);
     });
@@ -98,7 +98,7 @@ describe('ChangeTracker', () => {
         value: 'test@example.com',
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'add', path: '/email', value: 'test@example.com' },
       ]);
     });
@@ -110,7 +110,7 @@ describe('ChangeTracker', () => {
         path: path('email'),
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'remove', path: '/email' },
       ]);
     });
@@ -123,7 +123,7 @@ describe('ChangeTracker', () => {
         value: { name: 'Item C' },
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'add', path: '/items/-', value: { name: 'Item C' } },
       ]);
     });
@@ -137,7 +137,7 @@ describe('ChangeTracker', () => {
         value: { name: 'Inserted' },
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'add', path: '/items/1', value: { name: 'Inserted' } },
       ]);
     });
@@ -150,7 +150,7 @@ describe('ChangeTracker', () => {
         index: 0,
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'remove', path: '/items/0' },
       ]);
     });
@@ -164,7 +164,7 @@ describe('ChangeTracker', () => {
         toIndex: 2,
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'move', from: '/items/0', path: '/items/2' },
       ]);
     });
@@ -178,7 +178,7 @@ describe('ChangeTracker', () => {
         value: { name: 'Replaced', price: 999 },
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'replace', path: '/items/0', value: { name: 'Replaced', price: 999 } },
       ]);
     });
@@ -190,7 +190,7 @@ describe('ChangeTracker', () => {
         path: path('items'),
       });
 
-      expect(tracker.toPatches()).toEqual([
+      expect(tracker.patches).toEqual([
         { op: 'replace', path: '/items', value: [] },
       ]);
     });
@@ -213,7 +213,7 @@ describe('ChangeTracker', () => {
         path: path('obsolete'),
       });
 
-      const patches = tracker.toPatches();
+      const patches = tracker.patches;
 
       expect(patches).toHaveLength(3);
       expect(patches[0]).toEqual({ op: 'replace', path: '/name', value: 'Jane' });
@@ -232,7 +232,7 @@ describe('ChangeTracker', () => {
 
       tracker.clear();
 
-      expect(tracker.toPatches()).toEqual([]);
+      expect(tracker.patches).toEqual([]);
     });
   });
 });

--- a/src/model/value-tree/__tests__/ValueTree.spec.ts
+++ b/src/model/value-tree/__tests__/ValueTree.spec.ts
@@ -191,7 +191,7 @@ describe('ValueTree', () => {
 
       tree.setValue('address', { city: 'LA' });
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'replace',
@@ -213,7 +213,7 @@ describe('ValueTree', () => {
 
       tree.setValue('profile', { firstName: 'Jane' });
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'replace',
@@ -395,18 +395,18 @@ describe('ValueTree', () => {
     });
   });
 
-  describe('getPatches', () => {
+  describe('patches', () => {
     it('returns empty array when no changes', () => {
       const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
     });
 
     it('returns patch after setValue', () => {
       const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
       tree.setValue('name', 'Jane');
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
       ]);
     });
@@ -416,7 +416,7 @@ describe('ValueTree', () => {
       tree.setValue('name', 'Jane');
       tree.setValue('age', 25);
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
         { op: 'replace', path: '/age', value: 25 },
       ]);
@@ -428,7 +428,7 @@ describe('ValueTree', () => {
 
       tree.commit();
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
     });
 
     it('clears patches after revert', () => {
@@ -437,7 +437,7 @@ describe('ValueTree', () => {
 
       tree.revert();
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
     });
 
     it('returns patch with nested path', () => {
@@ -447,7 +447,7 @@ describe('ValueTree', () => {
       });
       tree.setValue('address.city', 'LA');
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/address/city', value: 'LA' },
       ]);
     });
@@ -590,7 +590,7 @@ describe('ValueTree', () => {
         oldValue: 'John',
       });
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
       ]);
     });
@@ -731,7 +731,7 @@ describe('ValueTree', () => {
         nameNode!.setValue('Jane');
       }
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
       ]);
     });
@@ -748,7 +748,7 @@ describe('ValueTree', () => {
         cityNode!.setValue('LA');
       }
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/address/city', value: 'LA' },
       ]);
     });
@@ -765,7 +765,7 @@ describe('ValueTree', () => {
         valueNode!.setValue('computed', { internal: true });
       }
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
     });
 
     it('tree.setValue still works (backward compat)', () => {
@@ -773,7 +773,7 @@ describe('ValueTree', () => {
 
       tree.setValue('name', 'Jane');
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Jane' },
       ]);
     });
@@ -783,7 +783,7 @@ describe('ValueTree', () => {
 
       tree.setValue('name', 'Jane');
 
-      expect(tree.getPatches()).toHaveLength(1);
+      expect(tree.patches).toHaveLength(1);
     });
 
     it('generates add patch for array pushValue via direct call', () => {
@@ -797,7 +797,7 @@ describe('ValueTree', () => {
         itemsNode!.pushValue({ name: 'Item 2' });
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'add',
@@ -817,7 +817,7 @@ describe('ValueTree', () => {
         itemsNode!.removeAt(0);
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'remove',
@@ -836,7 +836,7 @@ describe('ValueTree', () => {
         itemsNode!.move(0, 1);
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'move',
@@ -856,7 +856,7 @@ describe('ValueTree', () => {
         itemsNode!.clear();
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'replace',
@@ -874,7 +874,7 @@ describe('ValueTree', () => {
 
       tree.commit();
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
     });
 
     it('clears patches from direct mutations after revert', () => {
@@ -886,7 +886,7 @@ describe('ValueTree', () => {
 
       tree.revert();
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
       expect(tree.getValue('name')).toBe('John');
     });
 
@@ -903,7 +903,7 @@ describe('ValueTree', () => {
         nameNode!.setValue('Bob');
       }
 
-      expect(tree.getPatches()).toEqual([
+      expect(tree.patches).toEqual([
         { op: 'replace', path: '/name', value: 'Bob' },
       ]);
     });
@@ -918,7 +918,7 @@ describe('ValueTree', () => {
         nameNode!.setValue('Jane');
       }
 
-      expect(tree.getPatches()).toEqual([]);
+      expect(tree.patches).toEqual([]);
     });
 
     it('tracks new nodes added to array via pushValue', () => {
@@ -938,7 +938,7 @@ describe('ValueTree', () => {
         newItemName!.setValue('Updated Item 2');
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(2);
       expect(patches[0]).toEqual({
         op: 'add',
@@ -965,7 +965,7 @@ describe('ValueTree', () => {
         nameNode!.setValue('ghost');
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       const setValuePatches = patches.filter((p) => p.op === 'replace' && p.path === '/name');
       expect(setValuePatches).toHaveLength(0);
     });
@@ -986,7 +986,7 @@ describe('ValueTree', () => {
         removedItemName!.setValue('ghost');
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       const ghostPatches = patches.filter((p) => p.op === 'replace');
       expect(ghostPatches).toHaveLength(0);
     });
@@ -1005,7 +1005,7 @@ describe('ValueTree', () => {
         itemsNode!.clear();
       }
 
-      const patchCountAfterClear = tree.getPatches().length;
+      const patchCountAfterClear = tree.patches.length;
 
       if (item1Name!.isPrimitive()) {
         item1Name!.setValue('ghost1');
@@ -1014,7 +1014,7 @@ describe('ValueTree', () => {
         item2Name!.setValue('ghost2');
       }
 
-      expect(tree.getPatches()).toHaveLength(patchCountAfterClear);
+      expect(tree.patches).toHaveLength(patchCountAfterClear);
     });
 
     it('unsubscribes old item and subscribes new item after array replaceAt', () => {
@@ -1035,7 +1035,7 @@ describe('ValueTree', () => {
         oldItemName!.setValue('ghost');
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       const ghostPatches = patches.filter((p) => p.op === 'replace' && 'value' in p && p.value === 'ghost');
       expect(ghostPatches).toHaveLength(0);
 
@@ -1045,7 +1045,7 @@ describe('ValueTree', () => {
         newItemName!.setValue('Updated New');
       }
 
-      const allPatches = tree.getPatches();
+      const allPatches = tree.patches;
       const updatePatch = allPatches.find((p) => p.op === 'replace' && 'value' in p && p.value === 'Updated New');
       expect(updatePatch).toBeDefined();
     });
@@ -1061,7 +1061,7 @@ describe('ValueTree', () => {
         itemsNode!.insertValueAt(1, { name: 'Inserted' });
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'add',
@@ -1083,7 +1083,7 @@ describe('ValueTree', () => {
         itemsNode!.replaceAt(0, newNode);
       }
 
-      const patches = tree.getPatches();
+      const patches = tree.patches;
       expect(patches).toHaveLength(1);
       expect(patches[0]).toEqual({
         op: 'replace',

--- a/src/model/value-tree/types.ts
+++ b/src/model/value-tree/types.ts
@@ -77,7 +77,7 @@ export interface ValueTreeLike {
   readonly isDirty: boolean;
   readonly isValid: boolean;
   readonly errors: readonly Diagnostic[];
-  getPatches(): readonly JsonValuePatch[];
+  readonly patches: readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
   nodeById(id: string): ValueNode | undefined;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make JSON Patch tracking observable and standardize the API by replacing getPatches() with a readonly patches getter on ValueTree and RowModel. This fixes non-reactive patch updates and keeps commit/revert semantics the same.

- **Bug Fixes**
  - Patches are now observable via ChangeTracker (makeAutoObservable), so UI reacts to changes immediately.

- **Migration**
  - Replace row.getPatches() with row.patches and tree.getPatches() with tree.patches.
  - commit() and revert() still clear patches; no other behavior changes.

<sup>Written for commit c57ef5c7643059ae94122f474fe0c1cef6b089b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

