### PR TITLE
feat: revisium validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@revisium/formula": "^0.10.0",
+        "ajv": "^8.18.0",
         "eventemitter3": "^5.0.4",
         "nanoid": "^3.3.7"
       },
@@ -18,7 +19,6 @@
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^24.10.7",
-        "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "eslint": "^9.15.0",
         "globals": "^15.12.0",
@@ -2600,10 +2600,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3624,7 +3623,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3675,7 +3673,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4943,7 +4940,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5846,7 +5842,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.10.7",
-    "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "eslint": "^9.15.0",
     "globals": "^15.12.0",
@@ -187,6 +186,7 @@
   },
   "dependencies": {
     "@revisium/formula": "^0.10.0",
+    "ajv": "^8.18.0",
     "eventemitter3": "^5.0.4",
     "nanoid": "^3.3.7"
   },

--- a/src/lib/__tests__/calculateDataWeight.spec.ts
+++ b/src/lib/__tests__/calculateDataWeight.spec.ts
@@ -1,0 +1,162 @@
+import { calculateDataWeight } from '../calculateDataWeight.js';
+
+describe('calculateDataWeight', () => {
+  it('should handle empty object', () => {
+    const result = calculateDataWeight({});
+
+    expect(result).toEqual({
+      totalBytes: 2,
+      totalNodes: 1,
+      maxDepth: 0,
+      maxArrayLength: 0,
+      maxStringLength: 0,
+      totalStringsBytes: 0,
+    });
+  });
+
+  it('should count primitive values', () => {
+    const result = calculateDataWeight({ name: 'Alice', age: 30, active: true });
+
+    expect(result).toEqual({
+      totalBytes: 39,
+      totalNodes: 4,
+      maxDepth: 1,
+      maxArrayLength: 0,
+      maxStringLength: 5,
+      totalStringsBytes: 5,
+    });
+  });
+
+  it('should track max array length', () => {
+    const result = calculateDataWeight({ items: [1, 2, 3, 4, 5], tags: ['a', 'b'] });
+
+    expect(result).toEqual({
+      totalBytes: 38,
+      totalNodes: 10,
+      maxDepth: 2,
+      maxArrayLength: 5,
+      maxStringLength: 1,
+      totalStringsBytes: 2,
+    });
+  });
+
+  it('should track max string length', () => {
+    const result = calculateDataWeight({ short: 'ab', long: 'hello world' });
+
+    expect(result).toEqual({
+      totalBytes: 35,
+      totalNodes: 3,
+      maxDepth: 1,
+      maxArrayLength: 0,
+      maxStringLength: 11,
+      totalStringsBytes: 13,
+    });
+  });
+
+  it('should sum all string bytes', () => {
+    const result = calculateDataWeight({ a: 'foo', b: 'bar', c: 'baz' });
+
+    expect(result).toEqual({
+      totalBytes: 31,
+      totalNodes: 4,
+      maxDepth: 1,
+      maxArrayLength: 0,
+      maxStringLength: 3,
+      totalStringsBytes: 9,
+    });
+  });
+
+  it('should handle nested objects', () => {
+    const result = calculateDataWeight({
+      level1: {
+        level2: {
+          value: 'deep',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      totalBytes: 38,
+      totalNodes: 4,
+      maxDepth: 3,
+      maxArrayLength: 0,
+      maxStringLength: 4,
+      totalStringsBytes: 4,
+    });
+  });
+
+  it('should handle nested arrays', () => {
+    const result = calculateDataWeight({
+      matrix: [
+        [1, 2],
+        [3, 4, 5],
+      ],
+    });
+
+    expect(result).toEqual({
+      totalBytes: 26,
+      totalNodes: 9,
+      maxDepth: 3,
+      maxArrayLength: 3,
+      maxStringLength: 0,
+      totalStringsBytes: 0,
+    });
+  });
+
+  it('should handle null values', () => {
+    const result = calculateDataWeight({ a: null, b: 'test' });
+
+    expect(result).toEqual({
+      totalBytes: 21,
+      totalNodes: 3,
+      maxDepth: 1,
+      maxArrayLength: 0,
+      maxStringLength: 4,
+      totalStringsBytes: 4,
+    });
+  });
+
+  it('should handle empty arrays', () => {
+    const result = calculateDataWeight({ items: [] });
+
+    expect(result).toEqual({
+      totalBytes: 12,
+      totalNodes: 2,
+      maxDepth: 1,
+      maxArrayLength: 0,
+      maxStringLength: 0,
+      totalStringsBytes: 0,
+    });
+  });
+
+  it('should handle array of objects', () => {
+    const result = calculateDataWeight({
+      users: [
+        { name: 'Alice', tags: ['admin', 'user'] },
+        { name: 'Bob', tags: ['user'] },
+      ],
+    });
+
+    expect(result).toEqual({
+      totalBytes: 83,
+      totalNodes: 11,
+      maxDepth: 4,
+      maxArrayLength: 2,
+      maxStringLength: 5,
+      totalStringsBytes: 21,
+    });
+  });
+
+  it('should count all nodes including containers', () => {
+    const result = calculateDataWeight({ arr: [1, 2], obj: { x: 'y' } });
+
+    expect(result).toEqual({
+      totalBytes: 29,
+      totalNodes: 6,
+      maxDepth: 2,
+      maxArrayLength: 2,
+      maxStringLength: 1,
+      totalStringsBytes: 1,
+    });
+  });
+});

--- a/src/lib/__tests__/calculateSchemaWeight.spec.ts
+++ b/src/lib/__tests__/calculateSchemaWeight.spec.ts
@@ -1,0 +1,317 @@
+import { JsonObjectSchema } from '../../types/schema.types.js';
+import { calculateSchemaWeight } from '../calculateSchemaWeight.js';
+
+describe('calculateSchemaWeight', () => {
+  it('should return zero for empty schema', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+      required: [],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 0,
+      maxDepth: 0,
+      fieldNames: 0,
+      totalArrays: 0,
+      maxArrayDepth: 0,
+    });
+  });
+
+  it('should count flat properties', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', default: '' },
+        age: { type: 'number', default: 0 },
+        active: { type: 'boolean', default: false },
+      },
+      additionalProperties: false,
+      required: ['name', 'age', 'active'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 3,
+      maxDepth: 1,
+      fieldNames: 13,
+      totalArrays: 0,
+      maxArrayDepth: 0,
+    });
+  });
+
+  it('should count nested object fields', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: {
+            city: { type: 'string', default: '' },
+            zip: { type: 'string', default: '' },
+          },
+          additionalProperties: false,
+          required: ['city', 'zip'],
+        },
+      },
+      additionalProperties: false,
+      required: ['address'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 3,
+      maxDepth: 2,
+      fieldNames: 14,
+      totalArrays: 0,
+      maxArrayDepth: 0,
+    });
+  });
+
+  it('should handle deeply nested objects', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'object',
+          properties: {
+            b: {
+              type: 'object',
+              properties: {
+                c: { type: 'string', default: '' },
+              },
+              additionalProperties: false,
+              required: ['c'],
+            },
+          },
+          additionalProperties: false,
+          required: ['b'],
+        },
+      },
+      additionalProperties: false,
+      required: ['a'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 3,
+      maxDepth: 3,
+      fieldNames: 3,
+      totalArrays: 0,
+      maxArrayDepth: 0,
+    });
+  });
+
+  it('should count $ref as a field but not traverse it', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', default: '' },
+        related: { $ref: 'other-table' },
+      },
+      additionalProperties: false,
+      required: ['name', 'related'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 2,
+      maxDepth: 1,
+      fieldNames: 11,
+      totalArrays: 0,
+      maxArrayDepth: 0,
+    });
+  });
+
+  it('should traverse array items with object schema', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', default: '' },
+              price: { type: 'number', default: 0 },
+            },
+            additionalProperties: false,
+            required: ['title', 'price'],
+          },
+        },
+      },
+      additionalProperties: false,
+      required: ['items'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 3,
+      maxDepth: 3,
+      fieldNames: 15,
+      totalArrays: 1,
+      maxArrayDepth: 1,
+    });
+  });
+
+  it('should handle array with primitive items', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string', default: '' },
+        },
+      },
+      additionalProperties: false,
+      required: ['tags'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 1,
+      maxDepth: 2,
+      fieldNames: 4,
+      totalArrays: 1,
+      maxArrayDepth: 1,
+    });
+  });
+
+  it('should sum field name lengths with long names', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        x: { type: 'string', default: '' },
+        longFieldName: { type: 'string', default: '' },
+        anotherLongFieldName: { type: 'number', default: 0 },
+      },
+      additionalProperties: false,
+      required: ['x', 'longFieldName', 'anotherLongFieldName'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 3,
+      maxDepth: 1,
+      fieldNames: 34,
+      totalArrays: 0,
+      maxArrayDepth: 0,
+    });
+  });
+
+  it('should count multiple arrays at same level', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string', default: '' },
+        },
+        scores: {
+          type: 'array',
+          items: { type: 'number', default: 0 },
+        },
+      },
+      additionalProperties: false,
+      required: ['tags', 'scores'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 2,
+      maxDepth: 2,
+      fieldNames: 10,
+      totalArrays: 2,
+      maxArrayDepth: 1,
+    });
+  });
+
+  it('should track nested array depth', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                items: { type: 'string', default: '' },
+              },
+            },
+            additionalProperties: false,
+            required: ['tags'],
+          },
+        },
+      },
+      additionalProperties: false,
+      required: ['items'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 2,
+      maxDepth: 4,
+      fieldNames: 9,
+      totalArrays: 2,
+      maxArrayDepth: 2,
+    });
+  });
+
+  it('should track deeply nested arrays', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        l1: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              l2: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    l3: {
+                      type: 'array',
+                      items: { type: 'string', default: '' },
+                    },
+                  },
+                  additionalProperties: false,
+                  required: ['l3'],
+                },
+              },
+            },
+            additionalProperties: false,
+            required: ['l2'],
+          },
+        },
+      },
+      additionalProperties: false,
+      required: ['l1'],
+    };
+
+    const result = calculateSchemaWeight(schema);
+
+    expect(result).toEqual({
+      totalFields: 3,
+      maxDepth: 6,
+      fieldNames: 6,
+      totalArrays: 3,
+      maxArrayDepth: 3,
+    });
+  });
+});

