### PR TITLE
feat: add sortTablesByDependencies utility

### DIFF
--- a/src/lib/__tests__/sortTablesByDependencies.spec.ts
+++ b/src/lib/__tests__/sortTablesByDependencies.spec.ts
@@ -1,0 +1,288 @@
+import { sortTablesByDependencies } from '../sortTablesByDependencies.js';
+
+describe('sortTablesByDependencies', () => {
+  describe('no dependencies', () => {
+    it('returns empty array for empty input', () => {
+      const result = sortTablesByDependencies({});
+      expect(result.sortedTables).toEqual([]);
+      expect(result.circularDependencies).toEqual([]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('returns tables in original order when no FK', () => {
+      const result = sortTablesByDependencies({
+        users: { type: 'object', properties: { name: { type: 'string' } } },
+        posts: { type: 'object', properties: { title: { type: 'string' } } },
+      });
+      expect(result.sortedTables).toEqual(['users', 'posts']);
+      expect(result.circularDependencies).toEqual([]);
+    });
+  });
+
+  describe('linear dependencies', () => {
+    it('sorts parent before child (single FK)', () => {
+      const result = sortTablesByDependencies({
+        reviews: {
+          type: 'object',
+          properties: {
+            productRef: { type: 'string', foreignKey: 'products' },
+          },
+        },
+        products: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      });
+      expect(result.sortedTables).toEqual(['products', 'reviews']);
+    });
+
+    it('sorts chain: A -> B -> C', () => {
+      const result = sortTablesByDependencies({
+        comments: {
+          type: 'object',
+          properties: {
+            postRef: { type: 'string', foreignKey: 'posts' },
+          },
+        },
+        posts: {
+          type: 'object',
+          properties: {
+            authorRef: { type: 'string', foreignKey: 'users' },
+          },
+        },
+        users: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      });
+      expect(result.sortedTables).toEqual(['users', 'posts', 'comments']);
+    });
+
+    it('handles multiple dependencies from one table', () => {
+      const result = sortTablesByDependencies({
+        order_items: {
+          type: 'object',
+          properties: {
+            orderRef: { type: 'string', foreignKey: 'orders' },
+            productRef: { type: 'string', foreignKey: 'products' },
+          },
+        },
+        orders: {
+          type: 'object',
+          properties: { total: { type: 'number' } },
+        },
+        products: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      });
+      expect(result.sortedTables.indexOf('orders')).toBeLessThan(
+        result.sortedTables.indexOf('order_items'),
+      );
+      expect(result.sortedTables.indexOf('products')).toBeLessThan(
+        result.sortedTables.indexOf('order_items'),
+      );
+    });
+  });
+
+  describe('nested and array FK', () => {
+    it('detects FK in nested object properties', () => {
+      const result = sortTablesByDependencies({
+        reviews: {
+          type: 'object',
+          properties: {
+            meta: {
+              type: 'object',
+              properties: {
+                productRef: { type: 'string', foreignKey: 'products' },
+              },
+            },
+          },
+        },
+        products: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      });
+      expect(result.sortedTables).toEqual(['products', 'reviews']);
+    });
+
+    it('detects FK in array items', () => {
+      const result = sortTablesByDependencies({
+        playlists: {
+          type: 'object',
+          properties: {
+            songs: {
+              type: 'array',
+              items: { type: 'string', foreignKey: 'songs' },
+            },
+          },
+        },
+        songs: {
+          type: 'object',
+          properties: { title: { type: 'string' } },
+        },
+      });
+      expect(result.sortedTables).toEqual(['songs', 'playlists']);
+    });
+
+    it('detects FK in array of objects', () => {
+      const result = sortTablesByDependencies({
+        invoices: {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  productRef: { type: 'string', foreignKey: 'products' },
+                },
+              },
+            },
+          },
+        },
+        products: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      });
+      expect(result.sortedTables).toEqual(['products', 'invoices']);
+    });
+  });
+
+  describe('self-references', () => {
+    it('ignores self-referencing FK', () => {
+      const result = sortTablesByDependencies({
+        categories: {
+          type: 'object',
+          properties: {
+            parentRef: { type: 'string', foreignKey: 'categories' },
+            name: { type: 'string' },
+          },
+        },
+      });
+      expect(result.sortedTables).toEqual(['categories']);
+      expect(result.circularDependencies).toEqual([]);
+    });
+  });
+
+  describe('external references', () => {
+    it('ignores FK pointing to tables not in the input', () => {
+      const result = sortTablesByDependencies({
+        reviews: {
+          type: 'object',
+          properties: {
+            productRef: { type: 'string', foreignKey: 'products' },
+          },
+        },
+      });
+      // products is not in the input, so reviews has no resolvable dependency
+      expect(result.sortedTables).toEqual(['reviews']);
+      expect(result.circularDependencies).toEqual([]);
+    });
+  });
+
+  describe('circular dependencies', () => {
+    it('detects A <-> B cycle', () => {
+      const result = sortTablesByDependencies({
+        table_a: {
+          type: 'object',
+          properties: {
+            bRef: { type: 'string', foreignKey: 'table_b' },
+          },
+        },
+        table_b: {
+          type: 'object',
+          properties: {
+            aRef: { type: 'string', foreignKey: 'table_a' },
+          },
+        },
+      });
+      expect(result.circularDependencies.length).toBeGreaterThan(0);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      // Both tables should still appear in sortedTables
+      expect(result.sortedTables).toHaveLength(2);
+      expect(result.sortedTables).toContain('table_a');
+      expect(result.sortedTables).toContain('table_b');
+    });
+
+    it('detects A -> B -> C -> A cycle', () => {
+      const result = sortTablesByDependencies({
+        a: {
+          type: 'object',
+          properties: { ref: { type: 'string', foreignKey: 'b' } },
+        },
+        b: {
+          type: 'object',
+          properties: { ref: { type: 'string', foreignKey: 'c' } },
+        },
+        c: {
+          type: 'object',
+          properties: { ref: { type: 'string', foreignKey: 'a' } },
+        },
+      });
+      expect(result.circularDependencies.length).toBeGreaterThan(0);
+      expect(result.sortedTables).toHaveLength(3);
+    });
+
+    it('handles mix of cyclic and acyclic tables', () => {
+      const result = sortTablesByDependencies({
+        independent: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+        cycle_a: {
+          type: 'object',
+          properties: { ref: { type: 'string', foreignKey: 'cycle_b' } },
+        },
+        cycle_b: {
+          type: 'object',
+          properties: { ref: { type: 'string', foreignKey: 'cycle_a' } },
+        },
+        depends_on_independent: {
+          type: 'object',
+          properties: {
+            ref: { type: 'string', foreignKey: 'independent' },
+          },
+        },
+      });
+      // Acyclic tables come first in correct order
+      const indIdx = result.sortedTables.indexOf('independent');
+      const depIdx = result.sortedTables.indexOf('depends_on_independent');
+      expect(indIdx).toBeLessThan(depIdx);
+      // All tables present
+      expect(result.sortedTables).toHaveLength(4);
+      expect(result.circularDependencies.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('large graph', () => {
+    it('handles 10 tables with chain dependency', () => {
+      const schemas: Record<string, object> = {};
+      for (let i = 0; i < 10; i++) {
+        const tableId = `table_${i}`;
+        if (i === 0) {
+          schemas[tableId] = {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          };
+        } else {
+          schemas[tableId] = {
+            type: 'object',
+            properties: {
+              ref: { type: 'string', foreignKey: `table_${i - 1}` },
+            },
+          };
+        }
+      }
+      const result = sortTablesByDependencies(schemas);
+      // Each table should come after its dependency
+      for (let i = 1; i < 10; i++) {
+        expect(result.sortedTables.indexOf(`table_${i - 1}`)).toBeLessThan(
+          result.sortedTables.indexOf(`table_${i}`),
+        );
+      }
+    });
+  });
+});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,3 +24,4 @@ export * from './validateRevisiumSchema.js';
 export * from './createRevisiumValidator.js';
 export * from './calculateSchemaWeight.js';
 export * from './calculateDataWeight.js';
+export * from './sortTablesByDependencies.js';

--- a/src/lib/sortTablesByDependencies.ts
+++ b/src/lib/sortTablesByDependencies.ts
@@ -1,0 +1,210 @@
+interface TableDependency {
+  tableId: string;
+  dependsOn: string[];
+}
+
+export interface SortTablesByDependenciesResult {
+  sortedTables: string[];
+  circularDependencies: string[][];
+  warnings: string[];
+}
+
+/**
+ * Sorts tables by foreign key dependencies using Kahn's algorithm.
+ * Tables with no dependencies come first, then tables that depend on them.
+ * Handles circular dependencies gracefully by appending them at the end with warnings.
+ *
+ * @param tableSchemas - Record of tableId -> JSON Schema (plain object, not JsonSchemaStore)
+ */
+export function sortTablesByDependencies(
+  tableSchemas: Record<string, object>,
+): SortTablesByDependenciesResult {
+  const dependencies = extractDependencies(tableSchemas);
+  const circularDependencies = detectCircularDependencies(dependencies);
+  const sortedTables = topologicalSort(dependencies, circularDependencies);
+  const warnings = generateWarnings(circularDependencies);
+
+  return { sortedTables, circularDependencies, warnings };
+}
+
+function extractDependencies(
+  tableSchemas: Record<string, object>,
+): TableDependency[] {
+  const tableIds = new Set(Object.keys(tableSchemas));
+  const dependencies: TableDependency[] = [];
+
+  for (const [tableId, schema] of Object.entries(tableSchemas)) {
+    const foreignKeys = findForeignKeyReferences(schema);
+    // Filter: remove self-references and references to tables not in the input
+    const dependsOn = foreignKeys.filter(
+      (fk) => fk !== tableId && tableIds.has(fk),
+    );
+    dependencies.push({ tableId, dependsOn });
+  }
+
+  return dependencies;
+}
+
+function findForeignKeyReferences(schema: object | null): string[] {
+  const foreignKeys = new Set<string>();
+
+  if (schema === null || typeof schema !== 'object') {
+    return [];
+  }
+
+  const record = schema as Record<string, unknown>;
+
+  if (typeof record.foreignKey === 'string') {
+    foreignKeys.add(record.foreignKey);
+  }
+
+  if (record.properties && typeof record.properties === 'object') {
+    for (const property of Object.values(
+      record.properties as Record<string, object>,
+    )) {
+      for (const fk of findForeignKeyReferences(property)) {
+        foreignKeys.add(fk);
+      }
+    }
+  }
+
+  if (record.items && typeof record.items === 'object') {
+    for (const fk of findForeignKeyReferences(record.items as object)) {
+      foreignKeys.add(fk);
+    }
+  }
+
+  return [...foreignKeys];
+}
+
+function detectCircularDependencies(
+  dependencies: TableDependency[],
+): string[][] {
+  const circularDependencies: string[][] = [];
+  const visited = new Set<string>();
+  const recursionStack = new Set<string>();
+  const dependencyMap = new Map<string, string[]>();
+
+  for (const dep of dependencies) {
+    dependencyMap.set(dep.tableId, dep.dependsOn);
+  }
+
+  const dfs = (tableId: string, path: string[]): void => {
+    if (recursionStack.has(tableId)) {
+      const cycleStart = path.indexOf(tableId);
+      const cycle = path.slice(cycleStart);
+      cycle.push(tableId);
+      circularDependencies.push(cycle);
+      return;
+    }
+
+    if (visited.has(tableId)) {
+      return;
+    }
+
+    visited.add(tableId);
+    recursionStack.add(tableId);
+    path.push(tableId);
+
+    const deps = dependencyMap.get(tableId) || [];
+    for (const dep of deps) {
+      if (dependencyMap.has(dep)) {
+        dfs(dep, [...path]);
+      }
+    }
+
+    recursionStack.delete(tableId);
+  };
+
+  for (const dep of dependencies) {
+    if (!visited.has(dep.tableId)) {
+      dfs(dep.tableId, []);
+    }
+  }
+
+  return circularDependencies;
+}
+
+function topologicalSort(
+  dependencies: TableDependency[],
+  circularDependencies: string[][],
+): string[] {
+  const circularTables = new Set<string>();
+  for (const cycle of circularDependencies) {
+    for (const table of cycle) {
+      circularTables.add(table);
+    }
+  }
+
+  const dependencyMap = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const dep of dependencies) {
+    dependencyMap.set(dep.tableId, dep.dependsOn);
+    inDegree.set(dep.tableId, 0);
+  }
+
+  for (const dep of dependencies) {
+    for (const target of dep.dependsOn) {
+      if (!inDegree.has(target)) continue;
+      if (circularTables.has(dep.tableId) && circularTables.has(target))
+        continue;
+      inDegree.set(dep.tableId, (inDegree.get(dep.tableId) ?? 0) + 1);
+    }
+  }
+
+  // Kahn's algorithm
+  const result: string[] = [];
+  const queue: string[] = [];
+
+  for (const [tableId, degree] of inDegree.entries()) {
+    if (degree === 0) {
+      queue.push(tableId);
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    result.push(current);
+
+    for (const [tableId, deps] of dependencyMap.entries()) {
+      if (!deps.includes(current)) continue;
+      if (!inDegree.has(tableId)) continue;
+      if (circularTables.has(current) && circularTables.has(tableId)) continue;
+
+      const newDegree = (inDegree.get(tableId) ?? 0) - 1;
+      inDegree.set(tableId, newDegree);
+
+      if (newDegree === 0) {
+        queue.push(tableId);
+      }
+    }
+  }
+
+  // Append circular tables that weren't already added
+  for (const tableId of circularTables) {
+    if (!result.includes(tableId)) {
+      result.push(tableId);
+    }
+  }
+
+  return result;
+}
+
+function generateWarnings(circularDependencies: string[][]): string[] {
+  const warnings: string[] = [];
+
+  for (const cycle of circularDependencies) {
+    warnings.push(
+      `Circular dependency detected: ${cycle.join(' -> ')}. Creation order may cause foreign key constraint errors.`,
+    );
+  }
+
+  if (circularDependencies.length > 0) {
+    warnings.push(
+      'Consider breaking circular dependencies or creating data in multiple passes.',
+    );
+  }
+
+  return warnings;
+}

--- a/src/lib/sortTablesByDependencies.ts
+++ b/src/lib/sortTablesByDependencies.ts
@@ -69,7 +69,7 @@ function findForeignKeyReferences(schema: object | null): string[] {
   }
 
   if (record.items && typeof record.items === 'object') {
-    for (const fk of findForeignKeyReferences(record.items as object)) {
+    for (const fk of findForeignKeyReferences(record.items)) {
       foreignKeys.add(fk);
     }
   }


### PR DESCRIPTION
## Summary
- Add `sortTablesByDependencies(tableSchemas)` — topological sort for tables based on foreign key dependencies
- Uses Kahn's algorithm with circular dependency detection (DFS)
- Extracts FK refs from nested objects and array items
- Handles edge cases: self-references (ignored), external refs (ignored), circular deps (appended with warnings)

Extracted from `revisium-cli`'s `TableDependencyService` as a pure function for reuse across CLI, core, and MCP tools.

## Export
```typescript
import { sortTablesByDependencies } from '@revisium/schema-toolkit/lib';

const result = sortTablesByDependencies({
  reviews: { type: 'object', properties: { productRef: { type: 'string', foreignKey: 'products' } } },
  products: { type: 'object', properties: { name: { type: 'string' } } },
});
// result.sortedTables = ['products', 'reviews']
```

## Test plan
- [x] 14 unit tests covering: no deps, linear chains, nested FK, array FK, self-refs, external refs, circular deps, mixed graphs, 10-table chains
- [x] Full suite: 2725 tests pass
- [x] ESLint clean
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Build succeeds (`tsup`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `sortTablesByDependencies(tableSchemas)` to order tables by foreign key dependencies. This helps create tables or seed data in a safe order and warns about cycles, and is exported from `@revisium/schema-toolkit/lib`.

- **New Features**
  - Topological sort using Kahn’s algorithm.
  - Finds FK refs in nested objects and array items; ignores self and external refs.
  - Detects cycles, appends cyclic tables at the end, and returns warnings.
  - Returns `sortedTables`, `circularDependencies`, and `warnings`.

- **Refactors**
  - Removed a redundant type assertion.

<sup>Written for commit 600143c712a4bea6d6bd7a66639295ac12a790e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



