### PR TITLE
fix: set-value

### DIFF
--- a/src/model/value-node/BasePrimitiveValueNode.ts
+++ b/src/model/value-node/BasePrimitiveValueNode.ts
@@ -93,8 +93,12 @@ export abstract class BasePrimitiveValueNode<T extends string | number | boolean
     if (this.isReadOnly && !options?.internal) {
       throw new Error(`Cannot set value on read-only field: ${this.name}`);
     }
+    const coercedValue = this.coerceValue(value);
+    if (coercedValue === this._value) {
+      return;
+    }
     const oldValue = this._value;
-    this._value = this.coerceValue(value);
+    this._value = coercedValue;
     if (!options?.internal) {
       this.emit({ type: 'setValue', node: this, value: this._value, oldValue });
     }

--- a/src/model/value-node/__tests__/NodeChangeEvents.spec.ts
+++ b/src/model/value-node/__tests__/NodeChangeEvents.spec.ts
@@ -42,6 +42,16 @@ describe('NodeChangeEvents', () => {
       expect(events).toHaveLength(0);
     });
 
+    it('does not emit when value is the same', () => {
+      const node = new StringValueNode(undefined, 'name', str(), 'John');
+      const events: NodeChangeEvent[] = [];
+      node.on('change', (e) => events.push(e));
+
+      node.setValue('John');
+
+      expect(events).toHaveLength(0);
+    });
+
     it('supports off to unsubscribe', () => {
       const node = new StringValueNode(undefined, 'name', str(), 'John');
       const events: NodeChangeEvent[] = [];

--- a/src/model/value-tree/__tests__/ValueTree.spec.ts
+++ b/src/model/value-tree/__tests__/ValueTree.spec.ts
@@ -1091,5 +1091,43 @@ describe('ValueTree', () => {
         value: { name: 'Replaced' },
       });
     });
+
+    it('does not generate patch when setValue called with same value', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      const nameNode = tree.get('name');
+      expect(nameNode).toBeDefined();
+
+      if (nameNode!.isPrimitive()) {
+        nameNode!.setValue('John');
+      }
+
+      expect(tree.patches).toEqual([]);
+    });
+
+    it('does not mark dirty when setValue called with same value', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      const nameNode = tree.get('name');
+      expect(nameNode).toBeDefined();
+
+      if (nameNode!.isPrimitive()) {
+        nameNode!.setValue('John');
+      }
+
+      expect(tree.isDirty).toBe(false);
+    });
+
+    it('generates patch when setValue called with different value', () => {
+      const tree = createTree(createSimpleSchema(), { name: 'John', age: 30 });
+      const nameNode = tree.get('name');
+      expect(nameNode).toBeDefined();
+
+      if (nameNode!.isPrimitive()) {
+        nameNode!.setValue('Jane');
+      }
+
+      expect(tree.patches).toEqual([
+        { op: 'replace', path: '/name', value: 'Jane' },
+      ]);
+    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Avoid unnecessary updates when setValue is called with the same value on primitive nodes. This stops emitting change events, patches, and dirty state churn.

- **Bug Fixes**
  - Added early return in BasePrimitiveValueNode.setValue when coerced value equals current.
  - Tests cover: no change event, no patches, not dirty for same value; patch emitted for different value.

<sup>Written for commit a2eea43af12be137bc13efbc02ef7d0e1b177703. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

