### PR TITLE
feat: pinned column

### DIFF
--- a/src/validation-schemas/__tests__/table-views-schema.spec.ts
+++ b/src/validation-schemas/__tests__/table-views-schema.spec.ts
@@ -241,6 +241,74 @@ describe('table-views-schema', () => {
     expect(validator.validateTableViews.errors).not.toBeNull();
   });
 
+  it('validates column with pinned left', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id', pinned: 'left' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates column with pinned right', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id', pinned: 'right' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('validates column with width and pinned', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id', width: 150, pinned: 'left' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(true);
+    expect(validator.validateTableViews.errors).toBeNull();
+  });
+
+  it('rejects invalid pinned value', () => {
+    const data = {
+      version: 1,
+      defaultViewId: 'default',
+      views: [
+        {
+          id: 'default',
+          name: 'Default',
+          columns: [{ field: 'id', pinned: 'center' }],
+        },
+      ],
+    };
+
+    expect(validator.validateTableViews(data)).toBe(false);
+    expect(validator.validateTableViews.errors).not.toBeNull();
+  });
+
   it('rejects column width less than minimum', () => {
     const data = {
       version: 1,

--- a/src/validation-schemas/table-views-schema.ts
+++ b/src/validation-schemas/table-views-schema.ts
@@ -56,6 +56,7 @@ export const tableViewsSchema: Schema = {
       properties: {
         field: { type: 'string', minLength: 1 },
         width: { type: 'number', minimum: 40 },
+        pinned: { type: 'string', enum: ['left', 'right'] },
       },
     },
     FilterGroup: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for pinning table columns to the left or right in table views. Updates the schema and tests to validate allowed values and combinations.

- **New Features**
  - Added pinned property to Column schema with enum: left | right.
  - Validation covers pinned alone and with width; rejects invalid values (e.g., center).
  - Added tests for left/right, width + pinned, and invalid pinned.

<sup>Written for commit eb33b0ccd7e13e12f94e7f54a0cb2250d82389db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