--- a/src/lib/__tests__/createRevisiumValidator.spec.ts
+++ b/src/lib/__tests__/createRevisiumValidator.spec.ts
@@ -1,0 +1,355 @@
+import { SystemSchemaIds } from '../../consts/system-schema-ids.js';
+import { RevisiumValidator } from '../createRevisiumValidator.js';
+
+describe('RevisiumValidator', () => {
+  let validator: RevisiumValidator;
+
+  beforeAll(() => {
+    validator = new RevisiumValidator();
+  });
+
+  describe('validateMetaSchema', () => {
+    it('accepts valid schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string', default: '' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+
+      expect(validator.validateMetaSchema(schema)).toBe(true);
+      expect(validator.validateMetaSchema.errors).toBeNull();
+    });
+
+    it('rejects schema missing default', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        additionalProperties: false,
+        required: ['name'],
+      };
+
+      expect(validator.validateMetaSchema(schema)).toBe(false);
+      expect(validator.validateMetaSchema.errors).not.toBeNull();
+    });
+  });
+
+  describe('validateJsonPatch', () => {
+    it('accepts valid patch', () => {
+      const patch = [
+        {
+          op: 'add',
+          path: '/field',
+          value: { type: 'string', default: '' },
+        },
+      ];
+
+      expect(validator.validateJsonPatch(patch)).toBe(true);
+      expect(validator.validateJsonPatch.errors).toBeNull();
+    });
+
+    it('rejects patch missing op', () => {
+      const patch = [{ path: '/field' }];
+
+      expect(validator.validateJsonPatch(patch)).toBe(false);
+      expect(validator.validateJsonPatch.errors).not.toBeNull();
+    });
+  });
+
+  describe('validateMigrations', () => {
+    it('accepts valid init migration', () => {
+      const migration = {
+        changeType: 'init',
+        tableId: 'table1',
+        hash: 'abc123',
+        id: 'mig1',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', default: '' },
+          },
+          additionalProperties: false,
+          required: ['name'],
+        },
+      };
+
+      expect(validator.validateMigrations(migration)).toBe(true);
+      expect(validator.validateMigrations.errors).toBeNull();
+    });
+
+    it('accepts valid update migration', () => {
+      const migration = {
+        changeType: 'update',
+        tableId: 'table1',
+        hash: 'abc123',
+        id: 'mig2',
+        patches: [
+          {
+            op: 'add',
+            path: '/age',
+            value: { type: 'number', default: 0 },
+          },
+        ],
+      };
+
+      expect(validator.validateMigrations(migration)).toBe(true);
+      expect(validator.validateMigrations.errors).toBeNull();
+    });
+
+    it('accepts valid rename migration', () => {
+      const migration = {
+        changeType: 'rename',
+        id: 'mig3',
+        tableId: 'table1',
+        nextTableId: 'table2',
+      };
+
+      expect(validator.validateMigrations(migration)).toBe(true);
+      expect(validator.validateMigrations.errors).toBeNull();
+    });
+
+    it('accepts valid remove migration', () => {
+      const migration = {
+        changeType: 'remove',
+        id: 'mig4',
+        tableId: 'table1',
+      };
+
+      expect(validator.validateMigrations(migration)).toBe(true);
+      expect(validator.validateMigrations.errors).toBeNull();
+    });
+
+    it('rejects invalid migration', () => {
+      const migration = {
+        changeType: 'unknown',
+        tableId: 'table1',
+      };
+
+      expect(validator.validateMigrations(migration)).toBe(false);
+      expect(validator.validateMigrations.errors).not.toBeNull();
+    });
+  });
+
+  describe('validateHistoryPatches', () => {
+    it('accepts valid history patches', () => {
+      const data = [
+        {
+          patches: [
+            {
+              op: 'add',
+              path: '/field',
+              value: { type: 'string', default: '' },
+            },
+          ],
+          hash: 'abc123',
+        },
+      ];
+
+      expect(validator.validateHistoryPatches(data)).toBe(true);
+      expect(validator.validateHistoryPatches.errors).toBeNull();
+    });
+
+    it('rejects invalid history patches', () => {
+      const data = [{ hash: 'abc123' }];
+
+      expect(validator.validateHistoryPatches(data)).toBe(false);
+      expect(validator.validateHistoryPatches.errors).not.toBeNull();
+    });
+  });
+
+  describe('validateTableViews', () => {
+    it('accepts valid views data', () => {
+      const data = {
+        version: 1,
+        defaultViewId: 'default',
+        views: [{ id: 'default', name: 'Default' }],
+      };
+
+      expect(validator.validateTableViews(data)).toBe(true);
+      expect(validator.validateTableViews.errors).toBeNull();
+    });
+
+    it('rejects invalid views data', () => {
+      const data = {
+        version: 'not-a-number',
+        views: [],
+      };
+
+      expect(validator.validateTableViews(data)).toBe(false);
+      expect(validator.validateTableViews.errors).not.toBeNull();
+    });
+  });
+
+  describe('compile', () => {
+    it('validates data against dynamic user schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['name', 'age'],
+        additionalProperties: false,
+      };
+
+      const validate = validator.compile(schema);
+
+      expect(validate({ name: 'Alice', age: 30 })).toBe(true);
+      expect(validate.errors).toBeNull();
+
+      expect(validate({ name: 'Alice' })).toBe(false);
+      expect(validate.errors).not.toBeNull();
+    });
+
+    it('caches compiled validators', () => {
+      const schema = {
+        type: 'object',
+        properties: { x: { type: 'number' } },
+        required: ['x'],
+      };
+
+      const fn1 = validator.compile(schema);
+      const fn2 = validator.compile(schema);
+
+      expect(fn1).toBe(fn2);
+    });
+
+    it('resolves $ref to plugin schemas', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { $ref: SystemSchemaIds.RowId },
+        },
+        required: ['id'],
+      };
+
+      const validate = validator.compile(schema);
+
+      expect(validate({ id: 'row-1' })).toBe(true);
+      expect(validate.errors).toBeNull();
+
+      expect(validate({ id: 123 })).toBe(false);
+      expect(validate.errors).not.toBeNull();
+    });
+  });
+
+  describe('regex format', () => {
+    it('accepts valid regex pattern in meta schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            default: '',
+            pattern: '^[A-Z]{3}$',
+          },
+        },
+        additionalProperties: false,
+        required: ['code'],
+      };
+
+      expect(validator.validateMetaSchema(schema)).toBe(true);
+      expect(validator.validateMetaSchema.errors).toBeNull();
+    });
+
+    it('rejects invalid regex pattern in meta schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            default: '',
+            pattern: '[invalid',
+          },
+        },
+        additionalProperties: false,
+        required: ['code'],
+      };
+
+      expect(validator.validateMetaSchema(schema)).toBe(false);
+      expect(validator.validateMetaSchema.errors).not.toBeNull();
+    });
+  });
+
+  describe('custom keywords', () => {
+    it('accepts schema with foreignKey', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          authorId: {
+            type: 'string',
+            default: '',
+            foreignKey: 'authors',
+          },
+        },
+        additionalProperties: false,
+        required: ['authorId'],
+      };
+
+      expect(validator.validateMetaSchema(schema)).toBe(true);
+      expect(validator.validateMetaSchema.errors).toBeNull();
+    });
+
+    it('accepts schema with x-formula', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          total: {
+            type: 'number',
+            default: 0,
+            readOnly: true,
+            'x-formula': { version: 1, expression: 'price * qty' },
+          },
+        },
+        additionalProperties: false,
+        required: ['total'],
+      };
+
+      expect(validator.validateMetaSchema(schema)).toBe(true);
+      expect(validator.validateMetaSchema.errors).toBeNull();
+    });
+  });
+
+  describe('error structure', () => {
+    it('returns ValidationError with expected fields', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name'],
+      };
+
+      const validate = validator.compile(schema);
+      validate({});
+
+      expect(validate.errors).not.toBeNull();
+      expect(validate.errors!.length).toBeGreaterThan(0);
+      const error = validate.errors![0]!;
+      expect(error).toHaveProperty('instancePath');
+      expect(error).toHaveProperty('keyword');
+      expect(error).toHaveProperty('params');
+      expect(typeof error.keyword).toBe('string');
+      expect(typeof error.params).toBe('object');
+    });
+
+    it('returns null errors on success', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name'],
+      };
+
+      const validate = validator.compile(schema);
+      validate({ name: 'test' });
+
+      expect(validate.errors).toBeNull();
+    });
+  });
+});

