### PR TITLE
feat: self referencing schema support

### DIFF
--- a/src/core/schema-diff/SchemaComparator.ts
+++ b/src/core/schema-diff/SchemaComparator.ts
@@ -28,16 +28,16 @@ export function areNodesEqual(
     return arePrimitivesEqual(current, base, context);
   }
 
+  if (current.isRef()) {
+    return current.ref() === base.ref();
+  }
+
   if (current.isObject()) {
     return areObjectsEqual(current, base, context);
   }
 
   if (current.isArray()) {
     return areArraysEqual(current, base, context);
-  }
-
-  if (current.isRef()) {
-    return current.ref() === base.ref();
   }
 
   return current.isNull() && base.isNull();
@@ -60,16 +60,16 @@ export function areNodesContentEqual(
     return arePrimitivesEqual(current, base, context);
   }
 
+  if (current.isRef()) {
+    return current.ref() === base.ref();
+  }
+
   if (current.isObject()) {
     return areObjectsEqual(current, base, context);
   }
 
   if (current.isArray()) {
     return areArraysEqual(current, base, context);
-  }
-
-  if (current.isRef()) {
-    return current.ref() === base.ref();
   }
 
   return current.isNull() && base.isNull();

--- a/src/core/schema-diff/SchemaComparator.ts
+++ b/src/core/schema-diff/SchemaComparator.ts
@@ -12,35 +12,11 @@ export function areNodesEqual(
   base: SchemaNode,
   context: ComparatorContext,
 ): boolean {
-  if (current.nodeType() !== base.nodeType()) {
-    return false;
-  }
-
   if (current.name() !== base.name()) {
     return false;
   }
 
-  if (!areMetadataEqual(current, base)) {
-    return false;
-  }
-
-  if (current.isPrimitive()) {
-    return arePrimitivesEqual(current, base, context);
-  }
-
-  if (current.isRef()) {
-    return current.ref() === base.ref();
-  }
-
-  if (current.isObject()) {
-    return areObjectsEqual(current, base, context);
-  }
-
-  if (current.isArray()) {
-    return areArraysEqual(current, base, context);
-  }
-
-  return current.isNull() && base.isNull();
+  return areNodesContentEqual(current, base, context);
 }
 
 export function areNodesContentEqual(

--- a/src/model/schema-model/__tests__/test-helpers.ts
+++ b/src/model/schema-model/__tests__/test-helpers.ts
@@ -1,5 +1,5 @@
-import type { JsonObjectSchema } from '../../../types/index.js';
-import { obj, str, num, arr } from '../../../mocks/schema.mocks.js';
+import type { JsonObjectSchema, JsonSchema } from '../../../types/index.js';
+import { obj, str, num, arr, ref } from '../../../mocks/schema.mocks.js';
 import { createSchemaModel } from '../SchemaModelImpl.js';
 import type { SchemaModel } from '../types.js';
 
@@ -40,6 +40,22 @@ export const schemaWithForeignKey = (): JsonObjectSchema =>
   obj({
     categoryId: str({ foreignKey: 'categories' }),
   });
+
+export const selfRefSchema = (): { schema: JsonObjectSchema; refSchemas: Record<string, JsonSchema> } => {
+  const schema = obj({
+    name: str(),
+    child: ref('self'),
+  });
+  return { schema, refSchemas: { self: schema } };
+};
+
+export const selfRefArraySchema = (): { schema: JsonObjectSchema; refSchemas: Record<string, JsonSchema> } => {
+  const schema = obj({
+    name: str(),
+    children: arr(ref('self')),
+  });
+  return { schema, refSchemas: { self: schema } };
+};
 
 export const createModel = (schema: JsonObjectSchema): SchemaModel => {
   return createSchemaModel(schema);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add self-referencing schema support. Cyclic refs ($ref: 'self') now parse safely and serialize/diff correctly; minor sonar lint cleanups.

- **New Features**
  - Parser guards cycles using a resolving-ref set; returns a ref node for self while expanding other refs.
  - Comparator compares names then content; ref nodes equal by ref value for stable diffs.
  - Serializer preserves $ref: 'self'. Tests cover objects, arrays, mixed refs; identical schemas show no diffs.

<sup>Written for commit 096d148c6acff019aaf83847f7097d8b3341244e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

