### PR TITLE
feat: array find and findIndex / reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ row.setValue('price', 19.99);   // OK
 row.setValue('price', 'wrong'); // TS Error!
 row.getPlainValue();            // { name: string, price: number }
 row.patches;                    // JSON Patch operations
-row.root;                       // typed root node (ObjectValueNode)
+row.root;                       // typed root node (InferNode<S>)
 row.reset({ name: 'New', price: 0 }); // reset to new data, commit
 row.reset();                    // reset to schema defaults
 ```
@@ -258,6 +258,7 @@ See [ForeignKeyResolver docs](src/model/foreign-key-resolver/README.md) for cach
 | `getValue(path)` | Get plain value at path |
 | `setValue(path, value)` | Set value at path |
 | `getPlainValue()` | Get full plain value |
+| `patches` | JSON Patch operations (`JsonValuePatch[]`) for current changes |
 | `reset(data?)` | Reset to given data (or schema defaults) and commit |
 | `commit()` | Commit current state as base |
 | `revert()` | Revert to last committed state |
@@ -267,8 +268,8 @@ See [ForeignKeyResolver docs](src/model/foreign-key-resolver/README.md) for cach
 | Method | Description |
 |--------|-------------|
 | `at(index)` | Get element at index (supports negative) |
-| `find(predicate)` | Find first element matching predicate |
-| `findIndex(predicate)` | Find index of first element matching predicate |
+| `find(predicate)` | Find first element matching predicate, or `undefined` |
+| `findIndex(predicate)` | Find index of first matching element, or `-1` |
 | `push(node)` | Append element |
 | `pushValue(value?)` | Create and append element from value |
 | `removeAt(index)` | Remove element at index |

--- a/src/model/table/row/typed.ts
+++ b/src/model/table/row/typed.ts
@@ -1,5 +1,6 @@
 import type { JsonSchema } from '../../../types/schema.types.js';
 import type {
+  InferNode,
   InferValue,
   NodeAtPath,
   SchemaPaths,
@@ -8,10 +9,12 @@ import type {
 import type { RowModel, RowModelOptions } from './types.js';
 
 export interface TypedRowModel<S> extends RowModel {
+  readonly root: InferNode<S>;
   get<P extends SchemaPaths<S>>(path: P): NodeAtPath<S, P>;
   getValue<P extends SchemaPaths<S>>(path: P): ValueAtPath<S, P>;
   setValue<P extends SchemaPaths<S>>(path: P, value: ValueAtPath<S, P>): void;
   getPlainValue(): InferValue<S>;
+  reset(data?: InferValue<S>): void;
 }
 
 export interface TypedRowModelOptions<S extends JsonSchema> extends Omit<RowModelOptions, 'schema' | 'data'> {

--- a/src/model/table/row/types.ts
+++ b/src/model/table/row/types.ts
@@ -26,6 +26,7 @@ export interface RowModel {
   readonly rowId: string;
   readonly tableModel: TableModelLike | null;
   readonly tree: ValueTreeLike;
+  readonly root: ValueNode;
 
   readonly index: number;
   readonly prev: RowModel | null;
@@ -45,5 +46,6 @@ export interface RowModel {
   readonly patches: readonly JsonValuePatch[];
   commit(): void;
   revert(): void;
+  reset(data?: unknown): void;
   dispose(): void;
 }

--- a/src/model/value-node/ArrayValueNode.ts
+++ b/src/model/value-node/ArrayValueNode.ts
@@ -74,6 +74,14 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
     return this._items[index];
   }
 
+  find(predicate: (node: ValueNode, index: number) => boolean): ValueNode | undefined {
+    return this._items.find(predicate);
+  }
+
+  findIndex(predicate: (node: ValueNode, index: number) => boolean): number {
+    return this._items.findIndex(predicate);
+  }
+
   push(node: ValueNode): void {
     node.parent = this;
     this._items.push(node);

--- a/src/model/value-node/ArrayValueNode.ts
+++ b/src/model/value-node/ArrayValueNode.ts
@@ -75,11 +75,11 @@ export class ArrayValueNode extends BaseValueNode implements IArrayValueNode {
   }
 
   find(predicate: (node: ValueNode, index: number) => boolean): ValueNode | undefined {
-    return this._items.find(predicate);
+    return this._items.find((node, index) => predicate(node, index));
   }
 
   findIndex(predicate: (node: ValueNode, index: number) => boolean): number {
-    return this._items.findIndex(predicate);
+    return this._items.findIndex((node, index) => predicate(node, index));
   }
 
   push(node: ValueNode): void {

--- a/src/model/value-node/types.ts
+++ b/src/model/value-node/types.ts
@@ -99,6 +99,8 @@ export interface ArrayValueNode extends ValueNode, DirtyTrackable {
   readonly length: number;
 
   at(index: number): ValueNode | undefined;
+  find(predicate: (node: ValueNode, index: number) => boolean): ValueNode | undefined;
+  findIndex(predicate: (node: ValueNode, index: number) => boolean): number;
   push(node: ValueNode): void;
   insertAt(index: number, node: ValueNode): void;
   removeAt(index: number): void;

--- a/src/types/typed.ts
+++ b/src/types/typed.ts
@@ -72,6 +72,8 @@ export interface TypedObjectValueNode<P> extends ObjectValueNode {
 
 export interface TypedArrayValueNode<I> extends ArrayValueNode {
   at(index: number): InferNode<I> | undefined;
+  find(predicate: (node: InferNode<I>, index: number) => boolean): InferNode<I> | undefined;
+  findIndex(predicate: (node: InferNode<I>, index: number) => boolean): number;
   getPlainValue(): InferValue<I>[];
   setValue(value: InferValue<I>[], options?: { internal?: boolean }): void;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds array search to ArrayValueNode and a simple one-call reset for RowModel. Also exposes a typed root node on RowModel for easier navigation.

- **New Features**
  - ArrayValueNode: add find(predicate) and findIndex(predicate); typed versions on TypedArrayValueNode.
  - RowModel: add root getter for direct, typed root access (InferNode<S>).
  - RowModel: add reset(data?) to replace the entire row with new data or schema defaults, then commit.
  - Docs: update README and TableModel docs with root, reset, and array search examples; switch to row.patches.
  - Tests: add coverage for root, reset (including defaults), and array find/findIndex behavior.

<sup>Written for commit 48998f29bd603e3950cc7137010aa2f100a1dfa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