--- a/src/lib/__tests__/validateRevisiumSchema.spec.ts
+++ b/src/lib/__tests__/validateRevisiumSchema.spec.ts
@@ -1,0 +1,241 @@
+import { JsonObjectSchema } from '../../types/schema.types.js';
+import { validateRevisiumSchema } from '../validateRevisiumSchema.js';
+
+describe('validateRevisiumSchema', () => {
+  it('should validate a correct schema', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', default: '' },
+        age: { type: 'number', default: 0 },
+      },
+      additionalProperties: false,
+      required: ['name', 'age'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it('should reject schema with missing required fields', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      additionalProperties: false,
+      required: ['name'],
+    } as unknown as JsonObjectSchema;
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+  });
+
+  it('should validate schema with nested objects', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: {
+            city: { type: 'string', default: '' },
+            zip: { type: 'string', default: '' },
+          },
+          additionalProperties: false,
+          required: ['city', 'zip'],
+        },
+      },
+      additionalProperties: false,
+      required: ['address'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should validate schema with arrays', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string', default: '' },
+        },
+      },
+      additionalProperties: false,
+      required: ['tags'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should validate schema with boolean fields', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        active: { type: 'boolean', default: false },
+      },
+      additionalProperties: false,
+      required: ['active'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should validate schema with $ref', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        related: { $ref: 'other-table' },
+      },
+      additionalProperties: false,
+      required: ['related'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject schema with invalid type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        field: { type: 'invalid', default: '' },
+      },
+      additionalProperties: false,
+      required: ['field'],
+    } as unknown as JsonObjectSchema;
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+  });
+
+  it('should validate schema with string pattern', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        email: {
+          type: 'string',
+          default: '',
+          pattern: '^[a-z]+$',
+        },
+      },
+      additionalProperties: false,
+      required: ['email'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject schema with invalid regex pattern', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        field: {
+          type: 'string',
+          default: '',
+          pattern: '[invalid',
+        },
+      },
+      additionalProperties: false,
+      required: ['field'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+  });
+
+  it('should validate schema with x-formula', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        price: { type: 'number', default: 0 },
+        tax: {
+          type: 'number',
+          default: 0,
+          readOnly: true,
+          'x-formula': { version: 1, expression: 'price * 0.1' },
+        },
+      },
+      additionalProperties: false,
+      required: ['price', 'tax'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should format error messages with instancePath', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      additionalProperties: false,
+      required: ['name'],
+    } as unknown as JsonObjectSchema;
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    for (const error of result.errors!) {
+      expect(typeof error).toBe('string');
+      expect(error).toContain(':');
+    }
+  });
+
+  it('should validate schema with foreignKey', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        authorId: {
+          type: 'string',
+          default: '',
+          foreignKey: 'authors',
+        },
+      },
+      additionalProperties: false,
+      required: ['authorId'],
+    };
+
+    const result = validateRevisiumSchema(schema);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should return same result on repeated calls (singleton validator)', () => {
+    const schema: JsonObjectSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', default: '' },
+      },
+      additionalProperties: false,
+      required: ['name'],
+    };
+
+    const result1 = validateRevisiumSchema(schema);
+    const result2 = validateRevisiumSchema(schema);
+
+    expect(result1.valid).toBe(true);
+    expect(result2.valid).toBe(true);
+  });
+});

