### PR TITLE
fix: content media type diff

### DIFF
--- a/src/core/schema-diff/SchemaComparator.ts
+++ b/src/core/schema-diff/SchemaComparator.ts
@@ -75,6 +75,10 @@ function arePrimitivesEqual(
     return false;
   }
 
+  if (current.contentMediaType() !== base.contentMediaType()) {
+    return false;
+  }
+
   const currentFormula = current.formula();
   const baseFormula = base.formula();
 

--- a/src/core/schema-diff/__tests__/ChangeCollector.spec.ts
+++ b/src/core/schema-diff/__tests__/ChangeCollector.spec.ts
@@ -166,6 +166,80 @@ describe('ChangeCollector', () => {
     });
   });
 
+  describe('contentMediaType changes', () => {
+    it('detects modified contentMediaType', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { contentMediaType: 'text/markdown' }),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const fieldChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'name',
+      );
+      expect(fieldChange).toBeDefined();
+      expect(fieldChange?.baseNode?.contentMediaType()).toBeUndefined();
+      expect(fieldChange?.currentNode?.contentMediaType()).toBe('text/markdown');
+    });
+
+    it('detects contentMediaType change between types', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { contentMediaType: 'text/plain' }),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { contentMediaType: 'text/markdown' }),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const fieldChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'name',
+      );
+      expect(fieldChange).toBeDefined();
+      expect(fieldChange?.baseNode?.contentMediaType()).toBe('text/plain');
+      expect(fieldChange?.currentNode?.contentMediaType()).toBe('text/markdown');
+    });
+
+    it('detects contentMediaType removal', () => {
+      const baseRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name', { contentMediaType: 'text/markdown' }),
+      ]);
+      const currentRoot = createObjectNode('root', 'root', [
+        createStringNode('name', 'name'),
+      ]);
+
+      const baseTree = createSchemaTree(baseRoot);
+      const currentTree = createSchemaTree(currentRoot);
+      const index = new NodePathIndex(baseTree);
+
+      const collector = new ChangeCollector(baseTree, currentTree, index);
+      const changes = collector.collect();
+
+      const modifiedChanges = changes.filter((c) => c.type === 'modified');
+      const fieldChange = modifiedChanges.find(
+        (c) => c.currentNode?.name() === 'name',
+      );
+      expect(fieldChange).toBeDefined();
+      expect(fieldChange?.baseNode?.contentMediaType()).toBe('text/markdown');
+      expect(fieldChange?.currentNode?.contentMediaType()).toBeUndefined();
+    });
+  });
+
   describe('moved nodes (renamed)', () => {
     it('detects renamed field as moved only when content unchanged', () => {
       const baseRoot = createObjectNode('root', 'root', [

--- a/src/model/schema-model/SchemaParser.ts
+++ b/src/model/schema-model/SchemaParser.ts
@@ -137,6 +137,7 @@ export class SchemaParser {
     return createStringNode(nodeId, name, {
       defaultValue: schema.default,
       foreignKey: schema.foreignKey,
+      contentMediaType: schema.contentMediaType,
       metadata: this.extractMetadata(schema),
       ref,
     });

--- a/src/model/schema-model/__tests__/SchemaParser.additional.spec.ts
+++ b/src/model/schema-model/__tests__/SchemaParser.additional.spec.ts
@@ -76,6 +76,31 @@ describe('SchemaParser additional coverage', () => {
     });
   });
 
+
+  describe('contentMediaType', () => {
+    it('parses string field with contentMediaType', () => {
+      const schema = obj({
+        content: str({ contentMediaType: 'text/markdown' }),
+      });
+
+      const node = parser.parse(schema);
+
+      const content = node.property('content');
+      expect(content.nodeType()).toBe('string');
+      expect(content.contentMediaType()).toBe('text/markdown');
+    });
+
+    it('parses string field without contentMediaType as undefined', () => {
+      const schema = obj({
+        name: str(),
+      });
+
+      const node = parser.parse(schema);
+
+      expect(node.property('name').contentMediaType()).toBeUndefined();
+    });
+  });
+
   describe('nested arrays', () => {
     it('parses nested array with object items', () => {
       const schema = obj({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Detect changes to contentMediaType in schema diffs for string fields. Fixes missing modified events when media type is added, changed, or removed.

- **Bug Fixes**
  - Compare contentMediaType in primitive equality checks.
  - Parse contentMediaType for string nodes in SchemaParser.
  - Added tests for added/changed/removed media types and parser coverage.

<sup>Written for commit 1d964b8e6aa3bdb7ebf4050adb3950475a8fa37c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