--- a/src/lib/__tests__/validateRevisiumSchema.spec.ts
+++ b/src/lib/__tests__/validateRevisiumSchema.spec.ts
@@ -19,7 +19,7 @@ describe('validateRevisiumSchema', () => {
     expect(result.errors).toBeUndefined();
   });
 
-  it('should reject schema with missing required fields', () => {
+  it('should reject schema with missing default', () => {
     const schema = {
       type: 'object',
       properties: {

--- a/src/lib/calculateDataWeight.ts
+++ b/src/lib/calculateDataWeight.ts
@@ -6,7 +6,7 @@ export interface DataWeight {
   maxDepth: number;
   maxArrayLength: number;
   maxStringLength: number;
-  totalStringsBytes: number;
+  totalStringsLength: number;
 }
 
 export const calculateDataWeight = (data: unknown): DataWeight => {
@@ -16,7 +16,7 @@ export const calculateDataWeight = (data: unknown): DataWeight => {
     maxDepth: 0,
     maxArrayLength: 0,
     maxStringLength: 0,
-    totalStringsBytes: 0,
+    totalStringsLength: 0,
   };
 
   result.totalBytes = JSON.stringify(data).length;
@@ -39,7 +39,7 @@ const walkValue = (value: unknown, depth: number, result: DataWeight): void => {
     if (value.length > result.maxStringLength) {
       result.maxStringLength = value.length;
     }
-    result.totalStringsBytes += value.length;
+    result.totalStringsLength += value.length;
     return;
   }
 
@@ -73,7 +73,7 @@ export const calculateDataWeightFromStore = (
     maxDepth: 0,
     maxArrayLength: 0,
     maxStringLength: 0,
-    totalStringsBytes: 0,
+    totalStringsLength: 0,
   };
 
   result.totalBytes = JSON.stringify(store.getPlainValue()).length;
@@ -97,7 +97,7 @@ const walkStore = (
     if (val.length > result.maxStringLength) {
       result.maxStringLength = val.length;
     }
-    result.totalStringsBytes += val.length;
+    result.totalStringsLength += val.length;
   } else if (store.type === 'object') {
     for (const child of Object.values(store.value)) {
       walkStore(child, depth + 1, result);

--- a/src/lib/calculateDataWeight.ts
+++ b/src/lib/calculateDataWeight.ts
@@ -1,0 +1,113 @@
+import { JsonValueStore } from '../model/value/json-value.store.js';
+
+export interface DataWeight {
+  totalBytes: number;
+  totalNodes: number;
+  maxDepth: number;
+  maxArrayLength: number;
+  maxStringLength: number;
+  totalStringsBytes: number;
+}
+
+export const calculateDataWeight = (data: unknown): DataWeight => {
+  const result: DataWeight = {
+    totalBytes: 0,
+    totalNodes: 0,
+    maxDepth: 0,
+    maxArrayLength: 0,
+    maxStringLength: 0,
+    totalStringsBytes: 0,
+  };
+
+  result.totalBytes = JSON.stringify(data).length;
+  walkValue(data, 0, result);
+  return result;
+};
+
+const walkValue = (value: unknown, depth: number, result: DataWeight): void => {
+  result.totalNodes++;
+
+  if (result.maxDepth < depth) {
+    result.maxDepth = depth;
+  }
+
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    if (value.length > result.maxStringLength) {
+      result.maxStringLength = value.length;
+    }
+    result.totalStringsBytes += value.length;
+    return;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length > result.maxArrayLength) {
+      result.maxArrayLength = value.length;
+    }
+    for (const item of value) {
+      walkValue(item, depth + 1, result);
+    }
+    return;
+  }
+
+  if (typeof value === 'object') {
+    for (const val of Object.values(value)) {
+      walkValue(val, depth + 1, result);
+    }
+  }
+};
+
+export const calculateDataWeightFromStore = (
+  store: JsonValueStore,
+): DataWeight => {
+  const result: DataWeight = {
+    totalBytes: 0,
+    totalNodes: 0,
+    maxDepth: 0,
+    maxArrayLength: 0,
+    maxStringLength: 0,
+    totalStringsBytes: 0,
+  };
+
+  result.totalBytes = JSON.stringify(store.getPlainValue()).length;
+  walkStore(store, 0, result);
+  return result;
+};
+
+const walkStore = (
+  store: JsonValueStore,
+  depth: number,
+  result: DataWeight,
+): void => {
+  result.totalNodes++;
+
+  if (result.maxDepth < depth) {
+    result.maxDepth = depth;
+  }
+
+  if (store.type === 'string') {
+    const val = store.getPlainValue();
+    if (val.length > result.maxStringLength) {
+      result.maxStringLength = val.length;
+    }
+    result.totalStringsBytes += val.length;
+  } else if (store.type === 'object') {
+    for (const child of Object.values(store.value)) {
+      walkStore(child, depth + 1, result);
+    }
+  } else if (store.type === 'array') {
+    if (store.value.length > result.maxArrayLength) {
+      result.maxArrayLength = store.value.length;
+    }
+    for (const child of store.value) {
+      walkStore(child, depth + 1, result);
+    }
+  }
+};

--- a/src/lib/calculateSchemaWeight.ts
+++ b/src/lib/calculateSchemaWeight.ts
@@ -1,0 +1,56 @@
+import { JsonObjectSchema, JsonSchema } from '../types/schema.types.js';
+
+export interface SchemaWeight {
+  totalFields: number;
+  maxDepth: number;
+  fieldNames: number;
+  totalArrays: number;
+  maxArrayDepth: number;
+}
+
+export const calculateSchemaWeight = (
+  schema: JsonObjectSchema,
+): SchemaWeight => {
+  const result: SchemaWeight = {
+    totalFields: 0,
+    maxDepth: 0,
+    fieldNames: 0,
+    totalArrays: 0,
+    maxArrayDepth: 0,
+  };
+
+  walkSchema(schema, 0, 0, result);
+  return result;
+};
+
+const walkSchema = (
+  schema: JsonSchema,
+  depth: number,
+  arrayDepth: number,
+  result: SchemaWeight,
+): void => {
+  if (result.maxDepth < depth) {
+    result.maxDepth = depth;
+  }
+
+  if ('$ref' in schema) {
+    return;
+  }
+
+  if (schema.type === 'object' && schema.properties) {
+    for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
+      result.totalFields++;
+      result.fieldNames += fieldName.length;
+      walkSchema(fieldSchema, depth + 1, arrayDepth, result);
+    }
+  }
+
+  if (schema.type === 'array' && schema.items) {
+    const nextArrayDepth = arrayDepth + 1;
+    result.totalArrays++;
+    if (nextArrayDepth > result.maxArrayDepth) {
+      result.maxArrayDepth = nextArrayDepth;
+    }
+    walkSchema(schema.items, depth + 1, nextArrayDepth, result);
+  }
+};

--- a/src/lib/createRevisiumValidator.ts
+++ b/src/lib/createRevisiumValidator.ts
@@ -1,0 +1,126 @@
+import Ajv, { ValidateFunction } from 'ajv/dist/2020';
+import { metaSchema } from '../validation-schemas/meta-schema.js';
+import { jsonPatchSchema } from '../validation-schemas/json-patch-schema.js';
+import { tableMigrationsSchema } from '../validation-schemas/table-migrations-schema.js';
+import { historyPatchesSchema } from '../validation-schemas/history-patches-schema.js';
+import { tableViewsSchema } from '../validation-schemas/table-views-schema.js';
+import {
+  ajvRowIdSchema,
+  ajvRowCreatedIdSchema,
+  ajvRowVersionIdSchema,
+  ajvRowCreatedAtSchema,
+  ajvRowPublishedAtSchema,
+  ajvRowUpdatedAtSchema,
+  ajvRowHashSchema,
+  ajvRowSchemaHashSchema,
+  ajvFileSchema,
+} from '../plugins/index.js';
+
+export interface ValidationError {
+  instancePath: string;
+  message?: string;
+  keyword: string;
+  params: Record<string, unknown>;
+}
+
+export interface ValidateFn {
+  (data: unknown): boolean;
+  errors: ValidationError[] | null;
+}
+
+const mapErrors = (
+  errors: ValidateFunction['errors'],
+): ValidationError[] | null => {
+  if (!errors || errors.length === 0) {
+    return null;
+  }
+
+  return errors.map((err) => ({
+    instancePath: err.instancePath,
+    message: err.message,
+    keyword: err.keyword,
+    params: err.params as Record<string, unknown>,
+  }));
+};
+
+const wrapValidateFn = (ajvFn: ValidateFunction): ValidateFn => {
+  const fn = ((data: unknown): boolean => {
+    const result = ajvFn(data);
+    fn.errors = mapErrors(ajvFn.errors);
+    return result;
+  }) as ValidateFn;
+
+  fn.errors = null;
+  return fn;
+};
+
+export class RevisiumValidator {
+  public readonly validateMetaSchema: ValidateFn;
+  public readonly validateJsonPatch: ValidateFn;
+  public readonly validateMigrations: ValidateFn;
+  public readonly validateHistoryPatches: ValidateFn;
+  public readonly validateTableViews: ValidateFn;
+
+  private readonly ajv: Ajv;
+  private readonly cache = new Map<string, ValidateFn>();
+
+  constructor() {
+    this.ajv = new Ajv();
+
+    this.ajv.addKeyword({
+      keyword: 'foreignKey',
+      type: 'string',
+    });
+    this.ajv.addKeyword({
+      keyword: 'x-formula',
+    });
+    this.ajv.addFormat('regex', {
+      type: 'string',
+      validate: (str: string) => {
+        try {
+          new RegExp(str);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    });
+
+    this.ajv.compile(ajvRowIdSchema);
+    this.ajv.compile(ajvRowCreatedIdSchema);
+    this.ajv.compile(ajvRowVersionIdSchema);
+    this.ajv.compile(ajvRowCreatedAtSchema);
+    this.ajv.compile(ajvRowPublishedAtSchema);
+    this.ajv.compile(ajvRowUpdatedAtSchema);
+    this.ajv.compile(ajvRowHashSchema);
+    this.ajv.compile(ajvRowSchemaHashSchema);
+    this.ajv.compile(ajvFileSchema);
+
+    this.validateMetaSchema = wrapValidateFn(this.ajv.compile(metaSchema));
+    this.validateJsonPatch = wrapValidateFn(this.ajv.compile(jsonPatchSchema));
+    this.validateMigrations = wrapValidateFn(
+      this.ajv.compile(tableMigrationsSchema),
+    );
+    this.validateHistoryPatches = wrapValidateFn(
+      this.ajv.compile(historyPatchesSchema),
+    );
+    this.validateTableViews = wrapValidateFn(
+      this.ajv.compile(tableViewsSchema),
+    );
+  }
+
+  public compile(schema: unknown): ValidateFn {
+    const key = JSON.stringify(schema);
+    const cached = this.cache.get(key);
+
+    if (cached) {
+      return cached;
+    }
+
+    const fn = wrapValidateFn(
+      this.ajv.compile(schema as Record<string, unknown>),
+    );
+    this.cache.set(key, fn);
+    return fn;
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,3 +20,7 @@ export * from './schema-table.js';
 export * from './traverseStore.js';
 export * from './traverseValue.js';
 export * from './validateJsonFieldName.js';
+export * from './validateRevisiumSchema.js';
+export * from './createRevisiumValidator.js';
+export * from './calculateSchemaWeight.js';
+export * from './calculateDataWeight.js';

--- a/src/lib/validateRevisiumSchema.ts
+++ b/src/lib/validateRevisiumSchema.ts
@@ -1,0 +1,36 @@
+import { JsonObjectSchema } from '../types/schema.types.js';
+import { RevisiumValidator } from './createRevisiumValidator.js';
+
+export interface MetaSchemaValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+let cachedValidator: RevisiumValidator | null = null;
+
+const getValidator = (): RevisiumValidator => {
+  if (cachedValidator) {
+    return cachedValidator;
+  }
+
+  cachedValidator = new RevisiumValidator();
+  return cachedValidator;
+};
+
+export const validateRevisiumSchema = (
+  schema: JsonObjectSchema,
+): MetaSchemaValidationResult => {
+  const validator = getValidator();
+  const valid = validator.validateMetaSchema(schema);
+
+  if (valid) {
+    return { valid: true };
+  }
+
+  const errors = (validator.validateMetaSchema.errors ?? []).map((err) => {
+    const path = err.instancePath || '/';
+    return `${path}: ${err.message ?? 'unknown error'}`;
+  });
+
+  return { valid: false, errors };
+};

--- a/src/validation-schemas/__tests__/table-views-schema.spec.ts
+++ b/src/validation-schemas/__tests__/table-views-schema.spec.ts
@@ -1,0 +1,496 @@
+import { RevisiumValidator } from '../../lib/createRevisiumValidator.js';
+
+describe('table-views-schema', () => {
+  let validator: RevisiumValidator;
+
+  beforeAll(() => {
+    validator = new RevisiumValidator();
+  });
+
+  it('validates minimal views data', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates views with all optional fields', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'published',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          description: 'Default view',
+          columns: [
+            { field: 'id', width: 150 },
+            { field: 'data.title', width: 300 },
+          ],
+          filters: {
+            logic: 'and',
+            conditions: [
+              { field: 'data.status', operator: 'equals', value: 'active' },
+            ],
+            groups: [
+              {
+                logic: 'or',
+                conditions: [
+                  { field: 'data.type', operator: 'equals', value: 'post' },
+                  { field: 'data.type', operator: 'equals', value: 'article' },
+                ],
+              },
+            ],
+          },
+          sorts: [{ field: 'data.createdAt', direction: 'desc' }],
+          search: 'test query',
+        },
+        {
+          id: 'published',
+          name: 'Published Only',
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates views with null columns', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default', columns: null }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates views with empty columns array', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default', columns: [] }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates column without width', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates all filter operators', () => {
+    const operators = [
+      'equals',
+      'not_equals',
+      'contains',
+      'not_contains',
+      'starts_with',
+      'ends_with',
+      'is_empty',
+      'is_not_empty',
+      'gt',
+      'gte',
+      'lt',
+      'lte',
+      'is_true',
+      'is_false',
+    ];
+
+    for (const operator of operators) {
+      const data = {
+        version: 1,
+        defaultViewId: 'default',
+        views: [
+          {
+            id: 'default',
+            name: 'Default',
+            filters: {
+              logic: 'and',
+              conditions: [{ field: 'data.test', operator, value: 'test' }],
+            },
+          },
+        ],
+      };
+
+      expect(validator.validateTableViews(data)).toBe(true);
+      expect(validator.validateTableViews.errors).toBeNull();
+    }
+  });
+
+  it('validates filter condition without value', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          filters: {
+            logic: 'and',
+            conditions: [{ field: 'data.test', operator: 'is_empty' }],
+          },
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('rejects invalid version type', () => {
+    const data = {
+      version: 'not-a-number',
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects version less than 1', () => {
+    const data = {
+      version: 0,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects view with empty id', () => {
+    const data = {
+      version: 1,
+      defaultViewId: '',
+      views: [{ id: '', name: 'Default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects view with empty name', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: '' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects view name exceeding max length', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'a'.repeat(101) }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects view description exceeding max length', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default', description: 'a'.repeat(501) }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects column with empty field', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: '' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects column width less than minimum', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id', width: 10 }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects invalid sort direction', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          sorts: [{ field: 'id', direction: 'invalid' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects invalid filter logic', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          filters: {
+            logic: 'invalid',
+            conditions: [],
+          },
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects invalid filter operator', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          filters: {
+            logic: 'and',
+            conditions: [{ field: 'id', operator: 'invalid_operator' }],
+          },
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects filter condition with empty field', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          filters: {
+            logic: 'and',
+            conditions: [{ field: '', operator: 'equals' }],
+          },
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects sort with empty field', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          sorts: [{ field: '', direction: 'asc' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects missing required version field', () => {
+    const data = {
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects missing required views field', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects view missing required id', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ name: 'Default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects view missing required name', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects additional properties in root', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default' }],
+      extra: 'property',
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects additional properties in view', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [{ id: 'default', name: 'Default', extra: 'property' }],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects additional properties in column', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id', extra: 'property' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects additional properties in filter group', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          filters: {
+            logic: 'and',
+            conditions: [],
+            extra: 'property',
+          },
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects additional properties in filter condition', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          filters: {
+            logic: 'and',
+            conditions: [
+              { field: 'id', operator: 'equals', value: 'test', extra: 'prop' },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
+  it('rejects additional properties in sort', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          sorts: [{ field: 'id', direction: 'asc', extra: 'property' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+});

--- a/src/validation-schemas/index.ts
+++ b/src/validation-schemas/index.ts
@@ -2,4 +2,5 @@ export * from './meta-schema.js';
 export * from './json-patch-schema.js';
 export * from './history-patches-schema.js';
 export * from './table-migrations-schema.js';
+export * from './table-views-schema.js';
 export * from './shared-fields.js';

--- a/src/validation-schemas/table-views-schema.ts
+++ b/src/validation-schemas/table-views-schema.ts
@@ -1,0 +1,123 @@
+import { Schema } from 'ajv/dist/2020';
+
+export const tableViewsSchema: Schema = {
+  $id: 'table-views-schema.json',
+  type: 'object',
+  additionalProperties: false,
+  required: ['version', 'views'],
+  properties: {
+    version: {
+      type: 'integer',
+      minimum: 1,
+      default: 1,
+    },
+    defaultViewId: {
+      type: 'string',
+      default: 'default',
+    },
+    views: {
+      type: 'array',
+      items: { $ref: '#/$defs/View' },
+      default: [],
+    },
+  },
+  $defs: {
+    View: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string', minLength: 1 },
+        name: { type: 'string', minLength: 1, maxLength: 100 },
+        description: { type: 'string', maxLength: 500, default: '' },
+        columns: {
+          oneOf: [
+            { type: 'null' },
+            { type: 'array', items: { $ref: '#/$defs/Column' } },
+          ],
+          default: null,
+        },
+        filters: { $ref: '#/$defs/FilterGroup' },
+        sorts: {
+          type: 'array',
+          items: { $ref: '#/$defs/Sort' },
+          default: [],
+        },
+        search: {
+          type: 'string',
+          default: '',
+        },
+      },
+    },
+    Column: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['field'],
+      properties: {
+        field: { type: 'string', minLength: 1 },
+        width: { type: 'number', minimum: 40 },
+      },
+    },
+    FilterGroup: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        logic: {
+          type: 'string',
+          enum: ['and', 'or'],
+          default: 'and',
+        },
+        conditions: {
+          type: 'array',
+          items: { $ref: '#/$defs/FilterCondition' },
+          default: [],
+        },
+        groups: {
+          type: 'array',
+          items: { $ref: '#/$defs/FilterGroup' },
+          default: [],
+        },
+      },
+    },
+    FilterCondition: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['field', 'operator'],
+      properties: {
+        field: { type: 'string', minLength: 1 },
+        operator: {
+          type: 'string',
+          enum: [
+            'equals',
+            'not_equals',
+            'contains',
+            'not_contains',
+            'starts_with',
+            'ends_with',
+            'is_empty',
+            'is_not_empty',
+            'gt',
+            'gte',
+            'lt',
+            'lte',
+            'is_true',
+            'is_false',
+          ],
+        },
+        value: {},
+      },
+    },
+    Sort: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['field', 'direction'],
+      properties: {
+        field: { type: 'string', minLength: 1 },
+        direction: {
+          type: 'string',
+          enum: ['asc', 'desc'],
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce an AJV-based Revisium validator to validate meta schemas, JSON patches, migrations, history patches, and table view configs. Add helpers to measure data and schema weight, and export all new APIs.

- **New Features**
  - RevisiumValidator with validateMetaSchema, validateJsonPatch, validateMigrations, validateHistoryPatches, validateTableViews.
  - compile() caches validators and resolves plugin $refs (row ids, timestamps, version/hash IDs, file).
  - Custom keywords: foreignKey, x-formula; regex format to validate pattern strings.
  - validateRevisiumSchema helper returning { valid, errors }.
  - table-views-schema (columns, filters, sorts, search).
  - calculateDataWeight, calculateDataWeightFromStore, and calculateSchemaWeight; exported from lib.

- **Dependencies**
  - Upgrade ajv to 8.18.0 and move it to dependencies.

<sup>Written for commit d20a4a45bbfb47e7739ed28fa47fb70255179362. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

